### PR TITLE
[fix] providerID must conform to linode://{instanceID} for node external/internal IP setting

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -70,13 +70,13 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
+          provider-id: 'linode://{{ ds.meta_data.id }}'
         name: '{{ ds.meta_data.label }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
+          provider-id: 'linode://{{ ds.meta_data.id }}'
         name: '{{ ds.meta_data.label }}'
   version: "${KUBERNETES_VERSION}"
 ---
@@ -164,7 +164,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            provider-id: 'linode:///{{ ds.meta_data.region }}/{{ ds.meta_data.id }}'
+            provider-id: 'linode://{{ ds.meta_data.id }}'
           name: '{{ ds.meta_data.label }}'
 ---
 apiVersion: v1

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ${CLUSTER_NAME}
   labels:
     cni: cilium
+    ccm: linode
 spec:
   clusterNetwork:
     pods:
@@ -65,7 +66,9 @@ spec:
       apiServer:
         extraArgs:
           cloud-provider: external
-        timeoutForControlPlane: 20m
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:


### PR DESCRIPTION
In order for the [linode-ccm](https://github.com/linode/linode-cloud-controller-manager) to correctly set the external and internal IPs for nodes in a cluster, the provider ID needs to be `linode://$(instanceID}`. See:
- https://github.com/linode/linode-cloud-controller-manager/blob/main/cloud/linode/common.go#L9
- https://github.com/linode/linode-cloud-controller-manager/blob/main/cloud/linode/instances.go#L111