### PR TITLE
[feat]: add cluster template, use CAAPH to install cilium for the CNI

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,7 +2,7 @@ docker_build("controller", ".", only=("Dockerfile", "Makefile", "vendor","go.mod
 
 local_resource(
     'capi-controller-manager',
-    cmd='clusterctl init',
+    cmd='clusterctl init --addon helm',
 )
 
 k8s_yaml(kustomize('config/default'))

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -57,7 +57,6 @@ func (*LinodeMachineReconciler) newCreateConfig(ctx context.Context, machineScop
 
 		return nil, err
 	}
-	createConfig.SwapSize = util.Pointer(0)
 	createConfig.PrivateIP = true
 
 	bootstrapData, err := machineScope.GetBootstrapData(ctx)

--- a/templates/addons/cilium-helm.yaml
+++ b/templates/addons/cilium-helm.yaml
@@ -8,7 +8,7 @@ spec:
       cni: cilium
   repoURL: https://helm.cilium.io/
   chartName: cilium
-  version: 0.15.0
+  version: 1.15.0
   options:
     waitForJobs: true
     wait: true

--- a/templates/addons/cilium-helm.yaml
+++ b/templates/addons/cilium-helm.yaml
@@ -1,0 +1,21 @@
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cilium
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: cilium
+  repoURL: https://helm.cilium.io/
+  chartName: cilium
+  options:
+    waitForJobs: true
+    wait: true
+    timeout: 5m
+  valuesTemplate: |
+    hubble:
+      relay:
+        enabled: true
+      ui:
+        enabled: true
+---

--- a/templates/addons/cilium-helm.yaml
+++ b/templates/addons/cilium-helm.yaml
@@ -8,6 +8,7 @@ spec:
       cni: cilium
   repoURL: https://helm.cilium.io/
   chartName: cilium
+  version: 0.15.0
   options:
     waitForJobs: true
     wait: true

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -204,3 +204,5 @@ stringData:
     modprobe overlay
     modprobe br_netfilter
     sysctl --system
+    sed -i '/swap/d' /etc/fstab
+    swapoff -a

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -22,7 +22,6 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeCluster
 metadata:
   name: ${CLUSTER_NAME}
-  namespace: default
 spec:
   region: ${LINODE_REGION}
 ---
@@ -199,7 +198,7 @@ stringData:
     curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update -y
-    apt-get install -y kubelet kubeadm kubectl containerd
+    apt-get install -y kubelet=$2* kubeadm=$2* kubectl=$2* containerd
     apt-mark hold kubelet kubeadm kubectl containerd
     modprobe overlay
     modprobe br_netfilter

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -26,29 +26,6 @@ metadata:
 spec:
   region: ${LINODE_REGION}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1alpha1
-kind: HelmChartProxy
-metadata:
-  name: cilium
-spec:
-  clusterSelector:
-    matchLabels:
-      cni: cilium
-  repoURL: https://helm.cilium.io/
-  chartName: cilium
-  options:
-    waitForJobs: true
-    wait: true
-    timeout: 5m
-  valuesTemplate: |
-    operator:
-      replicas: 1
-    hubble:
-      relay:
-        enabled: true
-      ui:
-        enabled: true
----
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -59,7 +59,7 @@ spec:
           secret:
             name: common-init-files
             key: kubeadm-pre-init.sh
-        permissions: "0777"
+        permissions: "0500"
     preKubeadmCommands:
       - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
     clusterConfiguration:
@@ -158,7 +158,7 @@ spec:
             secret:
               name: common-init-files
               key: kubeadm-pre-init.sh
-          permissions: "0777"
+          permissions: "0500"
       preKubeadmCommands:
         - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
       joinConfiguration:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -63,43 +63,28 @@ spec:
   kubeadmConfigSpec:
     files:
       - path: /etc/containerd/config.toml
-        content: |
-          version = 2
-          imports = ["/etc/containerd/conf.d/*.toml"]
-          [plugins]
-            [plugins."io.containerd.grpc.v1.cri"]
-              sandbox_image = "registry.k8s.io/pause:3.9"
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-              runtime_type = "io.containerd.runc.v2"
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              SystemdCgroup = true
+        contentFrom:
+          secret:
+            name: common-init-files
+            key: containerd-config.toml
       - path: /etc/modules-load.d/k8s.conf
-        content: |
-          overlay
-          br_netfilter
+        contentFrom:
+          secret:
+            name: common-init-files
+            key: k8s-modules.conf
       - path: /etc/sysctl.d/k8s.conf
-        content: |
-          net.bridge.bridge-nf-call-iptables  = 1
-          net.bridge.bridge-nf-call-ip6tables = 1
-          net.ipv4.ip_forward                 = 1
-      - path: /kubeadm-init.sh
-        content: |
-          #!/bin/bash
-          export DEBIAN_FRONTEND=noninteractive
-          hostnamectl set-hostname "$1" && hostname -F /etc/hostname
-          mkdir -p -m 755 /etc/apt/keyrings
-          VERSION=${2%.*}
-          curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-          apt-get update -y
-          apt-get install -y kubelet kubeadm kubectl containerd
-          apt-mark hold kubelet kubeadm kubectl containerd
-          modprobe overlay
-          modprobe br_netfilter
-          sysctl --system
+        contentFrom:
+          secret:
+            name: common-init-files
+            key: sysctl-k8s.conf
+      - path: /kubeadm-pre-init.sh
+        contentFrom:
+          secret:
+            name: common-init-files
+            key: kubeadm-pre-init.sh
         permissions: "0777"
     preKubeadmCommands:
-      - /kubeadm-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+      - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
     clusterConfiguration:
       apiServer:
         extraArgs:
@@ -177,46 +162,68 @@ spec:
     spec:
       files:
         - path: /etc/containerd/config.toml
-          content: |
-            version = 2
-            imports = ["/etc/containerd/conf.d/*.toml"]
-            [plugins]
-              [plugins."io.containerd.grpc.v1.cri"]
-                sandbox_image = "registry.k8s.io/pause:3.9"
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-                runtime_type = "io.containerd.runc.v2"
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-                SystemdCgroup = true
+          contentFrom:
+            secret:
+              name: common-init-files
+              key: containerd-config.toml
         - path: /etc/modules-load.d/k8s.conf
-          content: |
-            overlay
-            br_netfilter
+          contentFrom:
+            secret:
+              name: common-init-files
+              key: k8s-modules.conf
         - path: /etc/sysctl.d/k8s.conf
-          content: |
-            net.bridge.bridge-nf-call-iptables  = 1
-            net.bridge.bridge-nf-call-ip6tables = 1
-            net.ipv4.ip_forward                 = 1
-        - path: /kubeadm-init.sh
-          content: |
-            #!/bin/bash
-            export DEBIAN_FRONTEND=noninteractive
-            hostnamectl set-hostname "$1" && hostname -F /etc/hostname
-            mkdir -p -m 755 /etc/apt/keyrings
-            VERSION=${2%.*}
-            curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-            apt-get update -y
-            apt-get install -y kubelet kubeadm kubectl containerd
-            apt-mark hold kubelet kubeadm kubectl containerd
-            modprobe overlay
-            modprobe br_netfilter
-            sysctl --system
+          contentFrom:
+            secret:
+              name: common-init-files
+              key: sysctl-k8s.conf
+        - path: /kubeadm-pre-init.sh
+          contentFrom:
+            secret:
+              name: common-init-files
+              key: kubeadm-pre-init.sh
           permissions: "0777"
       preKubeadmCommands:
-        - /kubeadm-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+        - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
             provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
           name: '{{ ds.meta_data.label }}'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: common-init-files
+stringData:
+  containerd-config.toml: |
+    version = 2
+    imports = ["/etc/containerd/conf.d/*.toml"]
+    [plugins]
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "registry.k8s.io/pause:3.9"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+        runtime_type = "io.containerd.runc.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+        SystemdCgroup = true
+  k8s-modules.conf: |
+    overlay
+    br_netfilter
+  sysctl-k8s.conf: |
+    net.bridge.bridge-nf-call-iptables  = 1
+    net.bridge.bridge-nf-call-ip6tables = 1
+    net.ipv4.ip_forward                 = 1
+  kubeadm-pre-init.sh: |
+    #!/bin/bash
+    export DEBIAN_FRONTEND=noninteractive
+    hostnamectl set-hostname "$1" && hostname -F /etc/hostname
+    mkdir -p -m 755 /etc/apt/keyrings
+    VERSION=${2%.*}
+    curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    apt-get update -y
+    apt-get install -y kubelet kubeadm kubectl containerd
+    apt-mark hold kubelet kubeadm kubectl containerd
+    modprobe overlay
+    modprobe br_netfilter
+    sysctl --system

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -8,7 +8,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      - 192.168.0.0/16
+      - 192.168.128.0/17
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -1,0 +1,222 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  labels:
+    cni: cilium
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: LinodeCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeCluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  region: ${LINODE_REGION}
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: cilium
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: cilium
+  repoURL: https://helm.cilium.io/
+  chartName: cilium
+  options:
+    waitForJobs: true
+    wait: true
+    timeout: 5m
+  valuesTemplate: |
+    operator:
+      replicas: 1
+    hubble:
+      relay:
+        enabled: true
+      ui:
+        enabled: true
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: LinodeMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+      name: ${CLUSTER_NAME}-control-plane
+  kubeadmConfigSpec:
+    files:
+      - path: /etc/containerd/config.toml
+        content: |
+          version = 2
+          imports = ["/etc/containerd/conf.d/*.toml"]
+          [plugins]
+            [plugins."io.containerd.grpc.v1.cri"]
+              sandbox_image = "registry.k8s.io/pause:3.9"
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+              runtime_type = "io.containerd.runc.v2"
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+              SystemdCgroup = true
+      - path: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+      - path: /etc/sysctl.d/k8s.conf
+        content: |
+          net.bridge.bridge-nf-call-iptables  = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward                 = 1
+      - path: /kubeadm-init.sh
+        content: |
+          #!/bin/bash
+          export DEBIAN_FRONTEND=noninteractive
+          hostnamectl set-hostname "$1" && hostname -F /etc/hostname
+          mkdir -p -m 755 /etc/apt/keyrings
+          VERSION=${2%.*}
+          curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          apt-get update -y
+          apt-get install -y kubelet kubeadm kubectl containerd
+          apt-mark hold kubelet kubeadm kubectl containerd
+          modprobe overlay
+          modprobe br_netfilter
+          sysctl --system
+        permissions: "0777"
+    preKubeadmCommands:
+      - /kubeadm-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+        timeoutForControlPlane: 20m
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
+        name: '{{ ds.meta_data.label }}'
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
+        name: '{{ ds.meta_data.label }}'
+  version: "${KUBERNETES_VERSION}"
+---
+kind: LinodeMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      image: ${LINODE_OS}
+      type: ${LINODE_CONTROL_PLANE_MACHINE_TYPE}
+      region: ${LINODE_REGION}
+      authorizedKeys:
+        - ${LINODE_SSH_KEY}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: ${CLUSTER_NAME}-md-0
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: ${CLUSTER_NAME}-md-0
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: LinodeMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      image: ${LINODE_OS}
+      type: ${LINODE_MACHINE_TYPE}
+      region: ${LINODE_REGION}
+      authorizedKeys:
+        - ${LINODE_SSH_KEY}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      files:
+        - path: /etc/containerd/config.toml
+          content: |
+            version = 2
+            imports = ["/etc/containerd/conf.d/*.toml"]
+            [plugins]
+              [plugins."io.containerd.grpc.v1.cri"]
+                sandbox_image = "registry.k8s.io/pause:3.9"
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                runtime_type = "io.containerd.runc.v2"
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                SystemdCgroup = true
+        - path: /etc/modules-load.d/k8s.conf
+          content: |
+            overlay
+            br_netfilter
+        - path: /etc/sysctl.d/k8s.conf
+          content: |
+            net.bridge.bridge-nf-call-iptables  = 1
+            net.bridge.bridge-nf-call-ip6tables = 1
+            net.ipv4.ip_forward                 = 1
+        - path: /kubeadm-init.sh
+          content: |
+            #!/bin/bash
+            export DEBIAN_FRONTEND=noninteractive
+            hostnamectl set-hostname "$1" && hostname -F /etc/hostname
+            mkdir -p -m 755 /etc/apt/keyrings
+            VERSION=${2%.*}
+            curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+            echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+            apt-get update -y
+            apt-get install -y kubelet kubeadm kubectl containerd
+            apt-mark hold kubelet kubeadm kubectl containerd
+            modprobe overlay
+            modprobe br_netfilter
+            sysctl --system
+          permissions: "0777"
+      preKubeadmCommands:
+        - /kubeadm-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
+          name: '{{ ds.meta_data.label }}'


### PR DESCRIPTION
This adds CAAPH (https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm) into the KIND management created by Tilt to install Cilium via the helm controller. We are doing this instead of using `postKubeadmCommands` because we need to be able to retry in the case of transient failures with reaching the control plane.

Using this template, it is possible to set env vars and use `envstubst` to create a cluster in a one-liner:
```
envsubst "`printf '${%s} ' $(sh -c "env|cut -d'=' -f1")`" < templates/cluster-template.yaml | kubectl apply -f -
```

Result:
```
(⎈|kind-tilt:N/A) ~  clusterctl describe cluster adumaine-1
NAME                                                           READY  SEVERITY  REASON  SINCE  MESSAGE
Cluster/adumaine-1                                             True                     5m28s
├─ClusterInfrastructure - LinodeCluster/adumaine-1             True                     9m55s
├─ControlPlane - KubeadmControlPlane/adumaine-1-control-plane  True                     5m28s
│ └─Machine/adumaine-1-control-plane-27qv8                     True                     8m50s
└─Workers
  └─MachineDeployment/adumaine-1-md-0                          True                     5s
    └─Machine/adumaine-1-md-0-q6nsd-p8fqd                      True                     4m35s

```

closes #3