### PR TITLE
[fix]: tweaks for pre-init script

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -191,10 +191,11 @@ stringData:
     net.ipv4.ip_forward                 = 1
   kubeadm-pre-init.sh: |
     #!/bin/bash
+    set -euo pipefail
     export DEBIAN_FRONTEND=noninteractive
     hostnamectl set-hostname "$1" && hostname -F /etc/hostname
     mkdir -p -m 755 /etc/apt/keyrings
-    VERSION=${2%.*}
+    VERSION="${2%.*}"
     curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update -y

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -60,7 +60,7 @@ spec:
             key: kubeadm-pre-init.sh
         permissions: "0500"
     preKubeadmCommands:
-      - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+      - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' ${KUBERNETES_VERSION#[vV]}
     clusterConfiguration:
       apiServer:
         extraArgs:
@@ -159,7 +159,7 @@ spec:
               key: kubeadm-pre-init.sh
           permissions: "0500"
       preKubeadmCommands:
-        - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+        - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' ${KUBERNETES_VERSION#[vV]}
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
@@ -195,7 +195,7 @@ stringData:
     export DEBIAN_FRONTEND=noninteractive
     hostnamectl set-hostname "$1" && hostname -F /etc/hostname
     mkdir -p -m 755 /etc/apt/keyrings
-    VERSION="${2%.*}"
+    VERSION=$${2%.*}
     curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update -y


### PR DESCRIPTION
Slight tweaks to handle the k8s version being specified with or without a v prefix, set the init script to exit earlier on failures, and escape the `$` for setting the version which is needed if doing `clusterctl generate cluster` instead of `envsubst`