### PR TITLE
🔧  [tweak] - use different k8s version vars for different flavors

### DIFF
--- a/docs/src/topics/flavors/k3s.md
+++ b/docs/src/topics/flavors/k3s.md
@@ -7,7 +7,7 @@
 * [Quickstart](../topics/getting-started.md) completed
 * Select a [k3s kubernetes version](https://github.com/k3s-io/k3s/releases) to set for the kubernetes version
   ```bash
-  export KUBERNETES_VERSION=v1.29.1+k3s2
+  export K3S_KUBERNETES_VERSION=v1.29.1+k3s2
   ```
 * Installed [k3s bootstrap provider](https://github.com/k3s-io/cluster-api-k3s) into your management cluster
   * Add the following to `~/.cluster-api/clusterctl.yaml` for the k3s bootstrap/control plane providers

--- a/docs/src/topics/flavors/rke2.md
+++ b/docs/src/topics/flavors/rke2.md
@@ -7,7 +7,7 @@
 * [Quickstart](../topics/getting-started.md) completed
 * Select an [rke2 kubernetes version](https://github.com/rancher/rke2/releases) to set for the kubernetes version
   ```bash
-  export KUBERNETES_VERSION=v1.29.1+rke2r1
+  export RKE2_KUBERNETES_VERSION=v1.29.1+rke2r1
   ```
 * Installed [rke2 bootstrap provider](https://github.com/rancher-sandbox/cluster-api-provider-rke2) into your management cluster
   ```shell

--- a/templates/flavors/k3s/k3sControlPlane.yaml
+++ b/templates/flavors/k3s/k3sControlPlane.yaml
@@ -47,4 +47,4 @@ spec:
       - sed -i '/swap/d' /etc/fstab
       - swapoff -a
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  version: ${KUBERNETES_VERSION}
+  version: ${K3S_KUBERNETES_VERSION}

--- a/templates/flavors/k3s/kustomization.yaml
+++ b/templates/flavors/k3s/kustomization.yaml
@@ -22,3 +22,11 @@ patches:
       - op: replace
         path: /spec/template/spec/bootstrap/configRef/kind
         value: KThreesConfigTemplate
+  - target:
+      group: cluster.x-k8s.io
+      version: v1beta1
+      kind: MachineDeployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/version
+        value: ${K3S_KUBERNETES_VERSION}

--- a/templates/flavors/rke2/kustomization.yaml
+++ b/templates/flavors/rke2/kustomization.yaml
@@ -22,3 +22,11 @@ patches:
       - op: replace
         path: /spec/template/spec/bootstrap/configRef/kind
         value: RKE2ConfigTemplate
+  - target:
+      group: cluster.x-k8s.io
+      version: v1beta1
+      kind: MachineDeployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/version
+        value: ${RKE2_KUBERNETES_VERSION}

--- a/templates/flavors/rke2/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/rke2ConfigTemplate.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       agentConfig:
-        version: ${KUBERNETES_VERSION}
+        version: ${RKE2_KUBERNETES_VERSION}
         nodeName: '{{ ds.meta_data.label }}'
         kubelet:
           extraArgs:

--- a/templates/flavors/rke2/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/rke2ControlPlane.yaml
@@ -30,7 +30,7 @@ spec:
       kubernetesComponents:
         - "cloudController"
   agentConfig:
-    version: ${KUBERNETES_VERSION}
+    version: ${RKE2_KUBERNETES_VERSION}
     nodeName: '{{ ds.meta_data.label }}'
     kubelet:
       extraArgs:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->
/kind cleanup

**What this PR does / why we need it**:
It's easy to forget to set the correct k8s version for k3s vs rke2 vs kubeadm when swapping between flavors. This makes the variables distinct so `KUBERNETES_VERSION` doesn't need to be set every time a different flavor is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


