### PR TITLE
add support for stackscript based bootstrapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ gosec: ## Run gosec against code.
 
 .PHONY: lint
 lint: ## Run lint against code.
-	docker run --rm -w /workdir -v $(PWD):/workdir golangci/golangci-lint:v1.56.1 golangci-lint run -c .golangci.yml
+	docker run --rm -w /workdir -v $(PWD):/workdir golangci/golangci-lint:v1.57.2 golangci-lint run -c .golangci.yml
 
 .PHONY: nilcheck
 nilcheck: nilaway ## Run nil check against code.

--- a/api/v1alpha1/linodemachine_types.go
+++ b/api/v1alpha1/linodemachine_types.go
@@ -50,10 +50,10 @@ type LinodeMachineSpec struct {
 	AuthorizedKeys []string `json:"authorizedKeys,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AuthorizedUsers []string `json:"authorizedUsers,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	StackScriptID int `json:"stackscriptId,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	StackScriptData map[string]string `json:"stackscriptData,omitempty"`
+	// UseStackScriptBootstrap will specify to use a StackScript shim for running cloud init
+	// instead of relying on the Akamai datasource if the Image/DC does not support it.
+	// in DCs that do not support metadata this defaults to true, otherwise it defaults to false
+	UseStackScriptBootstrap bool `json:"useStackScriptBootstrap,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	BackupID int `json:"backupId,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
@@ -66,9 +66,6 @@ type LinodeMachineSpec struct {
 	PrivateIP bool `json:"privateIp,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	Tags []string `json:"tags,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	// +optional
-	Metadata *InstanceMetadataOptions `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	FirewallID int `json:"firewallId,omitempty"`
 

--- a/api/v1alpha1/linodemachine_types.go
+++ b/api/v1alpha1/linodemachine_types.go
@@ -50,10 +50,6 @@ type LinodeMachineSpec struct {
 	AuthorizedKeys []string `json:"authorizedKeys,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	AuthorizedUsers []string `json:"authorizedUsers,omitempty"`
-	// UseStackScriptBootstrap will specify to use a StackScript shim for running cloud init
-	// instead of relying on the Akamai datasource if the Image/DC does not support it.
-	// in DCs that do not support metadata this defaults to true, otherwise it defaults to false
-	UseStackScriptBootstrap bool `json:"useStackScriptBootstrap,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	BackupID int `json:"backupId,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -363,13 +363,6 @@ func (in *LinodeMachineSpec) DeepCopyInto(out *LinodeMachineSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.StackScriptData != nil {
-		in, out := &in.StackScriptData, &out.StackScriptData
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.Interfaces != nil {
 		in, out := &in.Interfaces, &out.Interfaces
 		*out = make([]InstanceConfigInterfaceCreateOptions, len(*in))
@@ -381,11 +374,6 @@ func (in *LinodeMachineSpec) DeepCopyInto(out *LinodeMachineSpec) {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]string, len(*in))
 		copy(*out, *in)
-	}
-	if in.Metadata != nil {
-		in, out := &in.Metadata, &out.Metadata
-		*out = new(InstanceMetadataOptions)
-		**out = **in
 	}
 	if in.CredentialsRef != nil {
 		in, out := &in.CredentialsRef, &out.CredentialsRef

--- a/cloud/scope/client.go
+++ b/cloud/scope/client.go
@@ -28,8 +28,9 @@ type LinodeInstanceClient interface {
 	CreateInstanceDisk(ctx context.Context, linodeID int, opts linodego.InstanceDiskCreateOptions) (*linodego.InstanceDisk, error)
 	GetInstance(ctx context.Context, linodeID int) (*linodego.Instance, error)
 	DeleteInstance(ctx context.Context, linodeID int) error
-	WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error)
 	GetRegion(ctx context.Context, regionID string) (*linodego.Region, error)
+	GetImage(ctx context.Context, imageID string) (*linodego.Image, error)
+	WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error)
 }
 
 // LinodeVPCClient defines the methods that a Linode client must have to interact with Linode's VPC service.

--- a/cloud/scope/client.go
+++ b/cloud/scope/client.go
@@ -29,6 +29,7 @@ type LinodeInstanceClient interface {
 	GetInstance(ctx context.Context, linodeID int) (*linodego.Instance, error)
 	DeleteInstance(ctx context.Context, linodeID int) error
 	WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error)
