### PR TITLE
fix: reconciliation spam for controllers 

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -91,9 +91,12 @@ func (s *ClusterScope) Close(ctx context.Context) error {
 	return s.PatchObject(ctx)
 }
 
-// AddFinalizer adds a finalizer and immediately patches the object to avoid any race conditions
+// AddFinalizer adds a finalizer if not present and immediately patches the
+// object to avoid any race conditions.
 func (s *ClusterScope) AddFinalizer(ctx context.Context) error {
-	controllerutil.AddFinalizer(s.LinodeCluster, infrav1alpha1.GroupVersion.String())
+	if controllerutil.AddFinalizer(s.LinodeCluster, infrav1alpha1.GroupVersion.String()) {
+		return s.Close(ctx)
+	}
 
-	return s.Close(ctx)
+	return nil
 }

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -85,11 +85,14 @@ func (s *MachineScope) Close(ctx context.Context) error {
 	return s.PatchObject(ctx)
 }
 
-// AddFinalizer adds a finalizer and immediately patches the object to avoid any race conditions
+// AddFinalizer adds a finalizer if not present and immediately patches the
+// object to avoid any race conditions.
 func (s *MachineScope) AddFinalizer(ctx context.Context) error {
-	controllerutil.AddFinalizer(s.LinodeMachine, infrav1alpha1.GroupVersion.String())
+	if controllerutil.AddFinalizer(s.LinodeMachine, infrav1alpha1.GroupVersion.String()) {
+		return s.Close(ctx)
+	}
 
-	return s.Close(ctx)
+	return nil
 }
 
 // GetBootstrapData returns the bootstrap data from the secret in the Machine's bootstrap.dataSecretName.

--- a/cloud/scope/vpc.go
+++ b/cloud/scope/vpc.go
@@ -84,9 +84,12 @@ func (s *VPCScope) Close(ctx context.Context) error {
 	return s.PatchObject(ctx)
 }
 
-// AddFinalizer adds a finalizer and immediately patches the object to avoid any race conditions
+// AddFinalizer adds a finalizer if not present and immediately patches the
+// object to avoid any race conditions.
 func (s *VPCScope) AddFinalizer(ctx context.Context) error {
-	controllerutil.AddFinalizer(s.LinodeVPC, infrav1alpha1.GroupVersion.String())
+	if controllerutil.AddFinalizer(s.LinodeVPC, infrav1alpha1.GroupVersion.String()) {
+		return s.Close(ctx)
+	}
 
-	return s.Close(ctx)
+	return nil
 }


### PR DESCRIPTION
fix: Stop controllers from constantly reconciling their objects due to overly-aggressive patching in `cloud/scope.AddFinalizer` methods