### PR TITLE
add support for devbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ A [Cluster API](https://cluster-api.sigs.k8s.io/) implementation for the [Linode
 
 ## Local development
 
+### Using Devbox
+
+1. [Download Devbox](https://jetpack.io/devbox/docs/installing_devbox/) 
+2. Install dependent packages in your project 
+   ```shell
+   devbox install
+   ```
+3. Use devbox environment
+   ```shell
+   # use a devbox shell
+   devbox shell
+   # or run a single command in devbox
+   devbox run make tilt-cluster
+   # or leverage direnv integration
+   devbox generate direnv
+   ```
+
+
 ### Enable git hooks
 
 To enable automatic code validation on code push, execute the following commands:
@@ -20,7 +38,7 @@ To enable automatic code validation on code push, execute the following commands
 PATH="$PWD/bin:$PATH" make husky && husky install
 ```
 
-If you temporary would like to disable git hook, set `SKIP_GIT_PUSH_HOOK` value:
+If you would like to temporarily disable git hook, set `SKIP_GIT_PUSH_HOOK` value:
 
 ```bash
 SKIP_GIT_PUSH_HOOK=1 git push

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,23 @@
+{
+  "packages": [
+    "clusterctl@latest",
+    "ctlptl@latest",
+    "docker@latest",
+    "go-tools@latest",
+    "go@1.21.5",
+    "golangci-lint@latest",
+    "govulncheck@latest",
+    "husky@latest",
+    "kind@latest",
+    "kubernetes-controller-tools@latest",
+    "kustomize@latest",
+    "kuttl@latest",
+    "nilaway@latest",
+    "tilt@latest",
+    "envsubst@latest"
+  ],
+  "shell": {
+    "init_hook": [],
+    "scripts":   {}
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,305 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "clusterctl@latest": {
+      "last_modified": "2024-01-18T00:05:01Z",
+      "resolved": "github:NixOS/nixpkgs/921fb3319c2a296fc65048272d22f3db889d7292#clusterctl",
+      "source": "devbox-search",
+      "version": "1.6.1",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/fb0kbrvaip39h589kwjkj5sw742rxmz6-clusterctl-1.6.1"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/6a1yn29mzsk7xd0yyzh4fms3x5walsdc-clusterctl-1.6.1"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/x7qv0417bd062sb2cx9892lgc058h0gi-clusterctl-1.6.1"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/s32zh7lrbc0n2zcdgnqvrv27xzxs0sck-clusterctl-1.6.1"
+        }
+      }
+    },
+    "ctlptl@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#ctlptl",
+      "source": "devbox-search",
+      "version": "0.8.25",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/1r25ywdx4jffs3harx3zaldawmip4lqa-ctlptl-0.8.25"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/lwv2cslpq3hxw7lhz1y85mms9wl3f1kh-ctlptl-0.8.25"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/ww1b2kxrrqayvs0ry50a09a33iggxg3b-ctlptl-0.8.25"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/rddb9inkhc0zw8g686mv0b8ya3xdgyzn-ctlptl-0.8.25"
+        }
+      }
+    },
+    "docker@latest": {
+      "last_modified": "2024-01-29T00:15:04Z",
+      "resolved": "github:NixOS/nixpkgs/90f456026d284c22b3e3497be980b2e47d0b28ac#docker",
+      "source": "devbox-search",
+      "version": "24.0.5",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/b1wvdq94zxwkpjsxdzhm9hf9igb83siz-docker-24.0.5"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/h10712wm42kns4wjy78qg0ycmw3v8hai-docker-24.0.5"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/16wz1cd6kz75rs0fnhihaqn1c7a5l8fy-docker-24.0.5"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/kahw87dwsj3m4czp636a58791qrpnj25-docker-24.0.5"
+        }
+      }
+    },
+    "envsubst@latest": {
+      "last_modified": "2024-01-27T14:55:31Z",
+      "resolved": "github:NixOS/nixpkgs/160b762eda6d139ac10ae081f8f78d640dd523eb#envsubst",
+      "source": "devbox-search",
+      "version": "1.4.2",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/0n0xrd9796b8lz0574v4cnl20d1hvhvb-envsubst-1.4.2"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/myjffrm8sfdncjg92n1kcx8p1h7ni2d1-envsubst-1.4.2"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/gn9537z5k45frrclsvix22l5kf9y8xc2-envsubst-1.4.2"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/1gkyrqqjcsiirx2c7x79bibn9xjb2nla-envsubst-1.4.2"
+        }
+      }
+    },
+    "go-tools@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#go-tools",
+      "source": "devbox-search",
+      "version": "2023.1.6",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/znwyinwhkfcbxs1krxrkifv8cfpsk2cv-go-tools-2023.1.6"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/wcyzvjnki8mxjha2h1k9zfg9grd7pbn6-go-tools-2023.1.6"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/9nzqn3p88bc93d15h3361prs1yqk32gf-go-tools-2023.1.6"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/k757m23123dbnjggb0lfmpjha4nl0mgy-go-tools-2023.1.6"
+        }
+      }
+    },
+    "go@1.21.5": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#go",
+      "source": "devbox-search",
+      "version": "1.21.5",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/z6p2j8shdwi74kbm86jwdh03vxq91l0q-go-1.21.5"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/1p00q366rk2j7w9lnflrl7xaks7wfq5d-go-1.21.5"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/brv7d6mlrclkzywf1vaf35wqhq4c0c82-go-1.21.5"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/rccpgf2bnh58hhh4908p78i1rln9gzvp-go-1.21.5"
+        }
+      }
+    },
+    "golangci-lint@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#golangci-lint",
+      "source": "devbox-search",
+      "version": "1.55.2",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/jn473vqnn5b22nfyi9i5q9baabins79d-golangci-lint-1.55.2"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/0bviwvbqc81gnhhg937q1dx8vnv0c3ml-golangci-lint-1.55.2"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/b5w76bajwnajcdxw60363g5m8vxgd17a-golangci-lint-1.55.2"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/4kq1iinaabjh96myl4q73d0yjw3p911l-golangci-lint-1.55.2"
+        }
+      }
+    },
+    "govulncheck@latest": {
+      "last_modified": "2024-01-27T14:55:31Z",
+      "resolved": "github:NixOS/nixpkgs/160b762eda6d139ac10ae081f8f78d640dd523eb#govulncheck",
+      "source": "devbox-search",
+      "version": "1.0.3",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/bg7ppwz9lzxmb2la2xnck5by0gnbbqlm-govulncheck-1.0.3"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/bmmfkm88fqkswqb9bdhkaf0lny8p3csq-govulncheck-1.0.3"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/7grbqm6ni2bhwnbv8vcm1bmy5l771w0y-govulncheck-1.0.3"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/z971gdv82lgfa5zys2q0sgbi0v2xrjw6-govulncheck-1.0.3"
+        }
+      }
+    },
+    "husky@latest": {
+      "last_modified": "2024-01-24T16:15:02Z",
+      "resolved": "github:NixOS/nixpkgs/5cd2baa57a9ff2d84f2615700434fa04f3067fdb#husky",
+      "source": "devbox-search",
+      "version": "8.0.3",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/6pfvr5kv4cgc0f718h2l1k5in7anrd4z-husky-8.0.3"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/x9jyvcnd0m5ankwnm37zma1wlq2mr6cp-husky-8.0.3"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/8zr6520c867af6qydicbc6wzxg304f66-husky-8.0.3"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/15wc8qkfny0gzkjij3mgvapss5x2yxp7-husky-8.0.3"
+        }
+      }
+    },
+    "kind@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#kind",
+      "source": "devbox-search",
+      "version": "0.20.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/9j3w2jyp43q8iqywclvshh0biw4zfpgg-kind-0.20.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/dj3rcbfcy2ydd9qn6mf0c62qbji36479-kind-0.20.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/hgb814j66wfw2wwiv8d7n1xbyykxkd1s-kind-0.20.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/l2714wfcba5fykdk97jggcgk7j12ci8g-kind-0.20.0"
+        }
+      }
+    },
+    "kubernetes-controller-tools@latest": {
+      "last_modified": "2024-01-27T14:55:31Z",
+      "resolved": "github:NixOS/nixpkgs/160b762eda6d139ac10ae081f8f78d640dd523eb#kubernetes-controller-tools",
+      "source": "devbox-search",
+      "version": "0.13.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/hbz0drjik0m36rp1apxk9939fyxh8d5h-controller-tools-0.13.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/x9bjgv574g1jra5vr7gg18rsimnnj8k8-controller-tools-0.13.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/l3d5bdfx6xrrswdl9mvs067x8j4drzag-controller-tools-0.13.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/aw12bhi3qdx6mj088i5gzyr268v5di5w-controller-tools-0.13.0"
+        }
+      }
+    },
+    "kustomize@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#kustomize",
+      "source": "devbox-search",
+      "version": "5.3.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/vlfk6x1pzj87mmj785dk5mfybm8wzq2w-kustomize-5.3.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/5lr548gl80yig96f05mw9qm6803hligg-kustomize-5.3.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/m56z92xjaxxxzz31ncgrzi91yl7hh8kf-kustomize-5.3.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/ci180n2s37ldipx4ci7i4cbjv5mc2lpr-kustomize-5.3.0"
+        }
+      }
+    },
+    "kuttl@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#kuttl",
+      "source": "devbox-search",
+      "version": "0.15.0",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/s4lxz5igkws0ksy2j9gags3qj9px1f36-kuttl-0.15.0"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/gs0sdwryb8vaw6b5fkykspbd4743wzn7-kuttl-0.15.0"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/id6055x74ql6fvvsli74rcnqlld8l0sx-kuttl-0.15.0"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/53qvvms2qmjpvhzr9bx1519xj24dcgcf-kuttl-0.15.0"
+        }
+      }
+    },
+    "nilaway@latest": {
+      "last_modified": "2024-01-14T03:55:27Z",
+      "resolved": "github:NixOS/nixpkgs/dd5621df6dcb90122b50da5ec31c411a0de3e538#nilaway",
+      "source": "devbox-search",
+      "version": "2023-11-17",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/hafzd3cza76sb9kbjcar4qj1ypskr3bl-nilaway-unstable-2023-11-17"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/4mgk8ifzd1xzcmywnfg5rsm1ywmy65wg-nilaway-unstable-2023-11-17"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/qgllj640ysy0w58163bbi33226mf6z8q-nilaway-unstable-2023-11-17"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/2vyjk226arv73kl8329sn3848kn9n22m-nilaway-unstable-2023-11-17"
+        }
+      }
+    },
+    "tilt@latest": {
+      "last_modified": "2024-01-24T16:15:02Z",
+      "resolved": "github:NixOS/nixpkgs/5cd2baa57a9ff2d84f2615700434fa04f3067fdb#tilt",
+      "source": "devbox-search",
+      "version": "0.33.6",
+      "systems": {
+        "aarch64-darwin": {
+          "store_path": "/nix/store/xc8wxiqff7wl38iqmpia31yj732d2av7-tilt-0.33.6"
+        },
+        "aarch64-linux": {
+          "store_path": "/nix/store/vjq35zfmj47y1jgh0bwpl7j22n092f1g-tilt-0.33.6"
+        },
+        "x86_64-darwin": {
+          "store_path": "/nix/store/b8rp91m58m2jblnjz8gi9bgyqdjdk9lw-tilt-0.33.6"
+        },
+        "x86_64-linux": {
+          "store_path": "/nix/store/kkjisx85yh2ylkz70n8n9sgqi3240fz9-tilt-0.33.6"
+        }
+      }
+    }
+  }
+}

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,8 +1,8 @@
 ROOT_DIR ?= $(shell git rev-parse --show-toplevel)