+	GetRegion(ctx context.Context, regionID string) (*linodego.Region, error)
 }
 
 // LinodeVPCClient defines the methods that a Linode client must have to interact with Linode's VPC service.

--- a/cloud/scope/client.go
+++ b/cloud/scope/client.go
@@ -30,6 +30,8 @@ type LinodeInstanceClient interface {
 	DeleteInstance(ctx context.Context, linodeID int) error
 	GetRegion(ctx context.Context, regionID string) (*linodego.Region, error)
 	GetImage(ctx context.Context, imageID string) (*linodego.Image, error)
+	CreateStackscript(ctx context.Context, opts linodego.StackscriptCreateOptions) (*linodego.Stackscript, error)
+	ListStackscripts(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Stackscript, error)
 	WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error)
 }
 

--- a/cloud/services/stackscript.sh
+++ b/cloud/services/stackscript.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# <UDF name="instancedata" label="instance-data contents(base64 encoded" />
+# <UDF name="userdata" label="user-data file contents (base64 encoded)" />
+
+cat > /etc/cloud/cloud.cfg.d/100_none.cfg <<EOF
+datasource_list: [ "None"]
+datasource:
+  None:
+    metadata:
+      id: $LINODE_ID
+$(echo "${INSTANCEDATA}" | base64 -d | sed "s/^/      /")
+    userdata_raw: |
+$(echo "${USERDATA}" | base64 -d | sed "s/^/      /")
+
+EOF
+
+cloud-init clean
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg init --local
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg init
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg modules --mode=config
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg modules --mode=final

--- a/cloud/services/stackscripts.go
+++ b/cloud/services/stackscripts.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/linode/linodego"
+
+	"github.com/linode/cluster-api-provider-linode/cloud/scope"
+	"github.com/linode/cluster-api-provider-linode/util"
+	"github.com/linode/cluster-api-provider-linode/version"
+
+	_ "embed"
+)
+
+//go:embed stackscript.sh
+var stackscriptTemplate string
+
+func EnsureStackscript(ctx context.Context, machineScope *scope.MachineScope) (int, error) {
+	stackscriptName := fmt.Sprintf("CAPL-%s", version.GetVersion())
+	listFilter := util.Filter{
+		ID:    nil,
+		Label: stackscriptName,
+		Tags:  []string{},
+	}
+	filter, err := listFilter.String()
+	if err != nil {
+		return 0, err
+	}
+	stackscripts, err := machineScope.LinodeClient.ListStackscripts(ctx, &linodego.ListOptions{Filter: filter})
+	if util.IgnoreLinodeAPIError(err, http.StatusNotFound) != nil {
+		return 0, fmt.Errorf("failed to get stackscript with label %s: %w", stackscriptName, err)
+	}
+	if stackscripts != nil {
+		return stackscripts[0].ID, nil
+	}
+	stackscriptCreateOptions := linodego.StackscriptCreateOptions{
+		Label:       fmt.Sprintf("CAPL-%s", version.GetVersion()),
+		Description: fmt.Sprintf("Stackscript for creating CAPL clusters with CAPL controller version %s", version.GetVersion()),
+		Script:      stackscriptTemplate,
+		Images:      []string{"any/all"},
+	}
+	stackscript, err := machineScope.LinodeClient.CreateStackscript(ctx, stackscriptCreateOptions)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create StackScript: %w", err)
+	}
+
+	return stackscript.ID, nil
+}

