### PR TITLE
Code of conduct + use existing dependencies label for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     commit-message:
       prefix: ":seedling:"
     labels:
-      - "kind/cleanup"
+      - "dependencies"
 
 # Docker
   - package-ecosystem: "docker"
@@ -19,7 +19,7 @@ updates:
     commit-message:
       prefix: ":seedling:"
     labels:
-      - "kind/cleanup"
+      - "dependencies"
 
 # github-actions
   - package-ecosystem: "github-actions"
@@ -29,4 +29,4 @@ updates:
     commit-message:
       prefix: ":seedling:"
     labels:
-      - "kind/cleanup"
+      - "dependencies"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,6 @@ All changes must be code reviewed. Coding conventions and standards are explaine
 
 In case you want to run our E2E tests locally, please refer to the [E2E Testing](https://linode.github.io/cluster-api-provider-linode/developers/development.html#e2e-testing) guide.
 
-## Code of Conduct
-
-This project follows the [Linode Community Code of Conduct](https://www.linode.com/community/questions/conduct). 
-
 ## Vulnerability Reporting
 
 If you discover a potential security issue in this project we ask that you notify Linode Security via our [vulnerability reporting process](https://hackerone.com/linode). Please do **not** create a public github issue.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,4 @@
+## Linode Community Code of Conduct
+
+This project follows the [Linode Community Code of Conduct](https://www.linode.com/community/questions/conduct). 
+


### PR DESCRIPTION
Github includes the code of conduct in the project overview so I moved that out. (e.g. https://github.com/linode/cluster-api-provider-linode/tree/code-of-conduct?tab=coc-ov-file)
This also changes the label dependabot will use since we have an existing dependencies label.

