### PR TITLE
add visualizer label to CRD for cluster-api-visualizer integration

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,6 +4,7 @@ labels:
   - pairs:
       cluster.x-k8s.io/v1beta1: v1alpha1
       cluster.x-k8s.io/provider: "infrastructure-linode"
+      visualizer.cluster.x-k8s.io: ""
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
-->

**What this PR does / why we need it**:
This PR adds the `` label to our CRDs so all resources can be ingested by the [cluster-api visualizer](https://github.com/Jont828/cluster-api-visualizer) per it's documentation for adding [custom resources](https://github.com/Jont828/cluster-api-visualizer/blob/main/docs/including-additional-crds.md)
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