--- a/cloud/services/stackscripts_test.go
+++ b/cloud/services/stackscripts_test.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/linode/cluster-api-provider-linode/cloud/scope"
+	"github.com/linode/cluster-api-provider-linode/mock"
+)
+
+func TestEnsureStackscripts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		machineScope  *scope.MachineScope
+		want          int
+		expectedError error
+		expects       func(client *mock.MockLinodeMachineClient)
+	}{
+		{
+			name:         "Success - Successfully get existing StackScript",
+			machineScope: &scope.MachineScope{},
+			want:         1234,
+			expects: func(mockClient *mock.MockLinodeMachineClient) {
+				mockClient.EXPECT().ListStackscripts(gomock.Any(), &linodego.ListOptions{Filter: "{\"label\":\"CAPL-dev\"}"}).Return([]linodego.Stackscript{{
+					Label: "CAPI Test 1",
+					ID:    1234,
+				}}, nil)
+			},
+		},
+		{
+			name:         "Error - failed get existing StackScript",
+			machineScope: &scope.MachineScope{},
+			expects: func(mockClient *mock.MockLinodeMachineClient) {
+				mockClient.EXPECT().ListStackscripts(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to get StackScript"))
+			},
+			expectedError: fmt.Errorf("failed to get StackScript"),
+		},
+		{
+			name:         "Success - Successfully created StackScript",
+			machineScope: &scope.MachineScope{},
+			want:         56345,
+			expects: func(mockClient *mock.MockLinodeMachineClient) {
+				mockClient.EXPECT().ListStackscripts(gomock.Any(), gomock.Any()).Return(nil, nil)
+				mockClient.EXPECT().CreateStackscript(gomock.Any(), linodego.StackscriptCreateOptions{
+					Label:       "CAPL-dev",
+					Description: "Stackscript for creating CAPL clusters with CAPL controller version dev",
+					Script: `#!/bin/sh
+# <UDF name="instancedata" label="instance-data contents(base64 encoded" />
+# <UDF name="userdata" label="user-data file contents (base64 encoded)" />
+
+cat > /etc/cloud/cloud.cfg.d/100_none.cfg <<EOF
+datasource_list: [ "None"]
+datasource:
+  None:
+    metadata:
+      id: $LINODE_ID
+$(echo "${INSTANCEDATA}" | base64 -d | sed "s/^/      /")
+    userdata_raw: |
+$(echo "${USERDATA}" | base64 -d | sed "s/^/      /")
+
+EOF
+
+cloud-init clean
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg init --local
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg init
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg modules --mode=config
+cloud-init -f /etc/cloud/cloud.cfg.d/100_none.cfg modules --mode=final
+`,
+					Images: []string{"any/all"},
+				}).Return(&linodego.Stackscript{
+					Label: "CAPI Test 1",
+					ID:    56345,
+				}, nil)
+			},
+		},
+		{
+			name:         "Error - failed create StackScript",
+			machineScope: &scope.MachineScope{},
+			expects: func(mockClient *mock.MockLinodeMachineClient) {
+				mockClient.EXPECT().ListStackscripts(gomock.Any(), gomock.Any()).Return(nil, nil)
+				mockClient.EXPECT().CreateStackscript(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("failed to create StackScript"))
+			},
+			expectedError: fmt.Errorf("failed to create StackScript"),
+		},
+	}
+	for _, tt := range tests {
+		testcase := tt
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock.NewMockLinodeMachineClient(ctrl)
+
+			testcase.machineScope.LinodeClient = mockClient
+
+			testcase.expects(mockClient)
+
+			got, err := EnsureStackscript(context.Background(), testcase.machineScope)
+			if testcase.expectedError != nil {
+				assert.ErrorContains(t, err, testcase.expectedError.Error())
+			} else {
+				assert.Equal(t, testcase.want, got)
+			}
+		})
+	}
+}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
@@ -192,12 +192,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-              useStackScriptBootstrap:
-                description: |-
-                  UseStackScriptBootstrap will specify to use a StackScript shim for running cloud init
-                  instead of relying on the Akamai datasource if the Image/DC does not support it.
-                  in DCs that do not support metadata this defaults to true, otherwise it defaults to false
-                type: boolean
             required:
             - region
             - type

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
@@ -161,16 +161,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-              metadata:
-                description: InstanceMetadataOptions defines metadata of instance
-                properties:
-                  userData:
-                    description: UserData expects a Base64-encoded string
-                    type: string
-                type: object
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               privateIp:
                 type: boolean
                 x-kubernetes-validations:
@@ -190,18 +180,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
-              stackscriptData:
-                additionalProperties:
-                  type: string
-                type: object
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-              stackscriptId:
-                type: integer
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
               tags:
                 items:
                   type: string
