### PR TITLE
change nodenames to lowercase

### DIFF
--- a/e2e/linodevpc-controller/minimal/03-verify-vpc.yaml
+++ b/e2e/linodevpc-controller/minimal/03-verify-vpc.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |-
-      URI="vpcs" FILTER="{\"label\":\"CLi-$(OBJ=linodevpcs/linodevpc-sample make getKubeUid | sed 's/-//g')\"}" make callLinodeApiGet | grep 'results": 0'
+      URI="vpcs" FILTER="{\"label\":\"cli-$(OBJ=linodevpcs/linodevpc-sample make getKubeUid | sed 's/-//g')\"}" make callLinodeApiGet | grep 'results": 0'

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -16,7 +16,7 @@ func Pointer[T any](t T) *T {
 
 // RenderObjectLabel renders a 63 charater long unique label
 func RenderObjectLabel(i types.UID) string {
-	return fmt.Sprintf("CLi-%s", strings.ReplaceAll(string(i), "-", ""))
+	return fmt.Sprintf("cli-%s", strings.ReplaceAll(string(i), "-", ""))
 }
 
 // CreateLinodeAPIFilter converts variables to API filter string


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
Currently, we name nodes as CLi-*. However, k8s registers nodes in lowercase and if we check the output of `kubectl get nodes`, all nodes are in lowercase.
```
root@CLi-7162b7cb893a4441b7fb30dc68cb0698:~# k get nodes
NAME                                   STATUS   ROLES           AGE   VERSION
cli-7162b7cb893a4441b7fb30dc68cb0698   Ready    control-plane   30m   v1.29.1
cli-72d7c4d5eb794425a1fb71cc1d075e69   Ready    control-plane   26m   v1.29.1
```

Similarly, kubelet uses a certificate which also contains nodename in lowercase.
```
# extracted cert from /var/lib/kubelet/pki/kubelet-client-current.pem to temp.crt
root@CLi-7162b7cb893a4441b7fb30dc68cb0698:~# openssl x509 -in temp.crt -noout -text | grep "Subject"
        Subject: O = system:nodes, CN = system:node:cli-7162b7cb893a4441b7fb30dc68cb0698
        Subject Public Key Info:
root@CLi-7162b7cb893a4441b7fb30dc68cb0698:~#
```
There are folks who had seen similar issues in the past with uppercase letters in hostname: https://discuss.kubernetes.io/t/we-just-got-bit-by-hostname-and-kubelet-case-sensitivity/15846

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I am open to changing the prefix from "cli-" to something more meaningful.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests


