### PR TITLE
use the cluster-api operator for tilt installs instead of clusterctl

### DIFF
--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -147,6 +147,8 @@ jobs:
           *.quay.io:443
           api.snapcraft.io:443
           cloud.tilt.dev:443
+          kubernetes-sigs.github.io:443
+          charts.jetstack.io:443
 
     - uses: actions/checkout@v4
 
@@ -191,6 +193,8 @@ jobs:
           github.com:443
           proxy.golang.org:443
           sum.golang.org:443
+          go.dev:443
+          golang.org:443
           objects.githubusercontent.com:443
           registry-1.docker.io:443
           auth.docker.io:443

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,55 +1,133 @@
 load("ext://k8s_attach", "k8s_attach")
+load("ext://helm_resource", "helm_resource", "helm_repo")
+load("ext://namespace", "namespace_create")
+update_settings(k8s_upsert_timeout_secs=60)
 
-docker_build(
-    "docker.io/linode/cluster-api-provider-linode",
-    context = ".",
-    only=("Dockerfile", "Makefile", "vendor","go.mod", "go.sum", "./api", "./cloud","./cmd", "./controller", "./util", "./version"),
-    build_args={'VERSION': os.getenv("VERSION","")},
+helm_repo("capi-operator-repo", "https://kubernetes-sigs.github.io/cluster-api-operator",labels=["helm-repos"])
+helm_repo("jetstack-repo", "https://charts.jetstack.io", labels=["helm-repos"])
+helm_resource(
+    "cert-manager",
+    "jetstack-repo/cert-manager",
+    namespace="cert-manager",
+    resource_deps=["jetstack-repo"],
+    flags=[
+        "--create-namespace",
+        "--set=installCRDs=true",
+        "--set=global.leaderElection.namespace=cert-manager",
+    ],
+    labels=["cert-manager"],
 )
 
-local_resource(
-    'capi-controller-manager',
-    cmd='EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true clusterctl init --addon helm',
+helm_resource(
+    "capi-operator",
+    "capi-operator-repo/cluster-api-operator",
+    namespace="capi-operator-system",
+    flags=["--create-namespace", "--wait"],
+    resource_deps=["capi-operator-repo", "cert-manager"],
+    labels=["CAPI"],
 )
-
-if os.getenv('INSTALL_K3S_PROVIDER'):
-    local_resource(
-        'capi-k3s-controller-manager',
-        cmd='clusterctl init --bootstrap k3s --control-plane k3s',
+namespace_create("capi-system")
+k8s_yaml("./hack/manifests/core.yaml")
+k8s_resource(
+    new_name="capi-controller-manager",
+    objects=["capi-system:namespace", "cluster-api:coreprovider"],
+    resource_deps=["capi-operator"],
+    labels=["CAPI"],
+)
+if os.getenv("INSTALL_KUBEADM_PROVIDER", "true") == "true":
+    namespace_create("kubeadm-control-plane-system")
+    namespace_create("kubeadm-bootstrap-system")
+    k8s_yaml("./hack/manifests/kubeadm.yaml")
+    k8s_resource(
+        new_name="kubeadm-controller-manager",
+        objects=[
+            "kubeadm-bootstrap-system:namespace",
+            "kubeadm-control-plane-system:namespace",
+            "kubeadm:bootstrapprovider",
+            "kubeadm:controlplaneprovider",
+        ],
+        resource_deps=["capi-controller-manager"],
+        labels=["CAPI"],
     )
 
-if os.getenv('INSTALL_RKE2_PROVIDER'):
-    local_resource(
-        'capi-rke2-controller-manager',
-        cmd='clusterctl init --bootstrap rke2 --control-plane rke2',
+if os.getenv("INSTALL_HELM_PROVIDER", "true") == "true":
+    namespace_create("caaph-system")
+    k8s_yaml("./hack/manifests/helm.yaml")
+    k8s_resource(
+        new_name="helm-controller-manager",
+        objects=["caaph-system:namespace", "helm:addonprovider"],
+        resource_deps=["capi-controller-manager"],
+        labels=["CAPI"],
+    )
+
+if os.getenv("INSTALL_K3S_PROVIDER", "false") == "true":
+    namespace_create("capi-k3s-control-plane-system")
+    namespace_create("capi-k3s-bootstrap-system")
+    k8s_yaml("./hack/manifests/k3s.yaml")
+    k8s_resource(
+        new_name="k3s-controller-manager",
+        objects=[
+            "capi-k3s-bootstrap-system:namespace",
+            "capi-k3s-control-plane-system:namespace",
+            "k3s:bootstrapprovider",
+            "k3s:controlplaneprovider",
+        ],
+        resource_deps=["capi-controller-manager"],
+        labels=["CAPI"],
+    )
+
+if os.getenv("INSTALL_RKE2_PROVIDER", "false") == "true":
+    namespace_create("rke2-control-plane-system")
+    namespace_create("rke2-bootstrap-system")
+    k8s_yaml("./hack/manifests/rke2.yaml")
+    k8s_resource(
+        new_name="capi-rke2-controller-manager",
+        objects=[
+            "rke2-bootstrap-system:namespace",
+            "rke2-control-plane-system:namespace",
+            "rke2:bootstrapprovider",
+            "rke2:controlplaneprovider",
+        ],
+        resource_deps=["capi-controller-manager"],
+        labels=["CAPI"],
     )
 
 manager_yaml = decode_yaml_stream(kustomize("config/default"))
 for resource in manager_yaml:
     if resource["metadata"]["name"] == "capl-manager-credentials":
-        resource["stringData"]["apiToken"] = os.getenv('LINODE_TOKEN')
-    if resource["kind"] == "CustomResourceDefinition" and resource["spec"]["group"] == "infrastructure.cluster.x-k8s.io":    
+        resource["stringData"]["apiToken"] = os.getenv("LINODE_TOKEN")
+    if resource["kind"] == "CustomResourceDefinition" and resource["spec"]["group"] == "infrastructure.cluster.x-k8s.io":
         resource["metadata"]["labels"]["clusterctl.cluster.x-k8s.io"] = ""
 k8s_yaml(encode_yaml_stream(manager_yaml))
+
+docker_build(
+    "docker.io/linode/cluster-api-provider-linode",
+    context=".",
+    only=("Dockerfile", "Makefile", "vendor", "go.mod", "go.sum",
+    "./api", "./cloud", "./cmd", "./controller", "./util", "./version",),
+    build_args={"VERSION": os.getenv("VERSION", "")},
+)
 
 k8s_resource(
     workload="capl-controller-manager",
     objects=[
-       "capl-system:namespace",
-       "linodeclusters.infrastructure.cluster.x-k8s.io:customresourcedefinition",
-       "linodemachines.infrastructure.cluster.x-k8s.io:customresourcedefinition",
-       "linodeclustertemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
-       "linodemachinetemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
-       "linodevpcs.infrastructure.cluster.x-k8s.io:customresourcedefinition",
-       "linodeobjectstoragebuckets.infrastructure.cluster.x-k8s.io:customresourcedefinition",
-       "capl-controller-manager:serviceaccount",
-       "capl-leader-election-role:role",
-       "capl-manager-role:clusterrole",
-       "capl-metrics-reader:clusterrole",
-       "capl-proxy-role:clusterrole",
-       "capl-leader-election-rolebinding:rolebinding",
-       "capl-manager-rolebinding:clusterrolebinding",
-       "capl-proxy-rolebinding:clusterrolebinding",
-       "capl-manager-credentials:secret",
-   ]
+        "capl-system:namespace",
+        "linodeclusters.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+        "linodemachines.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+        "linodeclustertemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+        "linodemachinetemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+        "linodevpcs.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+        "linodeobjectstoragebuckets.infrastructure.cluster.x-k8s.io:customresourcedefinition",
+        "capl-controller-manager:serviceaccount",
+        "capl-leader-election-role:role",
+        "capl-manager-role:clusterrole",
+        "capl-metrics-reader:clusterrole",
+        "capl-proxy-role:clusterrole",
+        "capl-leader-election-rolebinding:rolebinding",
+        "capl-manager-rolebinding:clusterrolebinding",
+        "capl-proxy-rolebinding:clusterrolebinding",
+        "capl-manager-credentials:secret",
+    ],
+    resource_deps=["capi-controller-manager"],
+    labels=["CAPL"],
 )

--- a/hack/manifests/core.yaml
+++ b/hack/manifests/core.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: CoreProvider
+metadata:
+  name: cluster-api
+  namespace: capi-system
+spec:
+  manager:
+    featureGates:
+      ClusterResourceSet: true
+      ClusterTopology: true

--- a/hack/manifests/helm.yaml
+++ b/hack/manifests/helm.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: AddonProvider
+metadata:
+  name: helm
+  namespace: caaph-system

--- a/hack/manifests/k3s.yaml
+++ b/hack/manifests/k3s.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: k3s
+  namespace: capi-k3s-bootstrap-system
+spec:
+  fetchConfig:
+    url: https://github.com/k3s-io/cluster-api-k3s/releases/latest/bootstrap-components.yaml
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: k3s
+  namespace: capi-k3s-control-plane-system
+spec:
+  fetchConfig:
+    url: https://github.com/k3s-io/cluster-api-k3s/releases/latest/control-plane-components.yaml

--- a/hack/manifests/kubeadm.yaml
+++ b/hack/manifests/kubeadm.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: kubeadm
+  namespace: kubeadm-bootstrap-system
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: kubeadm
+  namespace: kubeadm-control-plane-system

--- a/hack/manifests/rke2.yaml
+++ b/hack/manifests/rke2.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: BootstrapProvider
+metadata:
+  name: rke2
+  namespace: rke2-bootstrap-system
+---
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: ControlPlaneProvider
+metadata:
+  name: rke2
+  namespace: rke2-control-plane-system


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
This PR replaces `clusterctl init ...` local_commands in tilt with usage of the cluster-api operator and installs of the resources directly. The main benefit of doing it this way is we can easily stream container logs and see the health of the various parts of the CAPL installation. this otherwise should be a no-op for other workflows
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


