### PR TITLE
Introduce Husky git hook manager

### DIFF
--- a/.husky/hooks/pre-commit
+++ b/.husky/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$PWD/bin/husky install

--- a/.husky/hooks/pre-push
+++ b/.husky/hooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ "$SKIP_GIT_PUSH_HOOK" ]]; then exit 0; fi
+
+set -e
+
+if git status --short | grep -qv "??"; then
+    git stash
+    function unstash() {
+        git reset --hard
+        git stash pop
+    }
+    trap unstash EXIT
+fi
+
+make generate manifests
+git diff --exit-code --quiet || (git status && exit 1)
+
+make test

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 tilt: $(TILT) ## Download tilt locally if necessary. If wrong version is installed, it will be overwritten.
 $(TILT): $(LOCALBIN)
 	test -s $(LOCALBIN)/tilt && $(LOCALBIN)/tilt version | grep -q $(TILT_VERSION) || \
-	(cd $(LOCALBIN) ; curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v$(TILT_VERSION)/tilt.$(TILT_VERSION).linux.x86_64.tar.gz | tar -xzv tilt)
+	(cd $(LOCALBIN) ; curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v$(TILT_VERSION)/tilt.$(TILT_VERSION).$(shell uname -s | tr '[:upper:]' '[:lower:]').$(shell uname -m).tar.gz | tar -xzv tilt)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -144,12 +144,14 @@ CTLPTL ?= $(LOCALBIN)/ctlptl
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 TILT ?= $(LOCALBIN)/tilt
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+HUSKY ?= $(LOCALBIN)/husky
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.1.1
 CTLPTL_VERSION ?= v0.8.22
 CONTROLLER_TOOLS_VERSION ?= v0.13.0
 TILT_VERSION ?= 0.33.6
+HUSKY_VERSION ?= v0.2.16
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
@@ -183,3 +185,11 @@ $(TILT): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: husky
+husky: $(HUSKY) ## Download husky locally if necessary.
+	@echo Execute install command to enable git hooks: ./bin/husky install
+	@echo Set any value for SKIP_GIT_PUSH_HOOK env variable to skip git hook execution.
+$(HUSKY): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install github.com/automation-co/husky@$(HUSKY_VERSION)
+


### PR DESCRIPTION
Git hooks are a great way to save time by running basic validations before git push and wait for CI result. It is an optional feature, devs has to opt in by executing `husky install`