### PR TITLE
[dev tweak] - install rke2 and k3s providers in tilt cluster if env vars are set, update dev docs

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -12,6 +12,18 @@ local_resource(
     cmd='EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init --addon helm',
 )
 
+if os.getenv('INSTALL_K3S_PROVIDER'):
+    local_resource(
+        'capi-k3s-controller-manager',
+        cmd='clusterctl init --bootstrap k3s --control-plane k3s',
+    )
+
+if os.getenv('INSTALL_RKE2_PROVIDER'):
+    local_resource(
+        'capi-rke2-controller-manager',
+        cmd='clusterctl init --bootstrap rke2 --control-plane rke2',
+    )
+
 manager_yaml = decode_yaml_stream(kustomize("config/default"))
 for resource in manager_yaml:
     if resource["metadata"]["name"] == "capl-manager-credentials":

--- a/docs/src/developers/development.md
+++ b/docs/src/developers/development.md
@@ -96,6 +96,15 @@ go get <repository>@<version>
 
 
 ### Using tilt
+~~~admonish note
+If you want to create RKE2 and/or K3s clusters, make sure to
+set the following env vars first:
+```
+export INSTALL_RKE2_PROVIDER=true
+export INSTALL_K3S_PROVIDER=true
+```
+~~~
+
 To build a kind cluster and start Tilt, simply run:
 ```sh
 make local-deploy


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
Installs the RKE2 and K3S providers into the KIND cluster created by Tilt if env vars are set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #155

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


