### PR TITLE
[rke2] - enable cis-profile, add configuration for CIS hardening

### DIFF
--- a/docs/src/topics/flavors/rke2.md
+++ b/docs/src/topics/flavors/rke2.md
@@ -1,4 +1,14 @@
 # RKE2
+
+This flavor uses RKE2 for the kubernetes distribution. By default it configures the cluster
+with the [CIS profile](https://docs.rke2.io/security/hardening_guide#rke2-configuration):
+> Using the generic cis profile will ensure that the cluster passes the CIS benchmark (rke2-cis-1.XX-profile-hardened) associated with the Kubernetes version that RKE2 is running. For example, RKE2 v1.28.XX with the profile: cis will pass the rke2-cis-1.7-profile-hardened in Rancher.
+
+```admonish warning
+Until [this upstream PR](https://github.com/rancher-sandbox/cluster-api-provider-rke2/pull/301) is merged, CIS profile enabling
+will not work for RKE2 versions >= v1.29.
+```
+
 ## Specification
 | Control Plane                 | CNI    | Default OS   | Installs ClusterClass | IPv4 | IPv6 |
 |-------------------------------|--------|--------------|-----------------------|------|------|

--- a/templates/flavors/rke2/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/rke2ConfigTemplate.yaml
@@ -9,6 +9,8 @@ spec:
       agentConfig:
         version: ${KUBERNETES_VERSION}
         nodeName: '{{ ds.meta_data.label }}'
+        cisProfile: ${CIS_PROFILE:-"cis-1.23"}
+        protectKernelDefaults: true
       # TODO: use MDS to get public and private IP instead because hostname ordering can't always be assumed
       preRKE2Commands:
         - |

--- a/templates/flavors/rke2/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/rke2ControlPlane.yaml
@@ -33,6 +33,8 @@ spec:
   agentConfig:
     version: ${KUBERNETES_VERSION}
     nodeName: '{{ ds.meta_data.label }}'
+    cisProfile: ${CIS_PROFILE:-"cis-1.23"}
+    protectKernelDefaults: true
   preRKE2Commands:
     - |
       mkdir -p /etc/rancher/rke2/config.yaml.d/


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->
/kind feature

**What this PR does / why we need it**: Enables the [CIS profile](https://docs.rke2.io/security/hardening_guide#rke2-configuration) for the RKE2 flavor and adds some extra configuration for [CIS hardening](https://docs.rke2.io/security/hardening_guide). Unfortunately we can't use "cis" for RKE2 1.29 due to a CRD validation issue where that is not present in the enum. I've opened a [PR](https://github.com/rancher-sandbox/cluster-api-provider-rke2/pull/301) upstream for that in the meantime.

With an RKE2 cluster provisioned by CAPL with these changes, I ran a scan on it after installing the [`rancher-cis-benchmark` helm chart](https://github.com/rancher/charts/tree/dev-v2.9/charts/rancher-cis-benchmark/5.1.0):
```
    lastRunScanProfileName: rke2-cis-1.8-profile-hardened
    lastRunTimestamp: "2024-04-23T15:36:42Z"
    observedGeneration: 1
    summary:
      fail: 0
      notApplicable: 11
      pass: 71
      skip: 0
      total: 130
      warn: 48
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


