### PR TITLE
wait until after delete step to check that linodeCluster still exists

### DIFF
--- a/cloud/services/loadbalancers.go
+++ b/cloud/services/loadbalancers.go
@@ -177,6 +177,12 @@ func DeleteNodeFromNB(
 		return errors.New("no InstanceID")
 	}
 
+	if machineScope.LinodeCluster.Spec.ControlPlaneEndpoint.Host == "" {
+		logger.Info("NodeBalancer already deleted, no NodeBalancer backend Node to remove")
+
+		return nil
+	}
+
 	err := machineScope.LinodeClient.DeleteNodeBalancerNode(
 		ctx,
 		machineScope.LinodeCluster.Spec.Network.NodeBalancerID,

--- a/controller/linodecluster_controller.go
+++ b/controller/linodecluster_controller.go
@@ -84,7 +84,7 @@ func (r *LinodeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	} else if cluster == nil {
-		logger.Info("Machine Controller has not yet set OwnerRef, skipping reconciliation")
+		logger.Info("Cluster Controller has not yet set OwnerRef, skipping reconciliation")
 
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
This PR fixes an issue where checking for a cluster existing happens while stuff is in the process of deleting and some resources don't get deleted. just move the check until after we validate if we are doing a delete operation. this also changes the tagging in cloud manager to be based on cluster `name` instead of `uuid` for easier readability. 