### PR TITLE
Use Go 1.21 in Github Actions

### DIFF
--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'stable'
+        go-version: '1.21'
 
     - name: Build
       run: make build
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'stable'
+        go-version: '1.21'
 
     - name: Docker cache
       uses: ScribeMD/docker-cache@0.3.7
@@ -125,7 +125,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'stable'
+        go-version: '1.21'
 
     - name: Docker cache
       uses: ScribeMD/docker-cache@0.3.7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'stable'
+        go-version: '1.21'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Go 1.22 is not compatible with controller-gen 0.13:

```
/home/runner/work/cluster-api-provider-linode/cluster-api-provider-linode/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa0e55e]

goroutine 221 [running]:
go/types.(*Checker).handleBailout(0xc000cef200, 0xc00282bd40)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/check.go:367 +0x88
panic({0xbc8860?, 0x12b9880?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0xdc4c38, 0x12c2040})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/sizes.go:228 +0x31e
go/types.(*Config).sizeof(...)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/sizes.go:333
go/types.representableConst.func1({0xdc4c38?, 0x12c2040?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/const.go:76 +0x9e
go/types.representableConst({0xdcb010, 0x128d060}, 0xc000cef200, 0x12c2040, 0xc00284fe28)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/const.go:92 +0x192
go/types.(*Checker).conversion.func1({0xdc4c60?, 0xc000852c40?}, 0xc00284fe28)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/conversions.go:24 +0x[73](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:74)
go/types.(*Checker).conversion(0xc000cef200, 0xc00284fe00, {0xdc4c60, 0xc000852c40})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/conversions.go:44 +0x214
go/types.(*Checker).callExpr(0xc000cef200, 0xc00284fe00, 0xc001044b80)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/call.go:224 +0xc97
go/types.(*Checker).exprInternal(0xc000cef200, 0x0, 0xc00284fe00, {0xdc9380, 0xc001044b80}, {0x0, 0x0})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:13[74](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:75) +0xf8
go/types.(*Checker).rawExpr(0xc000cef200, 0x0, 0xc00284fe00, {0xdc9380?, 0xc001044b80?}, {0x0?, 0x0?}, 0x0)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:979 +0x19e
go/types.(*Checker).exprInternal(0xc000cef200, 0x0, 0xc00284fe00, {0xdc8c60, 0xc001033a60}, {0x0, 0x0})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:1320 +0x178
go/types.(*Checker).rawExpr(0xc000cef200, 0x0, 0xc00284fe00, {0xdc8c60?, 0xc001033a60?}, {0x0?, 0x0?}, 0x0)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:979 +0x19e
go/types.(*Checker).exprOrType(0xc000cef200, 0xc00284fe00, {0xdc8c60?, 0xc001033a60?}, 0xc0?)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:1573 +0x3b
go/types.(*Checker).selector(0xc000cef200, 0xc00284fe00, 0xc0014e3dd0, 0x0, 0x0)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/call.go:[76](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:77)9 +0x592
go/types.(*Checker).exprInternal(0xc000cef200, 0x0, 0xc00284fe00, {0xdc[78](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:79)b0, 0xc0014e3dd0}, {0x0, 0x0})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:1325 +0xd25
go/types.(*Checker).rawExpr(0xc000cef200, 0x0, 0xc00284fe00, {0xdc78b0?, 0xc0014e3dd0?}, {0x0?, 0x0?}, 0x0)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:9[79](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:80) +0x19e
go/types.(*Checker).expr(0xc000cef200, 0x0?, 0xc00284fe00, {0xdc78b0?, 0xc0014e3dd0?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/expr.go:1513 +0x30
go/types.(*Checker).varDecl(0xc000cef200, 0xc0023f5aa0, {0xc001611000, 0x1, 0x1}, {0x0, 0x0}, {0xdc78b0, 0xc0014e3dd0})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/decl.go:521 +0x17b
go/types.(*Checker).objDecl(0xc000cef200, {0xdd07f8, 0xc0023f5aa0}, 0x0)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/decl.go:194 +0x9e5
go/types.(*Checker).packageObjects(0xc000cef200)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/resolver.go:693 +0x4dd
go/types.(*Checker).checkFiles(0xc000cef200, {0xc002294900, 0x8, 0x8})
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/check.go:408 +0x1a5
go/types.(*Checker).Files(...)
	/opt/hostedtoolcache/go/1.22.0/x64/src/go/types/check.go:372
sigs.k8s.io/controller-tools/pkg/loader.(*loader).typeCheck(0xc000227440, 0xc0002844[80](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:81))
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:286 +0x36a
sigs.k8s.io/controller-tools/pkg/loader.(*Package).NeedTypesInfo(0xc0002[84](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:85)480)
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/loader.go:[99](https://github.com/linode/cluster-api-provider-linode/actions/runs/7811358939/job/21306310218?pr=80#step:7:100) +0x39
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check(0xc000a28f30, 0xc000284480)
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:268 +0x2b7
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check.func1(0x61?)
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:262 +0x53
created by sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check in goroutine 29
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-tools@v0.13.0/pkg/loader/refs.go:260 +0x1c5
```