### PR TITLE
remove wait for disk call and add retry for busy error code

### DIFF
--- a/cloud/scope/client.go
+++ b/cloud/scope/client.go
@@ -33,7 +33,6 @@ type LinodeInstanceClient interface {
 	GetImage(ctx context.Context, imageID string) (*linodego.Image, error)
 	CreateStackscript(ctx context.Context, opts linodego.StackscriptCreateOptions) (*linodego.Stackscript, error)
 	ListStackscripts(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Stackscript, error)
-	WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error)
 }
 
 // LinodeVPCClient defines the methods that a Linode client must have to interact with Linode's VPC service.

--- a/mock/client.go
+++ b/mock/client.go
@@ -369,21 +369,6 @@ func (mr *MockLinodeMachineClientMockRecorder) UpdateInstanceConfig(ctx, linodeI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInstanceConfig", reflect.TypeOf((*MockLinodeMachineClient)(nil).UpdateInstanceConfig), ctx, linodeID, configID, opts)
 }
 
-// WaitForInstanceDiskStatus mocks base method.
-func (m *MockLinodeMachineClient) WaitForInstanceDiskStatus(ctx context.Context, instanceID, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForInstanceDiskStatus", ctx, instanceID, diskID, status, timeoutSeconds)
-	ret0, _ := ret[0].(*linodego.InstanceDisk)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WaitForInstanceDiskStatus indicates an expected call of WaitForInstanceDiskStatus.
-func (mr *MockLinodeMachineClientMockRecorder) WaitForInstanceDiskStatus(ctx, instanceID, diskID, status, timeoutSeconds any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForInstanceDiskStatus", reflect.TypeOf((*MockLinodeMachineClient)(nil).WaitForInstanceDiskStatus), ctx, instanceID, diskID, status, timeoutSeconds)
-}
-
 // MockLinodeInstanceClient is a mock of LinodeInstanceClient interface.
 type MockLinodeInstanceClient struct {
 	ctrl     *gomock.Controller
@@ -627,21 +612,6 @@ func (m *MockLinodeInstanceClient) UpdateInstanceConfig(ctx context.Context, lin
 func (mr *MockLinodeInstanceClientMockRecorder) UpdateInstanceConfig(ctx, linodeID, configID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInstanceConfig", reflect.TypeOf((*MockLinodeInstanceClient)(nil).UpdateInstanceConfig), ctx, linodeID, configID, opts)
-}
-
-// WaitForInstanceDiskStatus mocks base method.
-func (m *MockLinodeInstanceClient) WaitForInstanceDiskStatus(ctx context.Context, instanceID, diskID int, status linodego.DiskStatus, timeoutSeconds int) (*linodego.InstanceDisk, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForInstanceDiskStatus", ctx, instanceID, diskID, status, timeoutSeconds)
-	ret0, _ := ret[0].(*linodego.InstanceDisk)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WaitForInstanceDiskStatus indicates an expected call of WaitForInstanceDiskStatus.
-func (mr *MockLinodeInstanceClientMockRecorder) WaitForInstanceDiskStatus(ctx, instanceID, diskID, status, timeoutSeconds any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForInstanceDiskStatus", reflect.TypeOf((*MockLinodeInstanceClient)(nil).WaitForInstanceDiskStatus), ctx, instanceID, diskID, status, timeoutSeconds)
 }
 
 // MockLinodeVPCClient is a mock of LinodeVPCClient interface.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
This PR removes the `WaitForInstanceDiskStatus` polling call and instead will re-queue any call and suppress any errors if the Linode API response is `Linode Busy`(400 response code).
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