@@ -214,6 +192,12 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
+              useStackScriptBootstrap:
+                description: |-
+                  UseStackScriptBootstrap will specify to use a StackScript shim for running cloud init
+                  instead of relying on the Akamai datasource if the Image/DC does not support it.
+                  in DCs that do not support metadata this defaults to true, otherwise it defaults to false
+                type: boolean
             required:
             - region
             - type

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
@@ -181,12 +181,6 @@ spec:
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
-                      useStackScriptBootstrap:
-                        description: |-
-                          UseStackScriptBootstrap will specify to use a StackScript shim for running cloud init
-                          instead of relying on the Akamai datasource if the Image/DC does not support it.
-                          in DCs that do not support metadata this defaults to true, otherwise it defaults to false
-                        type: boolean
                     required:
                     - region
                     - type

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
@@ -150,16 +150,6 @@ spec:
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
-                      metadata:
-                        description: InstanceMetadataOptions defines metadata of instance
-                        properties:
-                          userData:
-                            description: UserData expects a Base64-encoded string
-                            type: string
-                        type: object
-                        x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
                       privateIp:
                         type: boolean
                         x-kubernetes-validations:
@@ -179,18 +169,6 @@ spec:
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
-                      stackscriptData:
-                        additionalProperties:
-                          type: string
-                        type: object
-                        x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
-                      stackscriptId:
-                        type: integer
-                        x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
                       tags:
                         items:
                           type: string
