### PR TITLE
set ipam mode to kubernetes

### DIFF
--- a/docs/src/flavors/clusterclass-kubeadm.md
+++ b/docs/src/flavors/clusterclass-kubeadm.md
@@ -34,7 +34,7 @@
         clusterNetwork:
           pods:
             cidrBlocks:
-            - 192.168.128.0/17
+            - 10.192.0.0/10
         topology:
           class: kubeadm
           controlPlane:

--- a/templates/addons/cilium/cilium.yaml
+++ b/templates/addons/cilium/cilium.yaml
@@ -15,6 +15,10 @@ spec:
     wait: true
     timeout: 5m
   valuesTemplate: |
+    ipam:
+      mode: kubernetes
+    k8s:
+      requireIPv4PodCIDR: true
     hubble:
       relay:
         enabled: true

--- a/templates/flavors/base/cluster.yaml
+++ b/templates/flavors/base/cluster.yaml
@@ -9,7 +9,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.128.0/17
+        - 10.192.0.0/10
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: REPLACEME

--- a/templates/flavors/clusterclass-kubeadm/cluster-template.yaml
+++ b/templates/flavors/clusterclass-kubeadm/cluster-template.yaml
@@ -10,7 +10,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.128.0/17
+        - 10.192.0.0/10
   topology:
     class: kubeadm
     version: ${KUBERNETES_VERSION}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
Cilium when installed has ipam mode set to cluster-pool. We have kube-controller-manager configured to provide podCIDRs to nodes. Cilium ignores these settings and itself allocates podCIDRs to nodes. With this change, we tell cilium to use the podCIDRs allocated to nodes by kube-controller-manager and use them.
We are also changing the podCIDR to be 10.192.0.0/10 which allows us to have 16k /24 subnets. This also allows us to avoid conflicting with linode specific private subnet.

Sample output:
```
root@rs1-control-plane-z8qt2:~# k get pod/kube-controller-manager-rs1-control-plane-z8qt2 -n kube-system -o yaml | grep cidr
    - --allocate-node-cidrs=true
    - --cluster-cidr=10.192.0.0/10
root@rs1-control-plane-z8qt2:~# k get node rs1-control-plane-z8qt2 -o yaml | yq .spec.podCIDRs
- 10.192.0.0/24
root@rs1-control-plane-z8qt2:~# k get node rs1-md-0-wncvd -o yaml | yq .spec.podCIDRs
- 10.192.1.0/24
root@rs1-control-plane-z8qt2:~# k get pods -A -o wide
NAMESPACE     NAME                                              READY   STATUS    RESTARTS   AGE   IP                NODE                      NOMINATED NODE   READINESS GATES
kube-system   ccm-linode-pbhbx                                  1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   cilium-czzjb                                      1/1     Running   0          15m   192.168.135.28    rs1-md-0-wncvd            <none>           <none>
kube-system   cilium-operator-5cddcb98d5-fnrg7                  1/1     Running   0          17m   192.168.135.28    rs1-md-0-wncvd            <none>           <none>
kube-system   cilium-operator-5cddcb98d5-hnpgs                  1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   cilium-tk8m9                                      1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   coredns-76f75df574-cqbh9                          1/1     Running   0          17m   10.192.0.4        rs1-control-plane-z8qt2   <none>           <none>
kube-system   coredns-76f75df574-nz5ws                          1/1     Running   0          17m   10.192.0.185      rs1-control-plane-z8qt2   <none>           <none>
kube-system   etcd-rs1-control-plane-z8qt2                      1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   hubble-relay-59b8bfd6fb-8zt2f                     1/1     Running   0          17m   10.192.1.192      rs1-md-0-wncvd            <none>           <none>
kube-system   hubble-ui-6b4d867c59-jxvdj                        2/2     Running   0          17m   10.192.1.118      rs1-md-0-wncvd            <none>           <none>
kube-system   kube-apiserver-rs1-control-plane-z8qt2            1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   kube-controller-manager-rs1-control-plane-z8qt2   1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   kube-proxy-cvxgw                                  1/1     Running   0          15m   192.168.135.28    rs1-md-0-wncvd            <none>           <none>
kube-system   kube-proxy-rqv24                                  1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
kube-system   kube-scheduler-rs1-control-plane-z8qt2            1/1     Running   0          17m   192.168.149.223   rs1-control-plane-z8qt2   <none>           <none>
root@rs1-control-plane-z8qt2:~#
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


