### PR TITLE
Fix provider url at getting-started.md

### DIFF
--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -42,7 +42,7 @@ export LINODE_MACHINE_TYPE=g6-standard-2
     ```yaml
     providers:
        - name: linode
-         url: ~/cluster-api-provider-linode/infrastructure-linode/0.0.0/infrastructure-components.yaml
+         url: ${PWD}/infrastructure-linode/0.0.0/infrastructure-components.yaml
          type: InfrastructureProvider
     ```
 


### PR DESCRIPTION
Fixing: `Error: failed to get repository client for the InfrastructureProvider with name linode: error creating the local filesystem repository client: invalid path: path "infrastructure-linode/0.0.0/infrastructure-components.yaml" must be an absolute path`