### PR TITLE
[fix] set the provider ID correctly for linode-CCM to read

### DIFF
--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -359,7 +359,7 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 
 	machineScope.LinodeMachine.Status.Ready = true
 	machineScope.LinodeMachine.Spec.InstanceID = &linodeInstance.ID
-	machineScope.LinodeMachine.Spec.ProviderID = util.Pointer(fmt.Sprintf("linode:///%s/%d", linodeInstance.Region, linodeInstance.ID))
+	machineScope.LinodeMachine.Spec.ProviderID = util.Pointer(fmt.Sprintf("linode://%d", linodeInstance.ID))
 
 	machineScope.LinodeMachine.Status.Addresses = []clusterv1.MachineAddress{}
 	for _, add := range linodeInstance.IPv4 {


### PR DESCRIPTION
Follow-up to #109 to make sure provider ID can be parsed by the linode-CCM