### PR TITLE
[feat]: Add private IP on Linodes and add control plane nodes to NodeBalancer backend nodes

### DIFF
--- a/cloud/services/loadbalancers.go
+++ b/cloud/services/loadbalancers.go
@@ -208,15 +208,13 @@ func DeleteNodeFromNB(
 		return nil
 	}
 
+	if machineScope.LinodeMachine.Spec.InstanceID == nil {
+		return errors.New("no InstanceID")
+	}
+
 	linodeNBConfig, err := GetNodeBalancerConfig(ctx, clusterScope, logger)
 	if util.IgnoreLinodeAPIError(err, http.StatusNotFound) != nil || linodeNBConfig == nil {
 		logger.Error(err, "Failed to get Node Balancer config")
-
-		return err
-	}
-
-	if machineScope.LinodeMachine.Spec.InstanceID == nil {
-		err = errors.New("no InstanceID")
 
 		return err
 	}


### PR DESCRIPTION
We need to enable private IPs on created Linodes in order to add control plane nodes to the NodeBalancer. 
This change will add any new control plane nodes to the NB backend automatically which does eventually go to "up" on the status check in Cloud Manager. 