-BIN_DIR ?= $(ROOT_DIR)/bin
 TARGET_API ?= api.linode.com
 TARGET_API_VERSION ?= v4beta
 
+export PATH := $(ROOT_DIR)/bin:$(ROOT_DIR)/.devbox/nix/profile/default/bin:$(PATH)
 runThisTest:
 	@echo "PLease execute make -C ($ROOT_DIR)/Makefile _e2etest-infra to spin up infrastructure"
 	make --no-print-directory _runThisTest
@@ -12,10 +12,10 @@ _runThisTest:
 	cp $(ROOT_DIR)/e2e/Makefile $$D ;\
 	mkdir $$D/suit ;\
 	cp -r $(PWD) $$D/suit ;\
-	ROOT_DIR=$(ROOT_DIR) KUBECONFIG="$(ROOT_DIR)/kubeconfig" $(BIN_DIR)/kuttl test --timeout 300 --skip-delete "$$D/suit"
+	ROOT_DIR=$(ROOT_DIR) KUBECONFIG="$(ROOT_DIR)/kubeconfig" kubectl-kuttl test --timeout 300 --skip-delete "$$D/suit"
 
 runTestSuit:
-	@T="$$(KUBECONFIG="$$ROOT_DIR/kubeconfig" $(BIN_DIR)/kuttl test --timeout 300 --skip-delete --namespace "$$NAMESPACE" "$$TS" 2>&1)" ;\
+	@T="$$(KUBECONFIG="$$ROOT_DIR/kubeconfig" kubectl-kuttl test --timeout 300 --skip-delete --namespace "$$NAMESPACE" "$$TS" 2>&1)" ;\
 	echo "$$T" |\
 		grep -v harness.go |\
 		grep -v ^=== |\
@@ -30,7 +30,7 @@ runTestSuit:
 renderTestCase:
 	@D="$$(mktemp -d)" ;\
 	mkdir -p "$$D/case" ;\
-	$(BIN_DIR)/envsubst -i "$$TPL" -o "$$D/case/00-case.yaml" ;\
+	envsubst -i "$$TPL" -o "$$D/case/00-case.yaml" ;\
 	printf "$$D\n"
 
 renderManifest:


### PR DESCRIPTION
This PR adds support for [devbox](https://github.com/jetpack-io/devbox), it does not force any tool to use devbox but just supports the devbox version of the tool if it is present. if the Make target is not run within a devbox shell it reverts to the existing Makefile tool caching logic. Additionally, this PR fixes the tool Make targets so they are only run if the tool doesn't exist locally already(fixing a bug where some targets ran every time)

closes #87 