### PR TITLE
standardize k8s version and common setup steps in templates

### DIFF
--- a/docs/src/topics/flavors/k3s.md
+++ b/docs/src/topics/flavors/k3s.md
@@ -7,7 +7,7 @@
 * [Quickstart](../getting-started.md) completed
 * Select a [k3s kubernetes version](https://github.com/k3s-io/k3s/releases) to set for the kubernetes version
   ```bash
-  export K3S_KUBERNETES_VERSION=v1.29.1+k3s2
+  export KUBERNETES_VERSION=v1.29.1+k3s2
   ```
 * Installed [k3s bootstrap provider](https://github.com/k3s-io/cluster-api-k3s) into your management cluster
   * Add the following to `~/.cluster-api/clusterctl.yaml` for the k3s bootstrap/control plane providers

--- a/docs/src/topics/flavors/rke2.md
+++ b/docs/src/topics/flavors/rke2.md
@@ -7,7 +7,7 @@
 * [Quickstart](../getting-started.md) completed
 * Select an [rke2 kubernetes version](https://github.com/rancher/rke2/releases) to set for the kubernetes version
   ```bash
-  export RKE2_KUBERNETES_VERSION=v1.29.1+rke2r1
+  export KUBERNETES_VERSION=v1.29.1+rke2r1
   ```
 * Installed [rke2 bootstrap provider](https://github.com/rancher-sandbox/cluster-api-provider-rke2) into your management cluster
   ```shell

--- a/templates/common-init-files/secret.yaml
+++ b/templates/common-init-files/secret.yaml
@@ -27,9 +27,8 @@ stringData:
     #!/bin/bash
     set -euo pipefail
     export DEBIAN_FRONTEND=noninteractive
-    hostnamectl set-hostname "$1" && hostname -F /etc/hostname
     mkdir -p -m 755 /etc/apt/keyrings
-    PATCH_VERSION=$${2#[v]}
+    PATCH_VERSION=$${1#[v]}
     VERSION=$${PATCH_VERSION%.*}
     curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
@@ -39,6 +38,4 @@ stringData:
     modprobe overlay
     modprobe br_netfilter
     sysctl --system
-    sed -i '/swap/d' /etc/fstab
-    swapoff -a
 

--- a/templates/flavors/clusterclass-kubeadm/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/clusterclass-kubeadm/kubeadmConfigTemplate.yaml
@@ -28,7 +28,10 @@ spec:
               key: kubeadm-pre-init.sh
           permissions: "0500"
       preKubeadmCommands:
-        - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' ${KUBERNETES_VERSION}
+        - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
+        - sed -i '/swap/d' /etc/fstab
+        - swapoff -a
+        - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:

--- a/templates/flavors/clusterclass-kubeadm/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/clusterclass-kubeadm/kubeadmConfigTemplate.yaml
@@ -36,5 +36,4 @@ spec:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            provider-id: 'linode://{{ ds.meta_data.id }}'
           name: '{{ ds.meta_data.label }}'

--- a/templates/flavors/clusterclass-kubeadm/kubeadmControlPlaneTemplate.yaml
+++ b/templates/flavors/clusterclass-kubeadm/kubeadmControlPlaneTemplate.yaml
@@ -29,7 +29,10 @@ spec:
                 key: kubeadm-pre-init.sh
             permissions: "0500"
         preKubeadmCommands:
-          - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+          - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
+          - sed -i '/swap/d' /etc/fstab
+          - swapoff -a
+          - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
         clusterConfiguration:
           etcd:
             local:
@@ -54,11 +57,9 @@ spec:
           nodeRegistration:
             kubeletExtraArgs:
               cloud-provider: external
-              provider-id: 'linode://{{ ds.meta_data.id }}'
             name: '{{ ds.meta_data.label }}'
         joinConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
               cloud-provider: external
-              provider-id: 'linode://{{ ds.meta_data.id }}'
             name: '{{ ds.meta_data.label }}'

--- a/templates/flavors/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/default/kubeadmConfigTemplate.yaml
@@ -29,10 +29,12 @@ spec:
               key: kubeadm-pre-init.sh
           permissions: "0500"
       preKubeadmCommands:
-        - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+        - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
+        - sed -i '/swap/d' /etc/fstab
+        - swapoff -a
+        - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
             cloud-provider: external
-            provider-id: 'linode://{{ ds.meta_data.id }}'
           name: '{{ ds.meta_data.label }}'

--- a/templates/flavors/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/default/kubeadmControlPlane.yaml
@@ -54,12 +54,10 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          provider-id: 'linode://{{ ds.meta_data.id }}'
         name: '{{ ds.meta_data.label }}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           cloud-provider: external
-          provider-id: 'linode://{{ ds.meta_data.id }}'
         name: '{{ ds.meta_data.label }}'
   version: "${KUBERNETES_VERSION}"

--- a/templates/flavors/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/default/kubeadmControlPlane.yaml
@@ -34,7 +34,10 @@ spec:
             key: kubeadm-pre-init.sh
         permissions: "0500"
     preKubeadmCommands:
-      - /kubeadm-pre-init.sh '{{ ds.meta_data.label }}' "${KUBERNETES_VERSION}"
+      - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
+      - sed -i '/swap/d' /etc/fstab
+      - swapoff -a
+      - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
     clusterConfiguration:
       etcd:
         local:

--- a/templates/flavors/k3s/k3sConfigTemplate.yaml
+++ b/templates/flavors/k3s/k3sConfigTemplate.yaml
@@ -8,11 +8,10 @@ spec:
     spec:
       agentConfig:
         nodeName: '{{ ds.meta_data.label }}'
-        kubeletArgs:
-          - "provider-id=linode://{{ ds.meta_data.id }}"
       preK3sCommands:
         - |
           mkdir -p /etc/rancher/k3s/config.yaml.d/
           echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
         - sed -i '/swap/d' /etc/fstab
         - swapoff -a
+        - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/k3s/k3sControlPlane.yaml
+++ b/templates/flavors/k3s/k3sControlPlane.yaml
@@ -39,12 +39,11 @@ spec:
         - traefik
     agentConfig:
       nodeName: '{{ ds.meta_data.label }}'
-      kubeletArgs:
-        - "provider-id=linode://{{ ds.meta_data.id }}"
     preK3sCommands:
       - |
         echo "node-ip: $(hostname -I | grep -oE 192\.168\.[0-9]+\.[0-9]+)" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
       - sed -i '/swap/d' /etc/fstab
       - swapoff -a
+      - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  version: ${K3S_KUBERNETES_VERSION}
+  version: ${KUBERNETES_VERSION}

--- a/templates/flavors/k3s/kustomization.yaml
+++ b/templates/flavors/k3s/kustomization.yaml
@@ -22,11 +22,3 @@ patches:
       - op: replace
         path: /spec/template/spec/bootstrap/configRef/kind
         value: KThreesConfigTemplate
-  - target:
-      group: cluster.x-k8s.io
-      version: v1beta1
-      kind: MachineDeployment
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/version
-        value: ${K3S_KUBERNETES_VERSION}

--- a/templates/flavors/rke2/kustomization.yaml
+++ b/templates/flavors/rke2/kustomization.yaml
@@ -22,11 +22,3 @@ patches:
       - op: replace
         path: /spec/template/spec/bootstrap/configRef/kind
         value: RKE2ConfigTemplate
-  - target:
-      group: cluster.x-k8s.io
-      version: v1beta1
-      kind: MachineDeployment
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/version
-        value: ${RKE2_KUBERNETES_VERSION}

--- a/templates/flavors/rke2/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/rke2ConfigTemplate.yaml
@@ -7,11 +7,8 @@ spec:
   template:
     spec:
       agentConfig:
-        version: ${RKE2_KUBERNETES_VERSION}
+        version: ${KUBERNETES_VERSION}
         nodeName: '{{ ds.meta_data.label }}'
-        kubelet:
-          extraArgs:
-            - "provider-id=linode://{{ ds.meta_data.id }}"
       # TODO: use MDS to get public and private IP instead because hostname ordering can't always be assumed
       preRKE2Commands:
         - |

--- a/templates/flavors/rke2/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/rke2ControlPlane.yaml
@@ -31,11 +31,8 @@ spec:
       kubernetesComponents:
         - "cloudController"
   agentConfig:
-    version: ${RKE2_KUBERNETES_VERSION}
+    version: ${KUBERNETES_VERSION}
     nodeName: '{{ ds.meta_data.label }}'
-    kubelet:
-      extraArgs:
-        - "provider-id=linode://{{ ds.meta_data.id }}"
   preRKE2Commands:
     - |
       mkdir -p /etc/rancher/rke2/config.yaml.d/


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
This PR does some cleanup of our templates in a few ways
* executes common steps such as turning swap off in a consistent way across flavors
* removes providerID specification since the CCM can handle setting this correctly when it is installed
* sets all flavors to use the KUBERNETES_VERSION env variable so the `clusterctl --kubernetes-version` flag will work as expected

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


