### PR TITLE
fix: add additional name validation for custom resources

### DIFF
--- a/cloud/services/loadbalancers.go
+++ b/cloud/services/loadbalancers.go
@@ -23,7 +23,7 @@ const (
 func CreateNodeBalancer(ctx context.Context, clusterScope *scope.ClusterScope, logger logr.Logger) (*linodego.NodeBalancer, error) {
 	var linodeNB *linodego.NodeBalancer
 
-	NBLabel := fmt.Sprintf("%s-api-server", clusterScope.LinodeCluster.Name)
+	NBLabel := clusterScope.LinodeCluster.Name
 	clusterUID := string(clusterScope.LinodeCluster.UID)
 	tags := []string{string(clusterScope.LinodeCluster.UID)}
 	listFilter := util.Filter{
@@ -53,9 +53,9 @@ func CreateNodeBalancer(ctx context.Context, clusterScope *scope.ClusterScope, l
 		return &linodeNBs[0], nil
 	}
 
-	logger.Info(fmt.Sprintf("Creating NodeBalancer %s-api-server", clusterScope.LinodeCluster.Name))
+	logger.Info(fmt.Sprintf("Creating NodeBalancer %s", clusterScope.LinodeCluster.Name))
 	createConfig := linodego.NodeBalancerCreateOptions{
-		Label:  util.Pointer(fmt.Sprintf("%s-api-server", clusterScope.LinodeCluster.Name)),
+		Label:  util.Pointer(clusterScope.LinodeCluster.Name),
 		Region: clusterScope.LinodeCluster.Spec.Region,
 		Tags:   tags,
 	}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -36,6 +36,27 @@ patches:
 #- path: patches/cainjection_in_linodeobjectstoragebuckets.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# [VALIDATION]
+# patches here are for additional validation for each CRD
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: linodeclusters.infrastructure.cluster.x-k8s.io
+  path: patches/validation_in_linodeclusters.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: linodemachines.infrastructure.cluster.x-k8s.io
+  path: patches/validation_in_linodemachines.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: linodevpcs.infrastructure.cluster.x-k8s.io
+  path: patches/validation_in_linodevpcs.yaml
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -48,8 +48,20 @@ patches:
     group: apiextensions.k8s.io
     version: v1
     kind: CustomResourceDefinition
+    name: linodeclustertemplates.infrastructure.cluster.x-k8s.io
+  path: patches/validation_in_linodeclustertemplates.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
     name: linodemachines.infrastructure.cluster.x-k8s.io
   path: patches/validation_in_linodemachines.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: linodemachinetemplates.infrastructure.cluster.x-k8s.io
+  path: patches/validation_in_linodemachinetemplates.yaml
 - target:
     group: apiextensions.k8s.io
     version: v1

--- a/config/crd/patches/validation_in_linodeclusters.yaml
+++ b/config/crd/patches/validation_in_linodeclusters.yaml
@@ -1,0 +1,11 @@
+# The following patch adds additional constraints after the built-in name validation for the CRD
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      x-kubernetes-validations:
+      - rule: 3 <= size(self) && size(self) <= 32
+        message: >-
+          custom validation:
+          linode nodebalancer: labels must be between 3..32 characters

--- a/config/crd/patches/validation_in_linodeclustertemplates.yaml
+++ b/config/crd/patches/validation_in_linodeclustertemplates.yaml
@@ -1,0 +1,12 @@
+# The following patch adds additional constraints after the built-in name validation for the CRD
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      x-kubernetes-validations:
+      - rule: 3 <= size(self) && size(self) <= 26
+        message: >-
+          custom validation:
+          template: must be between 3..26 characters,
+          linode nodebalancer: labels must be between 3..32 characters

--- a/config/crd/patches/validation_in_linodemachines.yaml
+++ b/config/crd/patches/validation_in_linodemachines.yaml
@@ -1,0 +1,26 @@
+# The following patch adds additional constraints after the built-in name validation for the CRD
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      x-kubernetes-validations:
+      - rule: 3 <= size(self) && size(self) <= 64
+        message: >-
+          custom validation:
+          linode instance: labels must be between 3..64 characters
+      - rule: self.matches('^[[:alnum:]]([-_.[:alnum:]]+[[:alnum:]])*$')
+        message: >-
+          custom validation:
+          linode instance: labels:
+          must begin and end with an alphanumeric character,
+          may only consist of alphanumeric characters, hyphens (-), underscores (_) or periods (.),
+          cannot have two hyphens (--), underscores (__) or periods (..) in a row,
+          regex used for validation is: '^[[:alnum:]]([-_.[:alnum:]]+[[:alnum:]])*$',
+          see: https://www.linode.com/docs/api/linode-instances/#linode-create
+      # TODO: Consider combining this into the regex above to minimize time complexity
+      # See: https://github.com/google/cel-spec/blob/master/doc/langdef.md#time-complexity
+      - rule: "!(self.contains('--') || self.contains('__') || self.contains('..'))"
+        message: >-
+          custom validation:
+          linode instance: labels cannot have two hyphens (--), underscores (__) or periods (..) in a row

--- a/config/crd/patches/validation_in_linodemachinetemplates.yaml
+++ b/config/crd/patches/validation_in_linodemachinetemplates.yaml
@@ -1,0 +1,27 @@
+# The following patch adds additional constraints after the built-in name validation for the CRD
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      x-kubernetes-validations:
+      - rule: 3 <= size(self) && size(self) <= 58
+        message: >-
+          custom validation:
+          template: must be between 3..58 characters,
+          linode instance: labels must be between 3..64 characters
+      - rule: self.matches('^[[:alnum:]]([-_.[:alnum:]]+[[:alnum:]])*$')
+        message: >-
+          custom validation:
+          linode instance: labels:
+          must begin and end with an alphanumeric character,
+          may only consist of alphanumeric characters, hyphens (-), underscores (_) or periods (.),
+          cannot have two hyphens (--), underscores (__) or periods (..) in a row,
+          regex used for validation is: '^[[:alnum:]]([-_.[:alnum:]]+[[:alnum:]])*$',
+          see: https://www.linode.com/docs/api/linode-instances/#linode-create
+      # TODO: Consider combining this into the regex above to minimize time complexity
+      # See: https://github.com/google/cel-spec/blob/master/doc/langdef.md#time-complexity
+      - rule: "!(self.contains('--') || self.contains('__') || self.contains('..'))"
+        message: >-
+          custom validation:
+          linode instance: labels cannot have two hyphens (--), underscores (__) or periods (..) in a row

--- a/config/crd/patches/validation_in_linodevpcs.yaml
+++ b/config/crd/patches/validation_in_linodevpcs.yaml
@@ -1,0 +1,25 @@
+# The following patch adds additional constraints after the built-in name validation for the CRD
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      x-kubernetes-validations:
+      - rule: 1 <= size(self) && size(self) <= 64
+        message: >-
+          custom validation:
+          linode vpc: labels must be between 1..64 characters
+      - rule: self.matches('^[-[:alnum:]]*$')
+        message: >-
+          custom validation:
+          linode vpc: labels:
+          can only contain ASCII letters, numbers, and hyphens (-),
+          cannot have two consecutive hyphens (--),
+          regex used for validation is: '^[-[:alnum:]]*$',
+          see: https://www.linode.com/docs/api/vpcs/#vpc-create
+      # TODO: Consider combining this into the regex above to minimize time complexity
+      # See: https://github.com/google/cel-spec/blob/master/doc/langdef.md#time-complexity
+      - rule: "!self.contains('--')"
+        message: >-
+          custom validation:
+          linode vpc: labels cannot have two consecutive hyphens (--)

--- a/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
+++ b/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
@@ -10,9 +10,8 @@ spec:
   - name: run
     value: (join('-', ['e2e', 'min-cluster', env('GIT_REF')]))
   - name: cluster
-    # Format the cluster name into a valid Linode label
-    # TODO: This is over-truncated to account for the Linode NodeBalancer label
-    value: (trim((truncate(($run), `21`)), '-'))
+    # Format the cluster name
+    value: (trim((truncate(($run), `32`)), '-'))
   - name: nodebalancer
     value: ($cluster)
   template: true

--- a/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
+++ b/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
     # TODO: This is over-truncated to account for the Linode NodeBalancer label
     value: (trim((truncate(($run), `21`)), '-'))
   - name: nodebalancer
-    value: (join('-', [($cluster), 'api-server']))
+    value: ($cluster)
   template: true
   steps:
   - name: step-00

--- a/e2e/linodemachine-controller/minimal-linodemachine/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/minimal-linodemachine/chainsaw-test.yaml
@@ -10,9 +10,8 @@ spec:
   - name: run
     value: (join('-', ['e2e', 'min-lm', env('GIT_REF')]))
   - name: cluster
-    # Format the cluster name into a valid Linode label
-    # TODO: This is over-truncated to account for the Linode NodeBalancer label
-    value: (trim((truncate(($run), `21`)), '-'))
+    # Format the cluster name
+    value: (trim((truncate(($run), `32`)), '-'))
   template: true
   steps:
   - name: step-00

--- a/e2e/linodemachine-controller/vpc-integration/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/vpc-integration/chainsaw-test.yaml
@@ -10,9 +10,8 @@ spec:
   - name: run
     value: (join('-', ['e2e', 'lm-vpc', env('GIT_REF')]))
   - name: cluster
-    # Format the cluster name into a valid Linode label
-    # TODO: This is over-truncated to account for the Linode NodeBalancer label
-    value: (trim((truncate(($run), `21`)), '-'))
+    # Format the cluster name
+    value: (trim((truncate(($run), `32`)), '-'))
   - name: vpc
     # Format the VPC name into a valid Kubernetes object name
     value: (trim((truncate(($run), `63`)), '-'))


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
This propagates the label constraints of Linode resources to their associated CAPL CustomResourceDefinitions via the Kubernetes Validation Rules feature. When a custom resource is created, the Kubernetes object name is validated against the label constraints of its backing Linode resources. This allows CAPL-managed resources to maintain a human-readable naming scheme between its Kubernetes representation and the backing Linode resource implementations.

See:
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
- https://github.com/kubernetes/kubernetes/issues/74620

**Testing**
1. Create `Linode*` resources with invalid names:
```sh
## LinodeCluster
$ export NAME="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" && kubectl apply -f - <<EOF
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: LinodeCluster
metadata:
  name: ${NAME}
spec:
  region: us-sea
EOF

The LinodeCluster "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" is invalid: metadata.name: Invalid value: "string": custom validation: linode nodebalancer: labels must be between 3..32 characters

## LinodeMachine
$ export NAME="bad--name" && kubectl apply -f - <<EOF
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: LinodeMachine
metadata:
    name: ${NAME}
spec:
    region: us-sea
    type: g5-nanode-1
EOF
The LinodeMachine "bad--name" is invalid: metadata.name: Invalid value: "string": custom validation: linode instance: labels cannot have two hyphens (--), underscores (__) or periods (..) in a row

## LinodeVPC
export NAME="bad.name"
kubectl apply -f - <<EOF
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: LinodeVPC
metadata:
  name: ${NAME}
spec:
  region: us-sea
EOF
The LinodeVPC "bad.name" is invalid: metadata.name: Invalid value: "string": custom validation: linode vpc: labels: can only contain ASCII letters, numbers, and hyphens (-), cannot have two consecutive hyphens (--), regex used for validation is: '^[-[:alnum:]]*$', see: https://www.linode.com/docs/api/vpcs/#vpc-create
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Linode resources have constraints on the format of their labels, e.g.:
- https://www.linode.com/docs/api/nodebalancers/#nodebalancer-create
- https://www.linode.com/docs/api/linode-instances/#linode-create
- https://www.linode.com/docs/api/vpcs/#vpc-create

**UIDs vs. Names**
Prior to #143, CAPL was using the Kubernetes resource UID as a generalized [injection(?)](https://en.wikipedia.org/wiki/Injective_function) between the "space" of valid Kubernetes resource names ([RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)) to the "space" of valid Linode labels across various resource types. This provided three important properties:
1. Uniqueness
5. Identity: A Kubernetes resource can be mapped to a Linode resource label via its UID in the ObjectMeta.
6. Formatting: [Kubernetes UIDs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids) are standardized and well-formatted such that they do not break _any_ existing Linode label constraints.

**Why not validate in the controller?**
It didn't seem as user-friendly to require users to debug through controller logs, resource events, etc. to fix what is essentially a naming error. Kubernetes already enforces metadata validation on resources and we can ratchet off that mechanism to inject in our own additive validation constraints to the built-in ones.

See: https://github.com/kubernetes/kubernetes/issues/74620

**Why not automatically format Linode labels**?
For many Linode resources, labels also have an additional constraint that they _must be unique across a resource type in an account_. Auto-formatting labels could lead to a conflict where two independent Kubernetes resources attempt to use the same label for two independent Linode resources.

Unfortunately, this issue is still occurs if a user creates an object of the same name, but in a different namespace. 😢

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


