### PR TITLE
add CONTRIBUTING.md and github templates and labels

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,36 @@
+## General:
+
+* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
+* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?
+
+----
+
+## Feature Requests:
+* [ ] Have you explained your rationale for why this feature is needed? 
+* [ ] Have you offered a proposed implementation/solution? 
+
+----
+
+## Bug Reporting
+
+### Expected Behavior
+
+### Actual Behavior
+
+### Steps to Reproduce the Problem
+
+  1.
+  1.
+  1.
+
+### Environment Specifications
+
+#### Screenshots, Code Blocks, and Logs
+
+#### Additional Notes
+
+----
+
+For general help or discussion, join the [Kubernetes Slack team](https://kubernetes.slack.com/messages/CD4B15LUR/details/) channel `#linode`. To sign up, use the [Kubernetes Slack inviter](http://slack.kubernetes.io/).
+
+The [Linode Community](https://www.linode.com/community/questions/) is a great place to get additional support.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+ <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
+
+ <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind feature
+/kind bug
+/kind api-change
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**TODOs**:
+<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->
+
+- [ ] squashed commits
+- [ ] includes documentation
+- [ ] adds unit tests
+- [ ] adds or updates e2e tests
+
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,32 @@
 version: 2
 updates:
+
+# Go - root directory
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "kind/cleanup"
+
+# Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "kind/cleanup"
+
+# github-actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "kind/cleanup"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,24 @@
+- name: added-feature
+  description: for new features in the changelog.
+  color: a2eeef
+- name: changed
+  description: for changes in existing functionality in the changelog.
+  color: a2eeef
+- name: deprecated
+  description: for soon-to-be removed features in the changelog.
+  color: e4e669
+- name: removed
+  description: for now removed features in the changelog.
+  color: e4e669
+- name: bugfix
+  description: for any bug fixes in the changelog.
+  color: d73a4a
+- name: security
+  description: for vulnerabilities in the changelog.
+  color: dd4739
+- name: bug
+  description: Something isn't working in this issue.
+  color: d73a4a
+- name: enhancement
+  description: New feature request in this issue.
+  color: a2eeef

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Added'
+    label: 'added-feature'
+  - title: '🧰 Changed'
+    label: 'changed'
+  - title: "⚠️  Deprecated"
+    label: "deprecated"
+  - title: "⚠️  Removed"
+    label: "removed"
+  - title: '🐛 Bug Fixes'
+    label: 'bugfix'
+  - title: "⚠️  Security"
+    label: "security"
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+no-changes-template: "- No changes"
+template: |
+  ## Changes
+
+  $CHANGES

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing Guidelines
+
+:+1::tada: First off, we appreciate you taking the time to contribute! THANK YOU! :tada::+1:
+
+We put together the handy guide below to help you get support for your work. Read on!  
+
+## I Just Want to Ask the Maintainers a Question
+
+The [Linode Community](https://www.linode.com/community/questions/) is a great place to get additional support.
+
+## How Do I Submit A (Good) Bug Report or Feature Request
+
+Please open a [github issue](https://guides.github.com/features/issues/) to report bugs or suggest features.
+
+When filing an issue or feature request, help us avoid duplication and redundant effort -- check existing open or recently closed issues first.
+
+Detailed bug reports and requests are easier for us to work with. Please include the following in your issue:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made, relevant to the bug
+* Anything unusual about your environment or deployment
+* Screenshots and code samples where illustrative and helpful
+
+## How to Open a Pull Request
+
+We follow the [fork and pull model](https://opensource.guide/how-to-contribute/#opening-a-pull-request) for open source contributions.
+
+Tips for a faster merge:
+ * address one feature or bug per pull request. 
+ * large formatting changes make it hard for us to focus on your work.
+ * follow language coding conventions.
+ * make sure that tests pass.
+ * make sure your commits are atomic, [addressing one change per commit](https://chris.beams.io/posts/git-commit/). 
+ * add tests!
+
+## Contributing a Patch
+
+1. Fork the desired repo, develop and test your code changes.
+    1. See the [Development Guide](https://linode.github.io/cluster-api-provider-linode/developers/development.html) for more instructions on setting up your environment and testing changes locally.
+2. Submit a pull request.
+    1. All PRs should be labeled with one of the following kinds
+         - `/kind feature` for PRs related to adding new features/tests
+         - `/kind bug` for PRs related to bug fixes and patches
+         - `/kind api-change` for PRs related to adding, removing, or otherwise changing an API
+         - `/kind cleanup` for PRs related to code refactoring and cleanup
+         - `/kind deprecation` for PRs related to a feature/enhancement marked for deprecation.
+         - `/kind design` for PRs related to design proposals
+         - `/kind documentation` for PRs related to documentation
+         - `/kind other` for PRs related to updating dependencies, minor changes or other
+     2. All code changes must be covered by unit tests and E2E tests.
+     3. All new features should come with user documentation.
+3. Ensure that commit message(s) are be meaningful and commit history is readable.
+
+All changes must be code reviewed. Coding conventions and standards are explained in the official [developer docs](https://github.com/kubernetes/community/tree/master/contributors/devel). Expect reviewers to request that you avoid common [go style mistakes](https://github.com/golang/go/wiki/CodeReviewComments) in your PRs.
+
+In case you want to run our E2E tests locally, please refer to the [E2E Testing](https://linode.github.io/cluster-api-provider-linode/developers/development.html#e2e-testing) guide.
+
+## Code of Conduct
+
+This project follows the [Linode Community Code of Conduct](https://www.linode.com/community/questions/conduct). 
+
+## Vulnerability Reporting
+
+If you discover a potential security issue in this project we ask that you notify Linode Security via our [vulnerability reporting process](https://hackerone.com/linode). Please do **not** create a public github issue.
+
+## Licensing
+
+See the [LICENSE file](/LICENSE) for our project's licensing.


### PR DESCRIPTION
## Additions
- CONTRIBUTING.md based on https://github.com/linode/linode-cloud-controller-manager/blob/main/.github/CONTRIBUTING.md
- PR and issue templates
- release drafter
- labels
- dependabot for docker

## Changes
- makes dependabot apply a cleanup label on the commits