### PR TITLE
[feat] - enable cilium BGP control plane

### DIFF
--- a/docs/src/topics/addons.md
+++ b/docs/src/topics/addons.md
@@ -55,6 +55,10 @@ kubectl label cluster $CLUSTER_NAME cni=cilium --overwrite
 
 Cilium will then be automatically installed via CAAPH into the labeled cluster.
 
+#### Enabled Features
+By default, Cilium's [BGP Control Plane](https://docs.cilium.io/en/stable/network/bgp-control-plane/)
+is enabled when using Cilium as the CNI.
+
 ## CCM
 
 In order for the `InternalIP` and `ExternalIP` of the provisioned Nodes to be set correctly,

--- a/templates/addons/cilium/cilium-ipv6.yaml
+++ b/templates/addons/cilium/cilium-ipv6.yaml
@@ -16,6 +16,8 @@ spec:
     wait: true
     timeout: 5m
   valuesTemplate: |
+    bgpControlPlane:
+      enabled: true
     ipv6:
       enabled: true
     ipam:

--- a/templates/addons/cilium/cilium.yaml
+++ b/templates/addons/cilium/cilium.yaml
@@ -16,6 +16,8 @@ spec:
     wait: true
     timeout: 5m
   valuesTemplate: |
+    bgpControlPlane:
+      enabled: true
     ipam:
       mode: kubernetes
     k8s:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->
/kind feature

**What this PR does / why we need it**: This makes it so workload clusters using Cilium as the CNI can by default start using `CiliumBGPPeeringPolicies` to allow for Cilium to advertise routes to BGP routers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


