### PR TITLE
[feat]: Set metadata for LinodeMachines, disable swap

### DIFF
--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -2,26 +2,26 @@ package scope
 
 import (
 	"context"
-	b64 "encoding/base64"
 	"errors"
 	"fmt"
 
+	"github.com/linode/linodego"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	infrav1 "github.com/linode/cluster-api-provider-linode/api/v1alpha1"
-	"github.com/linode/linodego"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	infrav1alpha1 "github.com/linode/cluster-api-provider-linode/api/v1alpha1"
 )
 
 type MachineScopeParams struct {
 	Client        client.Client
 	Cluster       *clusterv1.Cluster
 	Machine       *clusterv1.Machine
-	LinodeCluster *infrav1.LinodeCluster
-	LinodeMachine *infrav1.LinodeMachine
+	LinodeCluster *infrav1alpha1.LinodeCluster
+	LinodeMachine *infrav1alpha1.LinodeMachine
 }
 
 type MachineScope struct {
@@ -31,8 +31,8 @@ type MachineScope struct {
 	Cluster       *clusterv1.Cluster
 	Machine       *clusterv1.Machine
 	LinodeClient  *linodego.Client
-	LinodeCluster *infrav1.LinodeCluster
-	LinodeMachine *infrav1.LinodeMachine
+	LinodeCluster *infrav1alpha1.LinodeCluster
+	LinodeMachine *infrav1alpha1.LinodeMachine
 }
 
 func validateMachineScopeParams(params MachineScopeParams) error {
@@ -75,10 +75,27 @@ func NewMachineScope(apiKey string, params MachineScopeParams) (*MachineScope, e
 	}, nil
 }
 
+// PatchObject persists the machine configuration and status.
+func (s *MachineScope) PatchObject(ctx context.Context) error {
+	return s.PatchHelper.Patch(ctx, s.LinodeMachine)
+}
+
+// Close closes the current scope persisting the machine configuration and status.
+func (s *MachineScope) Close(ctx context.Context) error {
+	return s.PatchObject(ctx)
+}
+
+// AddFinalizer adds a finalizer and immediately patches the object to avoid any race conditions
+func (s *MachineScope) AddFinalizer(ctx context.Context) error {
+	controllerutil.AddFinalizer(s.LinodeMachine, infrav1alpha1.GroupVersion.String())
+
+	return s.Close(ctx)
+}
+
 // GetBootstrapData returns the bootstrap data from the secret in the Machine's bootstrap.dataSecretName.
-func (m *MachineScope) GetBootstrapData(ctx context.Context) (string, error) {
+func (m *MachineScope) GetBootstrapData(ctx context.Context) ([]byte, error) {
 	if m.Machine.Spec.Bootstrap.DataSecretName == nil {
-		return "", fmt.Errorf(
+		return []byte{}, fmt.Errorf(
 			"bootstrap data secret is nil for LinodeMachine %s/%s",
 			m.LinodeMachine.Namespace,
 			m.LinodeMachine.Name,
@@ -88,7 +105,7 @@ func (m *MachineScope) GetBootstrapData(ctx context.Context) (string, error) {
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: m.LinodeMachine.Namespace, Name: *m.Machine.Spec.Bootstrap.DataSecretName}
 	if err := m.client.Get(ctx, key, secret); err != nil {
-		return "", fmt.Errorf(
+		return []byte{}, fmt.Errorf(
 			"failed to retrieve bootstrap data secret for LinodeMachine %s/%s",
 			m.LinodeMachine.Namespace,
 			m.LinodeMachine.Name,
@@ -97,12 +114,12 @@ func (m *MachineScope) GetBootstrapData(ctx context.Context) (string, error) {
 
 	value, ok := secret.Data["value"]
 	if !ok {
-		return "", fmt.Errorf(
+		return []byte{}, fmt.Errorf(
 			"bootstrap data secret value key is missing for LinodeMachine %s/%s",
 			m.LinodeMachine.Namespace,
 			m.LinodeMachine.Name,
 		)
 	}
 
-	return b64.StdEncoding.EncodeToString(value), nil
+	return value, nil
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,8 +10,19 @@ rules:
   - events
   verbs:
   - create
+  - get
+  - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/controller/linodecluster_controller.go
+++ b/controller/linodecluster_controller.go
@@ -143,12 +143,11 @@ func (r *LinodeClusterReconciler) reconcile(
 		if err := r.reconcileCreate(ctx, logger, clusterScope); err != nil {
 			return res, err
 		}
+		r.Recorder.Event(clusterScope.LinodeCluster, corev1.EventTypeNormal, string(clusterv1.ReadyCondition), "Load balancer is ready")
 	}
 
 	clusterScope.LinodeCluster.Status.Ready = true
 	conditions.MarkTrue(clusterScope.LinodeCluster, clusterv1.ReadyCondition)
-
-	r.Recorder.Event(clusterScope.LinodeCluster, corev1.EventTypeNormal, string(clusterv1.ReadyCondition), "Load balancer is ready")
 
 	return res, nil
 }

--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -290,6 +290,7 @@ func (*LinodeMachineReconciler) reconcileCreate(ctx context.Context, machineScop
 			return nil, err
 		}
 		createConfig.Tags = tags
+		createConfig.SwapSize = util.Pointer(0)
 
 		// get the bootstrap data for the Linode instance and set it for create config
 		bootstrapData, err := machineScope.GetBootstrapData(ctx)

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -26,6 +26,8 @@ const (
 	// DefaultMappingTimeout is the default timeout for a controller request mapping func.
 	DefaultMappingTimeout = 60 * time.Second
 
+	// DefaultMachineControllerWaitForBootstrapDelay is the default requeue delay if bootstrap data is not ready.
+	DefaultMachineControllerWaitForBootstrapDelay = 5 * time.Second
 	// DefaultMachineControllerWaitForRunningDelay is the default requeue delay if instance is not running.
 	DefaultMachineControllerWaitForRunningDelay = 5 * time.Second
 	// DefaultMachineControllerWaitForRunningTimeout is the default timeout if instance is not running.


### PR DESCRIPTION
This modifies the `LinodeMachine` controller to wait for bootstrap data to be ready before creating Linode instances since the cloud-config needs to be stored in the metadata field to configure the Linode properly. Additionally sets swap to be disabled since kubeadm fails with swap enabled.

Related issues:
- https://github.com/linode/cluster-api-provider-linode/issues/1
- https://github.com/linode/cluster-api-provider-linode/issues/3