### PR TITLE
[tweak]: Add additional printer columns, shortnames, and cluster-api category

### DIFF
--- a/api/v1alpha1/linodecluster_types.go
+++ b/api/v1alpha1/linodecluster_types.go
@@ -61,6 +61,7 @@ type LinodeClusterStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:path=linodeclusters,scope=Namespaced,categories=cluster-api,shortName=lc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this LinodeCluster belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready for Linode instances"

--- a/api/v1alpha1/linodemachine_types.go
+++ b/api/v1alpha1/linodemachine_types.go
@@ -155,8 +155,14 @@ type LinodeMachineStatus struct {
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=linodemachines,scope=Namespaced,categories=cluster-api,shortName=lm
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this LinodeMachine belongs"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="Linode instance state"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"
+// +kubebuilder:printcolumn:name="InstanceID",type="string",JSONPath=".spec.providerID",description="Linode instance ID"
+// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this LinodeMachine"
 
 // LinodeMachine is the Schema for the linodemachines API
 type LinodeMachine struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
@@ -8,9 +8,13 @@ metadata:
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: LinodeCluster
     listKind: LinodeClusterList
     plural: linodeclusters
+    shortNames:
+    - lc
     singular: linodecluster
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
@@ -8,13 +8,38 @@ metadata:
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: LinodeMachine
     listKind: LinodeMachineList
     plural: linodemachines
+    shortNames:
+    - lm
     singular: linodemachine
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Cluster to which this LinodeMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Linode instance state
+      jsonPath: .status.instanceState
+      name: State
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Linode instance ID
+      jsonPath: .spec.providerID
+      name: InstanceID
+      type: string
+    - description: Machine object which owns with this LinodeMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: LinodeMachine is the Schema for the linodemachines API


### PR DESCRIPTION
## CRD Improvements
- `lc` shortName for `LinodeClusters`
- `lm` shortName for `LinodeMachines`
- additional printer columns on `LinodeMachines` for State, Ready, InstanceID, and Machine
- adds the `cluster-api` category on `LinodeMachines` and `LinodeClusters` so they appear when running `kubectl get cluster-api`
- scopes `LinodeClusters` and `LinodeMachines` to be namespaced for consistency