### PR TITLE
e2e: Set full infrastructureRef everywhere

### DIFF
--- a/e2e/linodemachine-controller/byovpc/01-create-cluster.tpl.yml
+++ b/e2e/linodemachine-controller/byovpc/01-create-cluster.tpl.yml
@@ -21,6 +21,8 @@ metadata:
 spec:
   paused: true
   infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: LinodeCluster
     name: linodecluster-sample
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/e2e/linodemachine-controller/minimal/01-create-cluster.yaml
+++ b/e2e/linodemachine-controller/minimal/01-create-cluster.yaml
@@ -16,6 +16,8 @@ metadata:
 spec:
   paused: true
   infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: LinodeCluster
     name: linodecluster-sample
 ---
 apiVersion: cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
This specifies a full `infrastructureRef` for all test steps. It is technically a no-op since the CAPI controller won't process paused Cluster objects.