### PR TITLE
[fix] [rke2] - set node-ip, use internal-only-ips for rke2 registration, set the ip type properly for the machine addresses

### DIFF
--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -378,10 +378,14 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 	machineScope.LinodeMachine.Spec.ProviderID = util.Pointer(fmt.Sprintf("linode://%d", linodeInstance.ID))
 
 	machineScope.LinodeMachine.Status.Addresses = []clusterv1.MachineAddress{}
-	for _, add := range linodeInstance.IPv4 {
+	for _, addr := range linodeInstance.IPv4 {
+		addrType := clusterv1.MachineExternalIP
+		if addr.IsPrivate() {
+			addrType = clusterv1.MachineInternalIP
+		}
 		machineScope.LinodeMachine.Status.Addresses = append(machineScope.LinodeMachine.Status.Addresses, clusterv1.MachineAddress{
-			Type:    clusterv1.MachineExternalIP,
-			Address: add.String(),
+			Type:    addrType,
+			Address: addr.String(),
 		})
 	}
 

--- a/templates/flavors/rke2/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/rke2ConfigTemplate.yaml
@@ -12,7 +12,11 @@ spec:
         kubelet:
           extraArgs:
             - "provider-id=linode://{{ ds.meta_data.id }}"
+      # TODO: use MDS to get public and private IP instead because hostname ordering can't always be assumed
       preRKE2Commands:
+        - |
+          mkdir -p /etc/rancher/rke2/config.yaml.d/
+          echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/rke2/config.yaml.d/capi-config.yaml
         - sed -i '/swap/d' /etc/fstab
         - swapoff -a
         - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/rke2/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/rke2ControlPlane.yaml
@@ -21,6 +21,7 @@ spec:
           name: linode-${CLUSTER_NAME}-crs-0
       owner: root:root
       path: /var/lib/rancher/rke2/server/manifests/linode-token-region.yaml
+  registrationMethod: internal-only-ips
   serverConfig:
     cni: cilium
     cloudProviderName: external
@@ -36,6 +37,9 @@ spec:
       extraArgs:
         - "provider-id=linode://{{ ds.meta_data.id }}"
   preRKE2Commands:
+    - |
+      mkdir -p /etc/rancher/rke2/config.yaml.d/
+      echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/rke2/config.yaml.d/capi-config.yaml
     - sed -i '/swap/d' /etc/fstab
     - swapoff -a
     - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->
/kind bug

**What this PR does / why we need it**:
Adds the private IP to the `node-ip` and the public IP to the `tls-san` config for RKE2 like we had to do for K3s so the TLS certs are valid. Without `node-ip`, the container logs can't be retrieved and without the `tls-san` addition on top of that, server joining stops working. Ideally we need to have registration done via [controlPlaneEndpoint registration though that's still in progress](https://github.com/rancher-sandbox/cluster-api-provider-rke2/pull/266).
I'm aware `hostname -I` is brittle with the ordering per the manpage, but I don't have a much better solution at this time for this workaround.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


