### PR TITLE
update provider name in documentation to linode-linode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR)
 
 .PHONY: local-release
 local-release:
-	RELEASE_DIR=infrastructure-linode/v0.0.0 $(MAKE) release
+	RELEASE_DIR=infrastructure-local-linode/v0.0.0 $(MAKE) release
 	$(MAKE) clean-release-git
 
 ## --------------------------------------

--- a/docs/src/developers/development.md
+++ b/docs/src/developers/development.md
@@ -150,10 +150,10 @@ For local development, templates should be generated via:
 make local-release
 ```
 
-This creates `infrastructure-linode/v0.0.0/` with all the cluster templates:
+This creates `infrastructure-local-linode/v0.0.0/` with all the cluster templates:
 
 ```sh
-infrastructure-linode/v0.0.0
+infrastructure-local-linode/v0.0.0
 ├── cluster-template-clusterclass-kubeadm.yaml
 ├── cluster-template-etcd-backup-restore.yaml
 ├── cluster-template-k3s.yaml
@@ -169,7 +169,7 @@ This can then be used with `clusterctl` by adding the following to `~/.clusterct
 
 ```
 providers:
-  - name: akamai-linode
+  - name: local-linode
     url: ${HOME}/cluster-api-provider-linode/infrastructure-linode/v0.0.0/infrastructure-components.yaml
     type: InfrastructureProvider
 ```
@@ -194,7 +194,7 @@ export LINODE_MACHINE_TYPE=g6-standard-2
 You can also use `clusterctl generate` to see which variables need to be set:
 
 ```
-clusterctl generate cluster $CLUSTER_NAME --infrastructure akamai-linode:v0.0.0 [--flavor <flavor>] --list-variables
+clusterctl generate cluster $CLUSTER_NAME --infrastructure local-linode:v0.0.0 [--flavor <flavor>] --list-variables
 ```
 
 ~~~
@@ -209,7 +209,7 @@ you can deploy a workload cluster with the default flavor:
 ```sh
 clusterctl generate cluster $CLUSTER_NAME \
   --kubernetes-version v1.29.1 \
-  --infrastructure akamai-akamai-linode:v0.0.0 \
+  --infrastructure local-linode:v0.0.0 \
   | kubectl apply -f -
 ```
 
@@ -229,7 +229,7 @@ management cluster has the [ClusterTopology feature gate set](https://cluster-ap
 ```sh
 clusterctl generate cluster $CLUSTER_NAME \
   --kubernetes-version v1.29.1 \
-  --infrastructure akamai-linode:v0.0.0 \
+  --infrastructure local-linode:v0.0.0 \
   --flavor clusterclass-kubeadm \
   | kubectl apply -f -
 ```

--- a/docs/src/topics/backups.md
+++ b/docs/src/topics/backups.md
@@ -12,7 +12,7 @@ To enable backups, use the addon flag during provisioning to select the etcd-bac
 ```sh
 clusterctl generate cluster $CLUSTER_NAME \
   --kubernetes-version v1.29.1 \
-  --infrastructure akamai-linode \
+  --infrastructure linode-linode \
   --flavor etcd-backup-restore \
   | kubectl apply -f -
 ```

--- a/docs/src/topics/etcd.md
+++ b/docs/src/topics/etcd.md
@@ -39,7 +39,7 @@ export ETCDBR_IMAGE=docker.io/username/your-custom-image:version
 export SSE_KEY=cdQdZ3PrKgm5vmqxeqwQCuAWJ7pPVyHg
 clusterctl generate cluster $CLUSTER_NAME \
   --kubernetes-version v1.29.1 \
-  --infrastructure akamai-linode \
+  --infrastructure linode-linode \
   --flavor etcd-backup-restore \
   | kubectl apply -f -
 ```

