### PR TITLE
[FIX]: Setting correct GOROOT on startup for devbox

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -20,10 +20,9 @@
     "kyverno-chainsaw@latest"
   ],
   "shell": {
-    "init_hook": [],
+    "init_hook": [
+      "export GOROOT=$(go env GOROOT)"
+    ],
     "scripts":   {}
-  },
-  "env": {
-    "GOROOT": "/usr/local/go"
   }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -21,7 +21,7 @@
   ],
   "shell": {
     "init_hook": [
-      "export GOROOT=$(go env GOROOT)"
+      "export \"GOROOT=$(go env GOROOT)\""
     ],
     "scripts":   {}
   }

--- a/devbox.json
+++ b/devbox.json
@@ -22,5 +22,8 @@
   "shell": {
     "init_hook": [],
     "scripts":   {}
+  },
+  "env": {
+    "GOROOT": "/usr/local/go"
   }
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
Currently the `GOROOT` path that devbox is causing `make generate-mock` to fail. This PR add the config to set up the correct `GOROOT` path to `/usr/local/go`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


