### PR TITLE
E2E test vpc controller

### DIFF
--- a/controller/linodevpc_controller_helpers.go
+++ b/controller/linodevpc_controller_helpers.go
@@ -68,6 +68,7 @@ func (r *LinodeVPCReconciler) reconcileVPC(ctx context.Context, vpcScope *scope.
 		return err
 	}
 
+	vpcScope.LinodeVPC.Spec.Label = vpc.Label
 	vpcScope.LinodeVPC.Spec.VPCID = &vpc.ID
 
 	return nil

--- a/e2e/linodemachine-controller/byovpc/01-vpc-create-options.json
+++ b/e2e/linodemachine-controller/byovpc/01-vpc-create-options.json
@@ -1,10 +1,10 @@
 {
-    "label": "capli-e2e-byovpc-sample",
+    "label": "capli-e2e-byovpc-for-all-tests",
     "region": "us-sea",
     "subnets": [
         {
             "ipv4": "10.0.0.0/24",
-            "label": "capli-e2e-byovpc-sample"
+            "label": "capli-e2e-byovpc-for-all-tests"
         }
     ]
 }

--- a/e2e/linodemachine-controller/byovpc/Makefile
+++ b/e2e/linodemachine-controller/byovpc/Makefile
@@ -1,11 +1,11 @@
 include ../../Makefile
 
 createVPC:
-	@URI=vpcs FILTER='{"label":"capli-e2e-byovpc-sample"}' make --no-print-directory callLinodeApiGet | grep -v 'results": 0' ||\
+	@URI=vpcs FILTER='{"label":"capli-e2e-byovpc-for-all-tests"}' make --no-print-directory callLinodeApiGet | grep -v 'results": 0' ||\
 	URI=vpcs BODY='@01-vpc-create-options.json' make --no-print-directory callLinodeApiPost
 
 enableVPC:
 	PATCH='{"status":{"ready":true}}' OBJ="linodevpcs/linodevpc-sample" make --no-print-directory patchKubeObjStatus
 
 fetchVPCID:
-	@URI=vpcs FILTER='{"label":"capli-e2e-byovpc-sample"}' make --no-print-directory callLinodeApiGet | jq -r .data[0].id
+	@URI=vpcs FILTER='{"label":"capli-e2e-byovpc-for-all-tests"}' make --no-print-directory callLinodeApiGet | jq -r .data[0].id

--- a/e2e/linodevpc-controller/minimal/01-assert.yaml
+++ b/e2e/linodevpc-controller/minimal/01-assert.yaml
@@ -1,10 +1,9 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeVPC
 metadata:
-  annotations:
-    cluster.x-k8s.io/paused: "true"
   name: linodevpc-sample
 spec:
-  label: capli-e2e-byovpc-for-all-tests
+  label: capli-e2e-byovpc-sample
   region: us-sea
-  vpcID: ${VPC_ID}
+status:
+  ready: true

--- a/e2e/linodevpc-controller/minimal/01-create-vpc.yaml
+++ b/e2e/linodevpc-controller/minimal/01-create-vpc.yaml
@@ -1,10 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeVPC
 metadata:
-  annotations:
-    cluster.x-k8s.io/paused: "true"
   name: linodevpc-sample
 spec:
-  label: capli-e2e-byovpc-for-all-tests
+  label: capli-e2e-byovpc-sample
   region: us-sea
-  vpcID: ${VPC_ID}

--- a/e2e/linodevpc-controller/minimal/02-delete-vpc.yaml
+++ b/e2e/linodevpc-controller/minimal/02-delete-vpc.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+  kind: LinodeVPC
+  name: linodevpc-sample

--- a/e2e/linodevpc-controller/minimal/02-error.yaml
+++ b/e2e/linodevpc-controller/minimal/02-error.yaml
@@ -1,10 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeVPC
 metadata:
-  annotations:
-    cluster.x-k8s.io/paused: "true"
   name: linodevpc-sample
 spec:
-  label: capli-e2e-byovpc-for-all-tests
+  label: capli-e2e-byovpc-sample
   region: us-sea
-  vpcID: ${VPC_ID}

--- a/e2e/linodevpc-controller/minimal/03-verify-vpc.yaml
+++ b/e2e/linodevpc-controller/minimal/03-verify-vpc.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      URI="vpcs" FILTER="{\"label\":\"CLi-$(OBJ=linodevpcs/linodevpc-sample make getKubeUid | sed 's/-//g')\"}" make callLinodeApiGet | grep 'results": 0'

--- a/e2e/linodevpc-controller/minimal/Makefile
+++ b/e2e/linodevpc-controller/minimal/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile


### PR DESCRIPTION
This test suit creates a a vpc via vpc controller, deletes the vpc and verifies deletion.

Related to: https://github.com/linode/cluster-api-provider-linode/issues/7 and https://github.com/linode/cluster-api-provider-linode/issues/4