@@ -203,6 +181,12 @@ spec:
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
+                      useStackScriptBootstrap:
+                        description: |-
+                          UseStackScriptBootstrap will specify to use a StackScript shim for running cloud init
+                          instead of relying on the Akamai datasource if the Image/DC does not support it.
+                          in DCs that do not support metadata this defaults to true, otherwise it defaults to false
+                        type: boolean
                     required:
                     - region
                     - type

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -85,10 +85,10 @@ func (r *LinodeMachineReconciler) newCreateConfig(ctx context.Context, machineSc
 	if err != nil {
 		return nil, err
 	}
-
-	if machineScope.LinodeMachine.Spec.UseStackScriptBootstrap || !slices.Contains(region.Capabilities, "Metadata") {
-		logger.Info("metadata is not enabled in this region or 'useStackScriptBootstrap' is set to true, " +
-			"using StackScripts for bootstrapping")
+	regionMetadataSupport := slices.Contains(region.Capabilities, "Metadata")
+	if machineScope.LinodeMachine.Spec.UseStackScriptBootstrap || !regionMetadataSupport {
+		logger.Info(fmt.Sprintf("using StackScripts for bootstrapping. useStackScriptBootstrap: %b, regionMetadataSupport: %b",
+			&machineScope.LinodeMachine.Spec.UseStackScriptBootstrap, &regionMetadataSupport))
 		createConfig.StackScriptID = capiStackScriptID
 		createConfig.StackScriptData = map[string]string{
 			"label":    machineScope.LinodeMachine.Name,

--- a/controller/linodemachine_controller_helpers_test.go
+++ b/controller/linodemachine_controller_helpers_test.go
@@ -24,8 +24,6 @@ func TestLinodeMachineSpecToCreateInstanceConfig(t *testing.T) {
 		RootPass:        "rootPass",
 		AuthorizedKeys:  []string{"key"},
 		AuthorizedUsers: []string{"user"},
-		StackScriptID:   1,
-		StackScriptData: map[string]string{"script": "data"},
 		BackupID:        1,
 		Image:           "image",
 		Interfaces: []infrav1alpha1.InstanceConfigInterfaceCreateOptions{
@@ -45,10 +43,7 @@ func TestLinodeMachineSpecToCreateInstanceConfig(t *testing.T) {
 		BackupsEnabled: true,
 		PrivateIP:      true,
 		Tags:           []string{"tag"},
-		Metadata: &infrav1alpha1.InstanceMetadataOptions{
-			UserData: "userdata",
-		},
-		FirewallID: 1,
+		FirewallID:     1,
 	}
 
 	createConfig := linodeMachineSpecToInstanceCreateConfig(machineSpec)

--- a/devbox.lock
+++ b/devbox.lock
@@ -102,22 +102,50 @@
       }
     },
     "golangci-lint@latest": {
-      "last_modified": "2024-02-24T23:06:34Z",
-      "resolved": "github:NixOS/nixpkgs/9a9dae8f6319600fa9aebde37f340975cab4b8c0#golangci-lint",
+      "last_modified": "2024-03-22T11:26:23Z",
+      "resolved": "github:NixOS/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351#golangci-lint",
       "source": "devbox-search",
-      "version": "1.56.2",
+      "version": "1.57.1",
       "systems": {
         "aarch64-darwin": {
-          "store_path": "/nix/store/fs44z0nysjiwl2sj2m9x70dbrx2lbyhh-golangci-lint-1.56.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rbkz66qnxvnla1rms6bd6zky1bi62jwc-golangci-lint-1.57.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rbkz66qnxvnla1rms6bd6zky1bi62jwc-golangci-lint-1.57.1"
         },
         "aarch64-linux": {
-          "store_path": "/nix/store/bs18c2bx56b6xnpf49wb5kzi3vynbqmx-golangci-lint-1.56.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/r5xyf90x7c91j3r34sg6k9wbf4dm1v4q-golangci-lint-1.57.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/r5xyf90x7c91j3r34sg6k9wbf4dm1v4q-golangci-lint-1.57.1"
         },
         "x86_64-darwin": {
-          "store_path": "/nix/store/1xhl4b3nk3npq70d651vg4bamfg8xyga-golangci-lint-1.56.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8yd7j7jcg0sihbrbxnz7drqd6lwlcz6r-golangci-lint-1.57.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/8yd7j7jcg0sihbrbxnz7drqd6lwlcz6r-golangci-lint-1.57.1"
         },
         "x86_64-linux": {
-          "store_path": "/nix/store/kc58bqdmjdc6mfilih5pywprs7r7lxrw-golangci-lint-1.56.2"
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7vvwm8q3zx6xiln6rmdh21mqjccbrd9x-golangci-lint-1.57.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7vvwm8q3zx6xiln6rmdh21mqjccbrd9x-golangci-lint-1.57.1"
         }
       }
     },

--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -32,6 +32,19 @@ export LINODE_TOKEN=<your linode PAT>
 export LINODE_CONTROL_PLANE_MACHINE_TYPE=g6-standard-2
 export LINODE_MACHINE_TYPE=g6-standard-2
 ```
+## Specifying the region and image
+
+### Image
+The default image is linode/ubuntu22.04 if nothing is specified. This can be overridden, but currently only ubuntu is 
+supported for our kubeadm based templates, any k3s/rke2 based chart should work with other images. If the 
+image does not support the Akamai datasource for cloud init (see supported images via the [Linode api](https://www.linode.com/docs/api/images/))
+you will have to set the `USE_STACKSCRIPT_BOOTSTRAP=true` environment variable before generating your cluster or set the
+`useStackScriptBootstrap: true` field on your machine resources
+
+### Region
+Region is a required field. If you deploy to a region without the metadata service available
+CAPL will automatically set `useStackScriptBootstrap: true` and cluster provisioning should still work. To look up a 
+list of regions and what capabilities they have, use the regions endpoint of the [Linode api](https://www.linode.com/docs/api/regions/).
 
 ## Register linode locally as an infrastructure provider
 1. Generate local release files 
@@ -48,4 +61,4 @@ export LINODE_MACHINE_TYPE=g6-standard-2
 
 ## Deploying your first cluster
 
-Please refer to the [default flavor](../flavors/default.md) section for creating your first Kubernetes cluster on Linode using Cluster API. 
+Please refer to the [default flavor](./flavors/default.md) section for creating your first Kubernetes cluster on Linode using Cluster API. 

--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -32,19 +32,10 @@ export LINODE_TOKEN=<your linode PAT>
 export LINODE_CONTROL_PLANE_MACHINE_TYPE=g6-standard-2
 export LINODE_MACHINE_TYPE=g6-standard-2
 ```
-## Specifying the region and image
-
-### Image
-The default image is linode/ubuntu22.04 if nothing is specified. This can be overridden, but currently only ubuntu is 
-supported for our kubeadm based templates, any k3s/rke2 based chart should work with other images. If the 
-image does not support the Akamai datasource for cloud init (see supported images via the [Linode api](https://www.linode.com/docs/api/images/))
-you will have to set the `USE_STACKSCRIPT_BOOTSTRAP=true` environment variable before generating your cluster or set the
-`useStackScriptBootstrap: true` field on your machine resources
-
-### Region
-Region is a required field. If you deploy to a region without the metadata service available
-CAPL will automatically set `useStackScriptBootstrap: true` and cluster provisioning should still work. To look up a 
-list of regions and what capabilities they have, use the regions endpoint of the [Linode api](https://www.linode.com/docs/api/regions/).
+```admonish warning
+For Regions and Images that do not yet support Akamai's cloud-init datasource CAPL will automatically use a stackscript shim
+to provision the node. If you are using a custom image ensure the [cloud_init](https://www.linode.com/docs/api/images/#image-create) flag is set correctly on it
+```
 
 ## Register linode locally as an infrastructure provider
 1. Generate local release files 

--- a/mock/client.go
+++ b/mock/client.go
@@ -175,6 +175,21 @@ func (mr *MockLinodeMachineClientMockRecorder) DeleteNodeBalancerNode(ctx, nodeb
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeBalancerNode", reflect.TypeOf((*MockLinodeMachineClient)(nil).DeleteNodeBalancerNode), ctx, nodebalancerID, configID, nodeID)
 }
 
+// GetImage mocks base method.
+func (m *MockLinodeMachineClient) GetImage(ctx context.Context, imageID string) (*linodego.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImage", ctx, imageID)
+	ret0, _ := ret[0].(*linodego.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImage indicates an expected call of GetImage.
+func (mr *MockLinodeMachineClientMockRecorder) GetImage(ctx, imageID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockLinodeMachineClient)(nil).GetImage), ctx, imageID)
+}
+
 // GetInstance mocks base method.
 func (m *MockLinodeMachineClient) GetInstance(ctx context.Context, linodeID int) (*linodego.Instance, error) {
 	m.ctrl.T.Helper()
@@ -403,6 +418,21 @@ func (m *MockLinodeInstanceClient) DeleteInstance(ctx context.Context, linodeID 
 func (mr *MockLinodeInstanceClientMockRecorder) DeleteInstance(ctx, linodeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstance", reflect.TypeOf((*MockLinodeInstanceClient)(nil).DeleteInstance), ctx, linodeID)
+}
+
+// GetImage mocks base method.
+func (m *MockLinodeInstanceClient) GetImage(ctx context.Context, imageID string) (*linodego.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImage", ctx, imageID)
+	ret0, _ := ret[0].(*linodego.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImage indicates an expected call of GetImage.
+func (mr *MockLinodeInstanceClientMockRecorder) GetImage(ctx, imageID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImage", reflect.TypeOf((*MockLinodeInstanceClient)(nil).GetImage), ctx, imageID)
 }
 
 // GetInstance mocks base method.

--- a/mock/client.go
+++ b/mock/client.go
@@ -220,6 +220,21 @@ func (mr *MockLinodeMachineClientMockRecorder) GetInstanceIPAddresses(ctx, linod
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceIPAddresses", reflect.TypeOf((*MockLinodeMachineClient)(nil).GetInstanceIPAddresses), ctx, linodeID)
 }
 
+// GetRegion mocks base method.
+func (m *MockLinodeMachineClient) GetRegion(ctx context.Context, regionID string) (*linodego.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, regionID)
+	ret0, _ := ret[0].(*linodego.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion.
+func (mr *MockLinodeMachineClientMockRecorder) GetRegion(ctx, regionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockLinodeMachineClient)(nil).GetRegion), ctx, regionID)
+}
+
 // GetVPC mocks base method.
 func (m *MockLinodeMachineClient) GetVPC(ctx context.Context, vpcID int) (*linodego.VPC, error) {
 	m.ctrl.T.Helper()
@@ -433,6 +448,21 @@ func (m *MockLinodeInstanceClient) GetInstanceIPAddresses(ctx context.Context, l
 func (mr *MockLinodeInstanceClientMockRecorder) GetInstanceIPAddresses(ctx, linodeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceIPAddresses", reflect.TypeOf((*MockLinodeInstanceClient)(nil).GetInstanceIPAddresses), ctx, linodeID)
+}
+
+// GetRegion mocks base method.
+func (m *MockLinodeInstanceClient) GetRegion(ctx context.Context, regionID string) (*linodego.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, regionID)
+	ret0, _ := ret[0].(*linodego.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion.
+func (mr *MockLinodeInstanceClientMockRecorder) GetRegion(ctx, regionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockLinodeInstanceClient)(nil).GetRegion), ctx, regionID)
 }
 
 // ListInstanceConfigs mocks base method.

--- a/mock/client.go
+++ b/mock/client.go
@@ -133,6 +133,21 @@ func (mr *MockLinodeMachineClientMockRecorder) CreateNodeBalancerNode(ctx, nodeb
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodeBalancerNode", reflect.TypeOf((*MockLinodeMachineClient)(nil).CreateNodeBalancerNode), ctx, nodebalancerID, configID, opts)
 }
 
+// CreateStackscript mocks base method.
+func (m *MockLinodeMachineClient) CreateStackscript(ctx context.Context, opts linodego.StackscriptCreateOptions) (*linodego.Stackscript, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateStackscript", ctx, opts)
+	ret0, _ := ret[0].(*linodego.Stackscript)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateStackscript indicates an expected call of CreateStackscript.
+func (mr *MockLinodeMachineClientMockRecorder) CreateStackscript(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackscript", reflect.TypeOf((*MockLinodeMachineClient)(nil).CreateStackscript), ctx, opts)
+}
+
 // DeleteInstance mocks base method.
 func (m *MockLinodeMachineClient) DeleteInstance(ctx context.Context, linodeID int) error {
 	m.ctrl.T.Helper()
@@ -310,6 +325,21 @@ func (mr *MockLinodeMachineClientMockRecorder) ListNodeBalancers(ctx, opts any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeBalancers", reflect.TypeOf((*MockLinodeMachineClient)(nil).ListNodeBalancers), ctx, opts)
 }
 
+// ListStackscripts mocks base method.
+func (m *MockLinodeMachineClient) ListStackscripts(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Stackscript, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListStackscripts", ctx, opts)
+	ret0, _ := ret[0].([]linodego.Stackscript)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListStackscripts indicates an expected call of ListStackscripts.
+func (mr *MockLinodeMachineClientMockRecorder) ListStackscripts(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackscripts", reflect.TypeOf((*MockLinodeMachineClient)(nil).ListStackscripts), ctx, opts)
+}
+
 // ResizeInstanceDisk mocks base method.
 func (m *MockLinodeMachineClient) ResizeInstanceDisk(ctx context.Context, linodeID, diskID, size int) error {
 	m.ctrl.T.Helper()
@@ -404,6 +434,21 @@ func (m *MockLinodeInstanceClient) CreateInstanceDisk(ctx context.Context, linod
 func (mr *MockLinodeInstanceClientMockRecorder) CreateInstanceDisk(ctx, linodeID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceDisk", reflect.TypeOf((*MockLinodeInstanceClient)(nil).CreateInstanceDisk), ctx, linodeID, opts)
+}
+
+// CreateStackscript mocks base method.
+func (m *MockLinodeInstanceClient) CreateStackscript(ctx context.Context, opts linodego.StackscriptCreateOptions) (*linodego.Stackscript, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateStackscript", ctx, opts)
+	ret0, _ := ret[0].(*linodego.Stackscript)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateStackscript indicates an expected call of CreateStackscript.
+func (mr *MockLinodeInstanceClientMockRecorder) CreateStackscript(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackscript", reflect.TypeOf((*MockLinodeInstanceClient)(nil).CreateStackscript), ctx, opts)
 }
 
 // DeleteInstance mocks base method.
@@ -523,6 +568,21 @@ func (m *MockLinodeInstanceClient) ListInstances(ctx context.Context, opts *lino
 func (mr *MockLinodeInstanceClientMockRecorder) ListInstances(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstances", reflect.TypeOf((*MockLinodeInstanceClient)(nil).ListInstances), ctx, opts)
+}
+
+// ListStackscripts mocks base method.
+func (m *MockLinodeInstanceClient) ListStackscripts(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Stackscript, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListStackscripts", ctx, opts)
+	ret0, _ := ret[0].([]linodego.Stackscript)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListStackscripts indicates an expected call of ListStackscripts.
+func (mr *MockLinodeInstanceClientMockRecorder) ListStackscripts(ctx, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackscripts", reflect.TypeOf((*MockLinodeInstanceClient)(nil).ListStackscripts), ctx, opts)
 }
 
 // ResizeInstanceDisk mocks base method.

--- a/templates/flavors/base/linodeMachineTemplate.yaml
+++ b/templates/flavors/base/linodeMachineTemplate.yaml
@@ -9,7 +9,6 @@ spec:
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_CONTROL_PLANE_MACHINE_TYPE}
       region: ${LINODE_REGION}
-      useStackScriptBootstrap: ${USE_STACKSCRIPT_BOOTSTRAP:=false}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
       # - ${LINODE_SSH_PUBKEY:=""}
@@ -24,7 +23,6 @@ spec:
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_MACHINE_TYPE}
       region: ${LINODE_REGION}
-      useStackScriptBootstrap: ${USE_STACKSCRIPT_BOOTSTRAP:=false}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
       # - ${LINODE_SSH_PUBKEY:=""}

--- a/templates/flavors/base/linodeMachineTemplate.yaml
+++ b/templates/flavors/base/linodeMachineTemplate.yaml
@@ -9,6 +9,7 @@ spec:
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_CONTROL_PLANE_MACHINE_TYPE}
       region: ${LINODE_REGION}
+      useStackScriptBootstrap: ${USE_STACKSCRIPT_BOOTSTRAP:=false}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
       # - ${LINODE_SSH_PUBKEY:=""}
@@ -23,6 +24,7 @@ spec:
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_MACHINE_TYPE}
       region: ${LINODE_REGION}
+      useStackScriptBootstrap: ${USE_STACKSCRIPT_BOOTSTRAP:=false}
       authorizedKeys:
       # uncomment to include your ssh key in linode provisioning
       # - ${LINODE_SSH_PUBKEY:=""}

--- a/util/filter.go
+++ b/util/filter.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"maps"
 	"strconv"
 	"strings"
 )
@@ -11,16 +12,17 @@ import (
 // The fields within Filter are prioritized so that only the most-specific
 // field is present when Filter is marshaled to JSON.
 type Filter struct {
-	ID    *int     // Filter on the resource's ID (most specific).
-	Label string   // Filter on the resource's label.
-	Tags  []string // Filter resources by their tags (least specific).
+	ID                *int              // Filter on the resource's ID (most specific).
+	Label             string            // Filter on the resource's label.
+	Tags              []string          // Filter resources by their tags (least specific).
+	AdditionalFilters map[string]string // Filter resources by additional parameters
 }
 
 // MarshalJSON returns a JSON-encoded representation of a [Filter].
 // The resulting encoded value will have exactly 1 (one) field present.
 // See [Filter] for details on the value precedence.
 func (f Filter) MarshalJSON() ([]byte, error) {
-	filter := make(map[string]string, 1)
+	filter := make(map[string]string, len(f.AdditionalFilters)+1)
 	switch {
 	case f.ID != nil:
 		filter["id"] = strconv.Itoa(*f.ID)
@@ -30,6 +32,7 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 		filter["tags"] = strings.Join(f.Tags, ",")
 	}
 
+	maps.Copy(filter, f.AdditionalFilters)
 	return json.Marshal(filter)
 }
 

--- a/util/filter_test.go
+++ b/util/filter_test.go
@@ -33,6 +33,15 @@ func TestString(t *testing.T) {
 		},
 		expectErr: false,
 	}, {
+		name: "success additional info",
+		filter: Filter{
+			ID:                nil,
+			Label:             "",
+			Tags:              []string{"testtag"},
+			AdditionalFilters: map[string]string{"mine": "true"},
+		},
+		expectErr: false,
+	}, {
 		name: "failure unmarshal",
 		filter: Filter{
 			ID:    nil,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
This PR introduced the option to use a stackscript instead of cloud-init to bootstrap a cluster. cloud-init support is currently only rolled out to a few datacenters and the Akamai datasource has only been added/backported to a few official Linode OSes. Datacenter capabilities are fairly static so from a deployed DC we can infer whether or not you need stackscript based bootstrapping. For OSes, it is harder to confidently infer this information so a flag `useStackScriptBootstrap` is introduced with the corresponding template variable `USE_STACKSCRIPT_BOOTSTRAP` to enable this functionality if your OS/DC needs it and it is not enabled automatically. Stackscript [1319647](https://cloud.linode.com/stackscripts/1319647) has been introduced specifically for bridging user-data, stackscripts and cloud-init.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


