### PR TITLE
add vpc support for capl clusters

### DIFF
--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -61,7 +61,7 @@ const (
 	ConditionPreflightAdditionalDisksCreated clusterv1.ConditionType = "PreflightAdditionalDisksCreated"
 	ConditionPreflightConfigured             clusterv1.ConditionType = "PreflightConfigured"
 	ConditionPreflightBootTriggered          clusterv1.ConditionType = "PreflightBootTriggered"
-	ConditionPreflightNBConfigured           clusterv1.ConditionType = "PreflightNBConfigured"
+	ConditionPreflightNetworking             clusterv1.ConditionType = "PreflightNetworking"
 	ConditionPreflightReady                  clusterv1.ConditionType = "PreflightReady"
 )
 
@@ -351,12 +351,12 @@ func (r *LinodeMachineReconciler) reconcileInstanceCreate(
 		conditions.MarkTrue(machineScope.LinodeMachine, ConditionPreflightBootTriggered)
 	}
 
-	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightNBConfigured) {
+	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightNetworking) {
 		if err := services.AddNodeToNB(ctx, logger, machineScope); err != nil {
 			logger.Error(err, "Failed to add instance to Node Balancer backend")
 
 			if reconciler.RecordDecayingCondition(machineScope.LinodeMachine,
-				ConditionPreflightNBConfigured, string(cerrs.CreateMachineError), err.Error(),
+				ConditionPreflightNetworking, string(cerrs.CreateMachineError), err.Error(),
 				reconciler.DefaultMachineControllerPreflightTimeout(r.ReconcileTimeout)) {
 				return ctrl.Result{}, err
 			}
@@ -364,7 +364,7 @@ func (r *LinodeMachineReconciler) reconcileInstanceCreate(
 			return ctrl.Result{RequeueAfter: reconciler.DefaultMachineControllerWaitForRunningDelay}, nil
 		}
 
-		conditions.MarkTrue(machineScope.LinodeMachine, ConditionPreflightNBConfigured)
+		conditions.MarkTrue(machineScope.LinodeMachine, ConditionPreflightNetworking)
 	}
 
 	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightReady) {

--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -83,11 +83,6 @@ var requeueInstanceStatuses = map[linodego.InstanceStatus]bool{
 	linodego.InstanceResizing:     true,
 }
 
-type nodeIP struct {
-	ip     string
-	ipType clusterv1.MachineAddressType
-}
-
 // LinodeMachineReconciler reconciles a LinodeMachine object
 type LinodeMachineReconciler struct {
 	client.Client
@@ -365,7 +360,7 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 
 	machineScope.LinodeMachine.Spec.ProviderID = util.Pointer(fmt.Sprintf("linode://%d", linodeInstance.ID))
 
-	addrs, err := r.buildInstanceAddrs(ctx, logger, machineScope, linodeInstance.ID)
+	addrs, err := r.buildInstanceAddrs(ctx, machineScope, linodeInstance.ID)
 	if err != nil {
 		return linodeInstance, err
 	}

--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -61,6 +61,7 @@ const (
 	ConditionPreflightAdditionalDisksCreated clusterv1.ConditionType = "PreflightAdditionalDisksCreated"
 	ConditionPreflightConfigured             clusterv1.ConditionType = "PreflightConfigured"
 	ConditionPreflightBootTriggered          clusterv1.ConditionType = "PreflightBootTriggered"
+	ConditionPreflightNBConfigured           clusterv1.ConditionType = "PreflightNBConfigured"
 	ConditionPreflightReady                  clusterv1.ConditionType = "PreflightReady"
 )
 
@@ -248,7 +249,6 @@ func (r *LinodeMachineReconciler) reconcile(
 	return
 }
 
-//nolint:cyclop // keep top-level preflight condition checks in the same function for readability
 func (r *LinodeMachineReconciler) reconcileCreate(
 	ctx context.Context,
 	logger logr.Logger,
@@ -312,8 +312,17 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 		return ctrl.Result{}, err
 	}
 
+	return r.reconcileInstanceCreate(ctx, logger, machineScope, linodeInstance)
+}
+
+func (r *LinodeMachineReconciler) reconcileInstanceCreate(
+	ctx context.Context,
+	logger logr.Logger,
+	machineScope *scope.MachineScope,
+	linodeInstance *linodego.Instance,
+) (ctrl.Result, error) {
 	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightConfigured) {
-		if err = r.configureDisks(ctx, logger, machineScope, linodeInstance.ID); err != nil {
+		if err := r.configureDisks(ctx, logger, machineScope, linodeInstance.ID); err != nil {
 			if reconciler.RecordDecayingCondition(machineScope.LinodeMachine,
 				ConditionPreflightConfigured, string(cerrs.CreateMachineError), err.Error(),
 				reconciler.DefaultMachineControllerPreflightTimeout(r.ReconcileTimeout)) {
@@ -327,7 +336,7 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 	}
 
 	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightBootTriggered) {
-		if err = machineScope.LinodeClient.BootInstance(ctx, linodeInstance.ID, 0); err != nil {
+		if err := machineScope.LinodeClient.BootInstance(ctx, linodeInstance.ID, 0); err != nil {
 			logger.Error(err, "Failed to boot instance")
 
 			if reconciler.RecordDecayingCondition(machineScope.LinodeMachine,
@@ -342,12 +351,12 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 		conditions.MarkTrue(machineScope.LinodeMachine, ConditionPreflightBootTriggered)
 	}
 
-	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightReady) {
-		if err = services.AddNodeToNB(ctx, logger, machineScope); err != nil {
+	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightNBConfigured) {
+		if err := services.AddNodeToNB(ctx, logger, machineScope); err != nil {
 			logger.Error(err, "Failed to add instance to Node Balancer backend")
 
 			if reconciler.RecordDecayingCondition(machineScope.LinodeMachine,
-				ConditionPreflightReady, string(cerrs.CreateMachineError), err.Error(),
+				ConditionPreflightNBConfigured, string(cerrs.CreateMachineError), err.Error(),
 				reconciler.DefaultMachineControllerPreflightTimeout(r.ReconcileTimeout)) {
 				return ctrl.Result{}, err
 			}
@@ -355,6 +364,10 @@ func (r *LinodeMachineReconciler) reconcileCreate(
 			return ctrl.Result{RequeueAfter: reconciler.DefaultMachineControllerWaitForRunningDelay}, nil
 		}
 
+		conditions.MarkTrue(machineScope.LinodeMachine, ConditionPreflightNBConfigured)
+	}
+
+	if !reconciler.ConditionTrue(machineScope.LinodeMachine, ConditionPreflightReady) {
 		addrs, err := r.buildInstanceAddrs(ctx, machineScope, linodeInstance.ID)
 		if err != nil {
 			logger.Error(err, "Failed to get instance ip addresses")

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -88,6 +88,14 @@ func (r *LinodeMachineReconciler) newCreateConfig(ctx context.Context, machineSc
 		createConfig.RootPass = uuid.NewString()
 	}
 
+	// add public interface to linode (eth0)
+	iface := &linodego.InstanceConfigInterfaceCreateOptions{
+		Purpose: linodego.InterfacePurposePublic,
+		Primary: true,
+	}
+	createConfig.Interfaces = append(createConfig.Interfaces, *iface)
+
+	// if vpc, attach additional interface to linode (eth1)
 	if machineScope.LinodeCluster.Spec.VPCRef != nil {
 		iface, err := r.getVPCInterfaceConfig(ctx, machineScope, createConfig.Interfaces, logger)
 		if err != nil {

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -88,13 +88,6 @@ func (r *LinodeMachineReconciler) newCreateConfig(ctx context.Context, machineSc
 		createConfig.RootPass = uuid.NewString()
 	}
 
-	// add public interface to linode (eth0)
-	iface := linodego.InstanceConfigInterfaceCreateOptions{
-		Purpose: linodego.InterfacePurposePublic,
-		Primary: true,
-	}
-	createConfig.Interfaces = append(createConfig.Interfaces, iface)
-
 	// if vpc, attach additional interface to linode (eth1)
 	if machineScope.LinodeCluster.Spec.VPCRef != nil {
 		iface, err := r.getVPCInterfaceConfig(ctx, machineScope, createConfig.Interfaces, logger)

--- a/controller/linodemachine_controller_test.go
+++ b/controller/linodemachine_controller_test.go
@@ -493,6 +493,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				Return(&linodego.InstanceIPAddressResponse{
 					IPv4: &linodego.InstanceIPv4Response{
 						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
+						Public:  []*linodego.InstanceIP{{Address: "172.0.0.2"}},
 					},
 				}, nil)
 			createNB := mockLinodeClient.EXPECT().
@@ -509,6 +510,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				Return(&linodego.InstanceIPAddressResponse{
 					IPv4: &linodego.InstanceIPv4Response{
 						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
+						Public:  []*linodego.InstanceIP{{Address: "172.0.0.2"}},
 					},
 				}, nil)
 			mockLinodeClient.EXPECT().
@@ -518,6 +520,10 @@ var _ = Describe("create", Label("machine", "create"), func() {
 					Devices: &linodego.InstanceConfigDeviceMap{
 						SDA: &linodego.InstanceConfigDevice{DiskID: 100},
 					},
+					Interfaces: []linodego.InstanceConfigInterface{{
+						VPCID: ptr.To(1),
+						IPv4:  &linodego.VPCIPv4{VPC: "10.0.0.2"},
+					}},
 				}}, nil)
 
 			_, err = reconciler.reconcileCreate(ctx, logger, &mScope)
@@ -531,10 +537,20 @@ var _ = Describe("create", Label("machine", "create"), func() {
 			Expect(*linodeMachine.Status.InstanceState).To(Equal(linodego.InstanceOffline))
 			Expect(*linodeMachine.Spec.InstanceID).To(Equal(123))
 			Expect(*linodeMachine.Spec.ProviderID).To(Equal("linode://123"))
-			Expect(linodeMachine.Status.Addresses).To(Equal([]clusterv1.MachineAddress{{
-				Type:    clusterv1.MachineInternalIP,
-				Address: "192.168.0.2",
-			}}))
+			Expect(linodeMachine.Status.Addresses).To(Equal([]clusterv1.MachineAddress{
+				{
+					Type:    clusterv1.MachineExternalIP,
+					Address: "172.0.0.2",
+				},
+				{
+					Type:    clusterv1.MachineInternalIP,
+					Address: "10.0.0.2",
+				},
+				{
+					Type:    clusterv1.MachineInternalIP,
+					Address: "192.168.0.2",
+				},
+			}))
 
 			Expect(testLogs.String()).To(ContainSubstring("creating machine"))
 			Expect(testLogs.String()).To(ContainSubstring("Linode instance already exists"))

--- a/controller/linodemachine_controller_test.go
+++ b/controller/linodemachine_controller_test.go
@@ -148,10 +148,26 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				IPv4:   []*net.IP{ptr.To(net.IPv4(192, 168, 0, 2))},
 				Status: linodego.InstanceOffline,
 			}, nil)
-		mockLinodeClient.EXPECT().
+		bootInst := mockLinodeClient.EXPECT().
 			BootInstance(ctx, 123, 0).
 			After(createInst).
 			Return(nil)
+		getAddrs := mockLinodeClient.EXPECT().
+			GetInstanceIPAddresses(ctx, 123).
+			After(bootInst).
+			Return(&linodego.InstanceIPAddressResponse{
+				IPv4: &linodego.InstanceIPv4Response{
+					Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
+				},
+			}, nil)
+		mockLinodeClient.EXPECT().
+			ListInstanceConfigs(ctx, 123, gomock.Any()).
+			After(getAddrs).
+			Return([]linodego.InstanceConfig{{
+				Devices: &linodego.InstanceConfigDeviceMap{
+					SDA: &linodego.InstanceConfigDevice{DiskID: 100},
+				},
+			}}, nil)
 
 		mScope := scope.MachineScope{
 			Client:        k8sClient,
@@ -308,7 +324,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
 					},
 				}, nil)
-			mockLinodeClient.EXPECT().
+			createNB := mockLinodeClient.EXPECT().
 				CreateNodeBalancerNode(ctx, 1, 2, linodego.NodeBalancerNodeCreateOptions{
 					Label:   "mock",
 					Address: "192.168.0.2:6443",
@@ -316,6 +332,22 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				}).
 				After(getAddrs).
 				Return(nil, nil)
+			getAddrs = mockLinodeClient.EXPECT().
+				GetInstanceIPAddresses(ctx, 123).
+				After(createNB).
+				Return(&linodego.InstanceIPAddressResponse{
+					IPv4: &linodego.InstanceIPv4Response{
+						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
+					},
+				}, nil)
+			mockLinodeClient.EXPECT().
+				ListInstanceConfigs(ctx, 123, gomock.Any()).
+				After(getAddrs).
+				Return([]linodego.InstanceConfig{{
+					Devices: &linodego.InstanceConfigDeviceMap{
+						SDA: &linodego.InstanceConfigDevice{DiskID: 100},
+					},
+				}}, nil)
 
 			mScope := scope.MachineScope{
 				Client:        k8sClient,
@@ -463,7 +495,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
 					},
 				}, nil)
-			mockLinodeClient.EXPECT().
+			createNB := mockLinodeClient.EXPECT().
 				CreateNodeBalancerNode(ctx, 1, 2, linodego.NodeBalancerNodeCreateOptions{
 					Label:   "mock",
 					Address: "192.168.0.2:6443",
@@ -471,6 +503,22 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				}).
 				After(getAddrs).
 				Return(nil, nil)
+			getAddrs = mockLinodeClient.EXPECT().
+				GetInstanceIPAddresses(ctx, 123).
+				After(createNB).
+				Return(&linodego.InstanceIPAddressResponse{
+					IPv4: &linodego.InstanceIPv4Response{
+						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
+					},
+				}, nil)
+			mockLinodeClient.EXPECT().
+				ListInstanceConfigs(ctx, 123, gomock.Any()).
+				After(getAddrs).
+				Return([]linodego.InstanceConfig{{
+					Devices: &linodego.InstanceConfigDeviceMap{
+						SDA: &linodego.InstanceConfigDevice{DiskID: 100},
+					},
+				}}, nil)
 
 			_, err = reconciler.reconcileCreate(ctx, logger, &mScope)
 			Expect(err).NotTo(HaveOccurred())

--- a/docs/src/developers/development.md
+++ b/docs/src/developers/development.md
@@ -213,7 +213,7 @@ clusterctl generate cluster $CLUSTER_NAME \
   | kubectl apply -f -
 ```
 
-This will provision the cluster with the CNI defaulted to [cilium](../topics/addons.md#cilium)
+This will provision the cluster within VPC with the CNI defaulted to [cilium](../topics/addons.md#cilium)
 and the [linode-ccm](../topics/addons.md#ccm) installed.
 
 ##### Using ClusterClass (alpha)
@@ -244,6 +244,9 @@ To delete the cluster, simply run:
 
 ```sh
 kubectl delete cluster $CLUSTER_NAME
+```
+```admonish warning
+VPCs are not deleted when a cluster is deleted using kubectl. One can run `kubectl delete linodevpc <vpcname>` to cleanup VPC once cluster is deleted.
 ```
 
 ```admonish question title=""

--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -32,6 +32,9 @@ export LINODE_MACHINE_TYPE=g6-standard-2
 For Regions and Images that do not yet support Akamai's cloud-init datasource CAPL will automatically use a stackscript shim
 to provision the node. If you are using a custom image ensure the [cloud_init](https://www.linode.com/docs/api/images/#image-create) flag is set correctly on it
 ```
+```admonish warning
+By default, clusters are provisioned within VPC. For Regions which do not have [VPC support](https://www.linode.com/docs/products/networking/vpc/#availability) yet, use the VPCLess[TODO] flavor to have clusters provisioned.
+```
 
 ## Register linode as an infrastructure provider
 1. Add `linode` as an infrastructure provider in `~/.cluster-api/clusterctl.yaml`

--- a/templates/addons/cilium/cilium.yaml
+++ b/templates/addons/cilium/cilium.yaml
@@ -23,6 +23,12 @@ spec:
     ipv4NativeRoutingCIDR: 10.0.0.0/8
     tunnelProtocol: ""
     enableIPv4Masquerade: true
+    egressMasqueradeInterfaces: eth0
+    k8sServiceHost: {{ .InfraCluster.spec.controlPlaneEndpoint.host }}
+    k8sServicePort: {{ .InfraCluster.spec.controlPlaneEndpoint.port }}
+    extraArgs:
+    - --direct-routing-device=eth1
+    - --nodeport-addresses=0.0.0.0/0
     ipam:
       mode: kubernetes
     ipv4:
@@ -36,3 +42,7 @@ spec:
         enabled: true
       ui:
         enabled: true
+#    ipMasqAgent:
+#      enabled: true
+#    bpf:
+#      masquerade: true

--- a/templates/addons/cilium/cilium.yaml
+++ b/templates/addons/cilium/cilium.yaml
@@ -18,8 +18,17 @@ spec:
   valuesTemplate: |
     bgpControlPlane:
       enabled: true
+    routingMode: native
+    kubeProxyReplacement: true
+    ipv4NativeRoutingCIDR: 10.0.0.0/8
+    tunnelProtocol: ""
+    enableIPv4Masquerade: true
     ipam:
       mode: kubernetes
+    ipv4:
+      enabled: true
+    ipv6:
+      enabled: false
     k8s:
       requireIPv4PodCIDR: true
     hubble:

--- a/templates/addons/provider-linode/linode-ccm.yaml
+++ b/templates/addons/provider-linode/linode-ccm.yaml
@@ -9,7 +9,7 @@ spec:
   repoURL: https://linode.github.io/linode-cloud-controller-manager/
   chartName: ccm-linode
   namespace: kube-system
-  version: ${LINODE_CCM_VERSION:=v0.3.24}
+  version: ${LINODE_CCM_VERSION:=v0.4.1}
   options:
     waitForJobs: true
     wait: true
@@ -17,9 +17,8 @@ spec:
   valuesTemplate: |
     routeController:
       vpcName: ${VPC_NAME:=${CLUSTER_NAME}}
-      linodeNodePrivateSubnet: 10.0.0.0/8
+      clusterCIDR: 10.0.0.0/8
       configureCloudRoutes: true
-      routeReconciliationPeriod: 1m
     secretRef:
       name: "linode-token-region"
     image:

--- a/templates/addons/provider-linode/linode-ccm.yaml
+++ b/templates/addons/provider-linode/linode-ccm.yaml
@@ -9,7 +9,7 @@ spec:
   repoURL: https://linode.github.io/linode-cloud-controller-manager/
   chartName: ccm-linode
   namespace: kube-system
-  version: ${LINODE_CCM_VERSION:=v0.4.3}
+  version: ${LINODE_CCM_VERSION:=v0.4.4}
   options:
     waitForJobs: true
     wait: true

--- a/templates/addons/provider-linode/linode-ccm.yaml
+++ b/templates/addons/provider-linode/linode-ccm.yaml
@@ -15,6 +15,11 @@ spec:
     wait: true
     timeout: 5m
   valuesTemplate: |
+    routeController:
+      vpcName: ${VPC_NAME:=${CLUSTER_NAME}}
+      linodeNodePrivateSubnet: 10.0.0.0/8
+      configureCloudRoutes: true
+      routeReconciliationPeriod: 1m
     secretRef:
       name: "linode-token-region"
     image:

--- a/templates/addons/provider-linode/linode-ccm.yaml
+++ b/templates/addons/provider-linode/linode-ccm.yaml
@@ -9,7 +9,7 @@ spec:
   repoURL: https://linode.github.io/linode-cloud-controller-manager/
   chartName: ccm-linode
   namespace: kube-system
-  version: ${LINODE_CCM_VERSION:=v0.4.1}
+  version: ${LINODE_CCM_VERSION:=v0.4.3}
   options:
     waitForJobs: true
     wait: true

--- a/templates/common-init-files/secret.yaml
+++ b/templates/common-init-files/secret.yaml
@@ -38,4 +38,5 @@ stringData:
     modprobe overlay
     modprobe br_netfilter
     sysctl --system
-
+    IPADDR=$(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)
+    sed -i "s/kubeletExtraArgs:/kubeletExtraArgs:\n    node-ip: $IPADDR/g" /run/kubeadm/kubeadm.yaml

--- a/templates/flavors/base/kustomization.yaml
+++ b/templates/flavors/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cluster.yaml
+  - linodeVPC.yaml
   - linodeCluster.yaml
   - linodeMachineTemplate.yaml
   - machineDeployment.yaml

--- a/templates/flavors/base/linodeCluster.yaml
+++ b/templates/flavors/base/linodeCluster.yaml
@@ -10,4 +10,4 @@ spec:
   vpcRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
     kind: LinodeVPC
-    name: vpc-${CLUSTER_NAME}
+    name: ${VPC_NAME:=${CLUSTER_NAME}}

--- a/templates/flavors/base/linodeCluster.yaml
+++ b/templates/flavors/base/linodeCluster.yaml
@@ -7,3 +7,7 @@ spec:
   region: ${LINODE_REGION}
   credentialsRef:
     name: ${CLUSTER_NAME}-credentials
+  vpcRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: LinodeVPC
+    name: vpc-${CLUSTER_NAME}

--- a/templates/flavors/base/linodeMachineTemplate.yaml
+++ b/templates/flavors/base/linodeMachineTemplate.yaml
@@ -11,7 +11,7 @@ spec:
       region: ${LINODE_REGION}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
-      - ${LINODE_SSH_PUBKEY:=""}
+      # - ${LINODE_SSH_PUBKEY:=""}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeMachineTemplate
@@ -25,4 +25,4 @@ spec:
       region: ${LINODE_REGION}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
-      - ${LINODE_SSH_PUBKEY:=""}
+      # - ${LINODE_SSH_PUBKEY:=""}

--- a/templates/flavors/base/linodeMachineTemplate.yaml
+++ b/templates/flavors/base/linodeMachineTemplate.yaml
@@ -11,7 +11,7 @@ spec:
       region: ${LINODE_REGION}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
-      # - ${LINODE_SSH_PUBKEY:=""}
+      - ${LINODE_SSH_PUBKEY:=""}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeMachineTemplate
@@ -25,4 +25,4 @@ spec:
       region: ${LINODE_REGION}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
-      # - ${LINODE_SSH_PUBKEY:=""}
+      - ${LINODE_SSH_PUBKEY:=""}

--- a/templates/flavors/base/linodeMachineTemplate.yaml
+++ b/templates/flavors/base/linodeMachineTemplate.yaml
@@ -9,6 +9,9 @@ spec:
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_CONTROL_PLANE_MACHINE_TYPE}
       region: ${LINODE_REGION}
+      interfaces:
+      - purpose: public
+        primary: true
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
       # - ${LINODE_SSH_PUBKEY:=""}
@@ -23,6 +26,9 @@ spec:
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_MACHINE_TYPE}
       region: ${LINODE_REGION}
+      interfaces:
+      - purpose: public
+        primary: true
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
       # - ${LINODE_SSH_PUBKEY:=""}

--- a/templates/flavors/base/linodeVPC.yaml
+++ b/templates/flavors/base/linodeVPC.yaml
@@ -3,6 +3,8 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeVPC
 metadata:
   name: ${VPC_NAME:=${CLUSTER_NAME}}
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
 spec:
   region: ${LINODE_REGION}
   subnets:

--- a/templates/flavors/base/linodeVPC.yaml
+++ b/templates/flavors/base/linodeVPC.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeVPC
+metadata:
+  name: vpc-${CLUSTER_NAME}
+spec:
+  region: ${LINODE_REGION}
+  subnets:
+    - ipv4: 10.0.0.0/8
+      label: default

--- a/templates/flavors/base/linodeVPC.yaml
+++ b/templates/flavors/base/linodeVPC.yaml
@@ -2,7 +2,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: LinodeVPC
 metadata:
-  name: vpc-${CLUSTER_NAME}
+  name: ${VPC_NAME:=${CLUSTER_NAME}}
 spec:
   region: ${LINODE_REGION}
   subnets:

--- a/templates/flavors/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/default/kubeadmControlPlane.yaml
@@ -51,6 +51,8 @@ spec:
         extraArgs:
           cloud-provider: external
     initConfiguration:
+      skipPhases:
+        - addon/kube-proxy
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external

--- a/templates/flavors/k3s/k3sConfigTemplate.yaml
+++ b/templates/flavors/k3s/k3sConfigTemplate.yaml
@@ -11,7 +11,7 @@ spec:
       preK3sCommands:
         - |
           mkdir -p /etc/rancher/k3s/config.yaml.d/
-          echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
+          echo "node-ip: $(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
         - sed -i '/swap/d' /etc/fstab
         - swapoff -a
         - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/k3s/k3sControlPlane.yaml
+++ b/templates/flavors/k3s/k3sControlPlane.yaml
@@ -33,6 +33,36 @@ spec:
             name: linode-${CLUSTER_NAME}-crs-0
         owner: root:root
         path: /var/lib/rancher/k3s/server/manifests/linode-token-region.yaml
+      - path: /var/lib/rancher/k3s/server/manifests/k3s-cilium-config.yaml
+        owner: root:root
+        permissions: "0640"
+        content: |
+          apiVersion: helm.cattle.io/v1
+          kind: HelmChartConfig
+          metadata:
+            name: cilium
+            namespace: kube-system
+          spec:
+            valuesContent: |-
+              routingMode: native
+              kubeProxyReplacement: true
+              ipv4NativeRoutingCIDR: 10.0.0.0/8
+              tunnelProtocol: ""
+              enableIPv4Masquerade: true
+              egressMasqueradeInterfaces: eth0
+              k8sServiceHost: 10.0.0.2
+              k8sServicePort: 6443
+              extraArgs:
+              - --direct-routing-device=eth1
+              - --nodeport-addresses=0.0.0.0/0
+              ipam:
+                mode: kubernetes
+              ipv4:
+                enabled: true
+              ipv6:
+                enabled: false
+              k8s:
+                requireIPv4PodCIDR: true
     serverConfig:
       disableComponents:
         - servicelb
@@ -41,7 +71,7 @@ spec:
       nodeName: '{{ ds.meta_data.label }}'
     preK3sCommands:
       - |
-        echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
+        echo "node-ip: $(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
       - sed -i '/swap/d' /etc/fstab
       - swapoff -a
       - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/k3s/secret.yaml
+++ b/templates/flavors/k3s/secret.yaml
@@ -39,7 +39,7 @@ stringData:
      name: ccm-linode
     spec:
      targetNamespace: kube-system
-     version: ${LINODE_CCM_VERSION:=v0.4.1}
+     version: ${LINODE_CCM_VERSION:=v0.4.3}
      chart: ccm-linode
      repo: https://linode.github.io/linode-cloud-controller-manager/
      bootstrap: true

--- a/templates/flavors/k3s/secret.yaml
+++ b/templates/flavors/k3s/secret.yaml
@@ -39,11 +39,15 @@ stringData:
      name: ccm-linode
     spec:
      targetNamespace: kube-system
-     version: ${LINODE_CCM_VERSION:=v0.3.24}
+     version: ${LINODE_CCM_VERSION:=v0.4.1}
      chart: ccm-linode
      repo: https://linode.github.io/linode-cloud-controller-manager/
      bootstrap: true
      valuesContent: |-
+       routeController:
+         vpcName: ${VPC_NAME:=${CLUSTER_NAME}}
+         clusterCIDR: 10.0.0.0/8
+         configureCloudRoutes: true
        secretRef:
          name: "linode-token-region"
        nodeSelector:

--- a/templates/flavors/k3s/secret.yaml
+++ b/templates/flavors/k3s/secret.yaml
@@ -39,7 +39,7 @@ stringData:
      name: ccm-linode
     spec:
      targetNamespace: kube-system
-     version: ${LINODE_CCM_VERSION:=v0.4.3}
+     version: ${LINODE_CCM_VERSION:=v0.4.4}
      chart: ccm-linode
      repo: https://linode.github.io/linode-cloud-controller-manager/
      bootstrap: true

--- a/templates/flavors/rke2/kustomization.yaml
+++ b/templates/flavors/rke2/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - rke2ControlPlane.yaml
   - rke2ConfigTemplate.yaml
   - secret.yaml
+  - ../../addons/cilium
 patches:
   - target:
       group: cluster.x-k8s.io
@@ -14,6 +15,17 @@ patches:
       - op: replace
         path: /spec/controlPlaneRef/kind
         value: RKE2ControlPlane
+  - target:
+      group: cluster.x-k8s.io
+      version: v1beta1
+      kind: Cluster
+    patch: |-
+      apiVersion: cluster.x-k8s.io/v1beta1
+      kind: Cluster
+      metadata:
+        name: ${CLUSTER_NAME}
+        labels:
+            cni: cilium
   - target:
       group: cluster.x-k8s.io
       version: v1beta1

--- a/templates/flavors/rke2/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/rke2ConfigTemplate.yaml
@@ -12,10 +12,14 @@ spec:
         cisProfile: ${CIS_PROFILE:-"cis-1.23"}
         protectKernelDefaults: true
       # TODO: use MDS to get public and private IP instead because hostname ordering can't always be assumed
+        kubelet:
+          extraArgs:
+            - "provider-id=linode://{{ ds.meta_data.id }}"
+      # TODO: use MDS to get private IP instead
       preRKE2Commands:
         - |
           mkdir -p /etc/rancher/rke2/config.yaml.d/
-          echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/rke2/config.yaml.d/capi-config.yaml
+          echo "node-ip: $(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)" >> /etc/rancher/rke2/config.yaml.d/capi-config.yaml
         - sed -i '/swap/d' /etc/fstab
         - swapoff -a
         - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/rke2/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/rke2ControlPlane.yaml
@@ -21,6 +21,30 @@ spec:
           name: linode-${CLUSTER_NAME}-crs-0
       owner: root:root
       path: /var/lib/rancher/rke2/server/manifests/linode-token-region.yaml
+    - path: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+      owner: root:root
+      permissions: "0640"
+      content: |
+        apiVersion: helm.cattle.io/v1
+        kind: HelmChartConfig
+        metadata:
+          name: rke2-cilium
+          namespace: kube-system
+        spec:
+          valuesContent: |-
+            routingMode: native
+            kubeProxyReplacement: true
+            ipv4NativeRoutingCIDR: 10.0.0.0/8
+            tunnelProtocol: ""
+            enableIPv4Masquerade: true
+            ipam:
+              mode: kubernetes
+            ipv4:
+              enabled: true
+            ipv6:
+              enabled: false
+            k8s:
+              requireIPv4PodCIDR: true
   registrationMethod: internal-only-ips
   serverConfig:
     cni: cilium

--- a/templates/flavors/rke2/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/rke2ControlPlane.yaml
@@ -21,39 +21,16 @@ spec:
           name: linode-${CLUSTER_NAME}-crs-0
       owner: root:root
       path: /var/lib/rancher/rke2/server/manifests/linode-token-region.yaml
-    - path: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
-      owner: root:root
-      permissions: "0640"
-      content: |
-        apiVersion: helm.cattle.io/v1
-        kind: HelmChartConfig
-        metadata:
-          name: rke2-cilium
-          namespace: kube-system
-        spec:
-          valuesContent: |-
-            routingMode: native
-            kubeProxyReplacement: true
-            ipv4NativeRoutingCIDR: 10.0.0.0/8
-            tunnelProtocol: ""
-            enableIPv4Masquerade: true
-            ipam:
-              mode: kubernetes
-            ipv4:
-              enabled: true
-            ipv6:
-              enabled: false
-            k8s:
-              requireIPv4PodCIDR: true
   registrationMethod: internal-only-ips
   serverConfig:
-    cni: cilium
+    cni: none
     cloudProviderName: external
     disableComponents:
       pluginComponents:
         - "rke2-ingress-nginx"
       kubernetesComponents:
         - "cloudController"
+        - "kubeProxy"
   agentConfig:
     version: ${KUBERNETES_VERSION}
     nodeName: '{{ ds.meta_data.label }}'
@@ -62,7 +39,7 @@ spec:
   preRKE2Commands:
     - |
       mkdir -p /etc/rancher/rke2/config.yaml.d/
-      echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/rke2/config.yaml.d/capi-config.yaml
+      echo "node-ip: $(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)" >> /etc/rancher/rke2/config.yaml.d/capi-config.yaml
     - sed -i '/swap/d' /etc/fstab
     - swapoff -a
     - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/rke2/secret.yaml
+++ b/templates/flavors/rke2/secret.yaml
@@ -21,7 +21,7 @@ stringData:
      name: ccm-linode
     spec:
      targetNamespace: kube-system
-     version: ${LINODE_CCM_VERSION:=v0.4.3}
+     version: ${LINODE_CCM_VERSION:=v0.4.4}
      chart: ccm-linode
      repo: https://linode.github.io/linode-cloud-controller-manager/
      bootstrap: true

--- a/templates/flavors/rke2/secret.yaml
+++ b/templates/flavors/rke2/secret.yaml
@@ -21,7 +21,7 @@ stringData:
      name: ccm-linode
     spec:
      targetNamespace: kube-system
-     version: ${LINODE_CCM_VERSION:=v0.4.1}
+     version: ${LINODE_CCM_VERSION:=v0.4.3}
      chart: ccm-linode
      repo: https://linode.github.io/linode-cloud-controller-manager/
      bootstrap: true

--- a/templates/flavors/rke2/secret.yaml
+++ b/templates/flavors/rke2/secret.yaml
@@ -21,11 +21,15 @@ stringData:
      name: ccm-linode
     spec:
      targetNamespace: kube-system
-     version: ${LINODE_CCM_VERSION:=v0.3.24}
+     version: ${LINODE_CCM_VERSION:=v0.4.1}
      chart: ccm-linode
      repo: https://linode.github.io/linode-cloud-controller-manager/
      bootstrap: true
      valuesContent: |-
+       routeController:
+         vpcName: ${VPC_NAME:=${CLUSTER_NAME}}
+         clusterCIDR: 10.0.0.0/8
+         configureCloudRoutes: true
        secretRef:
          name: "linode-token-region"
        nodeSelector:


### PR DESCRIPTION
 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
With this change, k8s clusters are provisioned by default within a VPC.

1. Since nodebalancers don't yet work with VPC subnets, we attach two interfaces to a linode:
    - eth0 for public and private nodebalancer traffic
    - eth1 for VPC pod-to-pod traffic

    We have to keep pub+priv on eth0 because we want cloud-init to work within VPC. If eth0 is on VPC, then cloud-init fails unless we explicitly add route to make it go over eth1. Once nodebalancer and cloud-init works natively with VPC, we'll use just one interface.

2. We have cilium installed and configured with native routing (no vxlan). All pod-to-pod traffic goes over eth1 within the VPC.
```
root@rah6-control-plane-g8zh6:~# ip a | grep vxlan
root@rah6-control-plane-g8zh6:~#
```
3. Each node in a k8s cluster gets assigned a podCIDR. Linode ccm running in cluster with route-controller feature enabled automatically updates the routes within VPC so that pod-to-pod traffic can flow over the VPC subnet. This PR depends on that feature: see https://github.com/linode/linode-cloud-controller-manager/pull/184

One should be able to ping to pod ip's from any linode within the VPC.

To check if routes are added to interface or not, one can use curl as well:
```
curl --header 'Authorization: Bearer $LINODE_API_TOKEN' -X GET https://api.linode.com/v4/linode/instances/55519597/configs | jq .data[0].interfaces[].ip_ranges
```
The range returned in the output should match with the range present in node's spec `k get node <nodename> -o yaml | yq .spec.podCIDRs`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


