### PR TITLE
feat: extend multi-tenancy for LinodeMachines

### DIFF
--- a/api/v1alpha1/linodemachine_types.go
+++ b/api/v1alpha1/linodemachine_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"github.com/linode/linodego"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
@@ -75,6 +76,15 @@ type LinodeMachineSpec struct {
 	Metadata *InstanceMetadataOptions `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	FirewallID int `json:"firewallId,omitempty"`
+
+	// CredentialsRef is a reference to a Secret that contains the credentials
+	// to use for provisioning this machine. If not supplied then these
+	// credentials will be used in-order:
+	//   1. LinodeMachine
+	//   2. Owner LinodeCluster
+	//   3. Controller
+	// +optional
+	CredentialsRef *corev1.SecretReference `json:"credentialsRef,omitempty"`
 }
 
 // InstanceMetadataOptions defines metadata of instance

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
@@ -88,6 +88,25 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
+              credentialsRef:
+                description: |-
+                  CredentialsRef is a reference to a Secret that contains the credentials
+                  to use for provisioning this machine. If not supplied then these
+                  credentials will be used in-order:
+                    1. Machine
+                    2. Cluster
+                    2. Controller
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               firewallId:
                 type: integer
                 x-kubernetes-validations:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
@@ -75,6 +75,25 @@ spec:
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
+                      credentialsRef:
+                        description: |-
+                          CredentialsRef is a reference to a Secret that contains the credentials
+                          to use for provisioning this machine. If not supplied then these
+                          credentials will be used in-order:
+                            1. Machine
+                            2. Cluster
+                            2. Controller
+                        properties:
+                          name:
+                            description: name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
                       firewallId:
                         type: integer
                         x-kubernetes-validations:

--- a/docs/src/topics/multi-tenancy.md
+++ b/docs/src/topics/multi-tenancy.md
@@ -41,6 +41,16 @@ spec:
   credentialsRef:
     name: linode-credentials
   ...
+---
+# Example: LinodeMachine
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeMachine
+metadata:
+  name: test-machine
+spec:
+  credentialsRef:
+    name: linode-credentials
+  ...
 ```
 
 Secrets from other namespaces by additionally specifying an optional
@@ -49,3 +59,8 @@ Secrets from other namespaces by additionally specifying an optional
 ```admonish warning
 If `.spec.credentialsRef` is set for a LinodeCluster, it should also be set for adjacent resources (e.g. LinodeVPC).
 ```
+
+## LinodeMachine
+
+For LinodeMachines, credentials set on the LinodeMachine object will override any credentials supplied by the owner
+LinodeCluster. This can allow cross-account deployment of the Linodes for a cluster.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
Updates LinodeMachines to be able to supply an (optional) CredentialsRef field to override the credentials of their owner LinodeCluster.

This allows for a (potentially future) enhancement where clusters can provision Linode resources cross-account.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is being introduced now (rather than when the feature is determined to be absolutely needed) to provide a more stable API during development. However, we may wait to add this feature since:
1. The setting introduced is optional. Adding it later would have no effect on existing clusters post-addition.
2. We are allowed to break, drop support, etc. for alpha APIs without notice: https://kubernetes.io/docs/reference/using-api/#api-versioning

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [X] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