--- a/docs/src/topics/flavors/cluster-autoscaler.md
+++ b/docs/src/topics/flavors/cluster-autoscaler.md
@@ -33,7 +33,7 @@ Autoscaler](https://www.github.com/kubernetes/autoscaler/tree/master/cluster-aut
     ```sh
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor cluster-autoscaler > test-cluster.yaml
     ```
 

--- a/docs/src/topics/flavors/clusterclass-kubeadm.md
+++ b/docs/src/topics/flavors/clusterclass-kubeadm.md
@@ -11,7 +11,7 @@
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor clusterclass-kubeadm > test-cluster.yaml
     ```
 2. Apply cluster manifests

--- a/docs/src/topics/flavors/default.md
+++ b/docs/src/topics/flavors/default.md
@@ -10,7 +10,7 @@
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1 \
-        --infrastructure akamai-linode > test-cluster.yaml
+        --infrastructure linode-linode > test-cluster.yaml
     ```
 2. Apply cluster yaml
     ```bash

--- a/docs/src/topics/flavors/dual-stack.md
+++ b/docs/src/topics/flavors/dual-stack.md
@@ -10,7 +10,7 @@
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor dual-stack > test-cluster.yaml
     ```
 2. Apply cluster yaml

--- a/docs/src/topics/flavors/etcd-backup-restore.md
+++ b/docs/src/topics/flavors/etcd-backup-restore.md
@@ -12,7 +12,7 @@
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor etcd-backup-restore > test-cluster.yaml
     ```
 2. Apply cluster yaml

--- a/docs/src/topics/flavors/etcd-disk.md
+++ b/docs/src/topics/flavors/etcd-disk.md
@@ -18,7 +18,7 @@ the `quota-backend-bytes` to `8589934592` (8 GiB) per recommendation from
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor etcd-disk > test-cluster.yaml
     ```
 2. Apply cluster yaml

--- a/docs/src/topics/flavors/k3s.md
+++ b/docs/src/topics/flavors/k3s.md
@@ -27,7 +27,7 @@
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1+k3s2 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor k3s > test-k3s-cluster.yaml
     ```
 2. Apply cluster yaml

--- a/docs/src/topics/flavors/rke2.md
+++ b/docs/src/topics/flavors/rke2.md
@@ -25,7 +25,7 @@ will not work for RKE2 versions >= v1.29.
     ```bash
     clusterctl generate cluster test-cluster \
         --kubernetes-version v1.29.1+rke2r1 \
-        --infrastructure akamai-linode \
+        --infrastructure linode-linode \
         --flavor rke2 > test-rke2-cluster.yaml
     ```
 2. Apply cluster yaml

--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -40,7 +40,7 @@ By default, clusters are provisioned within VPC. For Regions which do not have [
 1. Add `linode` as an infrastructure provider in `~/.cluster-api/clusterctl.yaml`
     ```yaml
     providers:
-       - name: akamai-linode
+       - name: linode-linode
          url: https://github.com/linode/cluster-api-provider-linode/releases/latest/infrastructure-components.yaml
          type: InfrastructureProvider
     ```
@@ -48,7 +48,7 @@ By default, clusters are provisioned within VPC. For Regions which do not have [
 ## Install CAPL on your management cluster
 Install CAPL and enable the helm addon provider which is used by the majority of the CAPL flavors
 ```bash
-clusterctl init --infrastructure akamai-linode --addon helm
+clusterctl init --infrastructure linode-linode --addon helm
 ```
 
 ## Deploying your first cluster

--- a/docs/src/topics/health-checking.md
+++ b/docs/src/topics/health-checking.md
@@ -10,7 +10,7 @@ using the `self-healing` flavor is the quickest way to get started:
 ```sh
 clusterctl generate cluster $CLUSTER_NAME \
   --kubernetes-version v1.29.1 \
-  --infrastructure akamai-linode \
+  --infrastructure linode-linode \
   --flavor self-healing \
   | kubectl apply -f -
 ```


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
Based on feedback on https://github.com/kubernetes-sigs/cluster-api/pull/10471 this changes our documentation to use `linode-linode` instead of `akamai-linode`. it also separates out the naming for locally built manifest files into `local-linode` though I would be open to keeping this the same as `linode-linode`
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


