### PR TITLE
fix: add finalizer to credentials reference

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -108,3 +108,23 @@ func (s *ClusterScope) AddFinalizer(ctx context.Context) error {
 
 	return nil
 }
+
+func (s *ClusterScope) AddCredentialsRefFinalizer(ctx context.Context) error {
+	if s.LinodeCluster.Spec.CredentialsRef == nil {
+		return nil
+	}
+
+	return addCredentialsFinalizer(ctx, s.Client,
+		*s.LinodeCluster.Spec.CredentialsRef, s.LinodeCluster.GetNamespace(),
+		toFinalizer(s.LinodeCluster))
+}
+
+func (s *ClusterScope) RemoveCredentialsRefFinalizer(ctx context.Context) error {
+	if s.LinodeCluster.Spec.CredentialsRef == nil {
+		return nil
+	}
+
+	return removeCredentialsFinalizer(ctx, s.Client,
+		*s.LinodeCluster.Spec.CredentialsRef, s.LinodeCluster.GetNamespace(),
+		toFinalizer(s.LinodeCluster))
+}

--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/linode/linodego"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/linode/cluster-api-provider-linode/version"
 )
@@ -34,6 +36,47 @@ func CreateLinodeClient(apiKey string) (*linodego.Client, error) {
 }
 
 func getCredentialDataFromRef(ctx context.Context, crClient K8sClient, credentialsRef corev1.SecretReference, defaultNamespace string) ([]byte, error) {
+	credSecret, err := getCredentials(ctx, crClient, credentialsRef, defaultNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: This key is hard-coded (for now) to match the externally-managed `manager-credentials` Secret.
+	rawData, ok := credSecret.Data["apiToken"]
+	if !ok {
+		return nil, fmt.Errorf("no apiToken key in credentials secret %s/%s", credentialsRef.Namespace, credentialsRef.Name)
+	}
+
+	return rawData, nil
+}
+
+func addCredentialsFinalizer(ctx context.Context, crClient K8sClient, credentialsRef corev1.SecretReference, defaultNamespace, finalizer string) error {
+	secret, err := getCredentials(ctx, crClient, credentialsRef, defaultNamespace)
+	if err != nil {
+		return err
+	}
+
+	controllerutil.AddFinalizer(secret, finalizer)
+	if err := crClient.Update(ctx, secret); err != nil {
+		return fmt.Errorf("add finalizer to credentials secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+	return nil
+}
+
+func removeCredentialsFinalizer(ctx context.Context, crClient K8sClient, credentialsRef corev1.SecretReference, defaultNamespace, finalizer string) error {
+	secret, err := getCredentials(ctx, crClient, credentialsRef, defaultNamespace)
+	if err != nil {
+		return err
+	}
+
+	controllerutil.RemoveFinalizer(secret, finalizer)
+	if err := crClient.Update(ctx, secret); err != nil {
+		return fmt.Errorf("remove finalizer from credentials secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+	return nil
+}
+
+func getCredentials(ctx context.Context, crClient K8sClient, credentialsRef corev1.SecretReference, defaultNamespace string) (*corev1.Secret, error) {
 	secretRef := client.ObjectKey{
 		Name:      credentialsRef.Name,
 		Namespace: credentialsRef.Namespace,
@@ -47,11 +90,20 @@ func getCredentialDataFromRef(ctx context.Context, crClient K8sClient, credentia
 		return nil, fmt.Errorf("get credentials secret %s/%s: %w", secretRef.Namespace, secretRef.Name, err)
 	}
 
-	// TODO: This key is hard-coded (for now) to match the externally-managed `manager-credentials` Secret.
-	rawData, ok := credSecret.Data["apiToken"]
-	if !ok {
-		return nil, fmt.Errorf("no apiToken key in credentials secret %s/%s", secretRef.Namespace, secretRef.Name)
-	}
+	return &credSecret, nil
+}
 
-	return rawData, nil
+// toFinalizer converts an object into a valid finalizer key representation
+func toFinalizer(obj client.Object) string {
+	var (
+		gvk       = obj.GetObjectKind().GroupVersionKind()
+		group     = gvk.Group
+		kind      = strings.ToLower(gvk.Kind)
+		namespace = obj.GetNamespace()
+		name      = obj.GetName()
+	)
+	if namespace == "" {
+		return fmt.Sprintf("%s.%s/%s", kind, group, name)
+	}
+	return fmt.Sprintf("%s.%s/%s.%s", kind, group, namespace, name)
 }

--- a/cloud/scope/common_test.go
+++ b/cloud/scope/common_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	infrav1alpha1 "github.com/linode/cluster-api-provider-linode/api/v1alpha1"
 	"github.com/linode/cluster-api-provider-linode/mock"
 )
 
@@ -177,6 +180,304 @@ func TestGetCredentialDataFromRef(t *testing.T) {
 				assert.EqualError(t, err, testCase.expectedError)
 			} else {
 				assert.Equal(t, testCase.expectedByte, got)
+			}
+		})
+	}
+}
+
+// Test_addCredentialsFinalizer tests the addCredentialsFinalizer function.
+func Test_addCredentialsFinalizer(t *testing.T) {
+	t.Parallel()
+
+	type clientBehavior struct {
+		Get    func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error
+		Update func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
+	}
+
+	type args struct {
+		providedCredentialsRef corev1.SecretReference
+		clientBehavior         clientBehavior
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		expectedError string
+	}{
+		{
+			name: "Testing functionality using valid/good data. No error should be returned",
+			args: args{
+				providedCredentialsRef: corev1.SecretReference{
+					Name:      "example",
+					Namespace: "test",
+				},
+				clientBehavior: clientBehavior{
+					Get: func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error {
+						cred := corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "example",
+								Namespace: "test",
+							},
+						}
+						*obj = cred
+
+						return nil
+					},
+					Update: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "Handle error from crClient Get. Error should be returned.",
+			args: args{
+				providedCredentialsRef: corev1.SecretReference{
+					Name:      "example",
+					Namespace: "test",
+				},
+				clientBehavior: clientBehavior{
+					Get: func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error {
+						return errors.New("client get error")
+					},
+					Update: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			expectedError: "get credentials secret test/example: client get error",
+		},
+		{
+			name: "Handle error from crClient Update. Error should be returned.",
+			args: args{
+				providedCredentialsRef: corev1.SecretReference{
+					Name:      "example",
+					Namespace: "test",
+				},
+				clientBehavior: clientBehavior{
+					Get: func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error {
+						cred := corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "example",
+								Namespace: "test",
+							},
+						}
+						*obj = cred
+
+						return nil
+					},
+					Update: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return errors.New("client update error")
+					},
+				},
+			},
+			expectedError: "add finalizer to credentials secret test/example: client update error",
+		},
+	}
+
+	for _, tt := range tests {
+		testCase := tt
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create an instance of the mock K8sClient
+			mockClient := mock.NewMockK8sClient(ctrl)
+
+			// Setup Expected behaviour
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(testCase.args.clientBehavior.Get).AnyTimes()
+			mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(testCase.args.clientBehavior.Update).AnyTimes()
+
+			// Call addCredentialsFinalizer using the mock client
+			err := addCredentialsFinalizer(context.Background(), mockClient, testCase.args.providedCredentialsRef, "default", "test.test/test.test")
+
+			// Check that the function returned the expected result
+			if testCase.expectedError != "" {
+				assert.EqualError(t, err, testCase.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test_removeCredentialsFinalizer tests the removeCredentialsFinalizer function.
+func Test_removeCredentialsFinalizer(t *testing.T) {
+	t.Parallel()
+
+	type clientBehavior struct {
+		Get    func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error
+		Update func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
+	}
+
+	type args struct {
+		providedCredentialsRef corev1.SecretReference
+		clientBehavior         clientBehavior
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		expectedError string
+	}{
+		{
+			name: "Testing functionality using valid/good data. No error should be returned",
+			args: args{
+				providedCredentialsRef: corev1.SecretReference{
+					Name:      "example",
+					Namespace: "test",
+				},
+				clientBehavior: clientBehavior{
+					Get: func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error {
+						cred := corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "example",
+								Namespace: "test",
+							},
+						}
+						*obj = cred
+
+						return nil
+					},
+					Update: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "Handle error from crClient Get. Error should be returned.",
+			args: args{
+				providedCredentialsRef: corev1.SecretReference{
+					Name:      "example",
+					Namespace: "test",
+				},
+				clientBehavior: clientBehavior{
+					Get: func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error {
+						return errors.New("client get error")
+					},
+					Update: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+			},
+			expectedError: "get credentials secret test/example: client get error",
+		},
+		{
+			name: "Handle error from crClient Update. Error should be returned.",
+			args: args{
+				providedCredentialsRef: corev1.SecretReference{
+					Name:      "example",
+					Namespace: "test",
+				},
+				clientBehavior: clientBehavior{
+					Get: func(ctx context.Context, key types.NamespacedName, obj *corev1.Secret, opts ...client.GetOption) error {
+						cred := corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "example",
+								Namespace: "test",
+							},
+						}
+						*obj = cred
+
+						return nil
+					},
+					Update: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return errors.New("client update error")
+					},
+				},
+			},
+			expectedError: "remove finalizer from credentials secret test/example: client update error",
+		},
+	}
+
+	for _, tt := range tests {
+		testCase := tt
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create an instance of the mock K8sClient
+			mockClient := mock.NewMockK8sClient(ctrl)
+
+			// Setup Expected behaviour
+			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(testCase.args.clientBehavior.Get).AnyTimes()
+			mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).DoAndReturn(testCase.args.clientBehavior.Update).AnyTimes()
+
+			// Call removeCredentialsFinalizer using the mock client
+			err := removeCredentialsFinalizer(context.Background(), mockClient, testCase.args.providedCredentialsRef, "default", "test.test/test.test")
+
+			// Check that the function returned the expected result
+			if testCase.expectedError != "" {
+				assert.EqualError(t, err, testCase.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test_toFinalizer tests the toFinalizer function.
+func Test_toFinalizer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		gvk    schema.GroupVersionKind
+		object client.Object
+		want   string
+	}{
+		{
+			"Namespaced Resources",
+			schema.GroupVersionKind{
+				Group:   infrav1alpha1.GroupVersion.Group,
+				Version: infrav1alpha1.GroupVersion.Version,
+				Kind:    "LinodeCluster",
+			},
+			&infrav1alpha1.LinodeCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "example",
+				},
+			},
+			"linodecluster.infrastructure.cluster.x-k8s.io/test.example",
+		},
+		{
+			"Cluster Resources",
+			schema.GroupVersionKind{
+				Group:   infrav1alpha1.GroupVersion.Group,
+				Version: infrav1alpha1.GroupVersion.Version,
+				Kind:    "LinodeCluster",
+			},
+			&infrav1alpha1.LinodeCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "example",
+					// NOTE: Fake a cluster resource by setting Namespace to the default value
+					// See: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Object
+					Namespace: "",
+				},
+			},
+			"linodecluster.infrastructure.cluster.x-k8s.io/example",
+		},
+	}
+
+	for _, tt := range tests {
+		testCase := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Inject the unambiguous kind identity into the object
+			testCase.object.GetObjectKind().SetGroupVersionKind(testCase.gvk)
+
+			got := toFinalizer(testCase.object)
+			if testCase.want != got {
+				assert.Equal(t, testCase.want, got)
 			}
 		})
 	}

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -154,3 +154,25 @@ func (m *MachineScope) GetBootstrapData(ctx context.Context) ([]byte, error) {
 
 	return value, nil
 }
+
+func (s *MachineScope) AddCredentialsRefFinalizer(ctx context.Context) error {
+	// Only add the finalizer if the machine has an override for the credentials reference
+	if s.LinodeMachine.Spec.CredentialsRef == nil {
+		return nil
+	}
+
+	return addCredentialsFinalizer(ctx, s.Client,
+		*s.LinodeMachine.Spec.CredentialsRef, s.LinodeMachine.GetNamespace(),
+		toFinalizer(s.LinodeMachine))
+}
+
+func (s *MachineScope) RemoveCredentialsRefFinalizer(ctx context.Context) error {
+	// Only remove the finalizer if the machine has an override for the credentials reference
+	if s.LinodeMachine.Spec.CredentialsRef == nil {
+		return nil
+	}
+
+	return removeCredentialsFinalizer(ctx, s.Client,
+		*s.LinodeMachine.Spec.CredentialsRef, s.LinodeMachine.GetNamespace(),
+		toFinalizer(s.LinodeMachine))
+}

--- a/cloud/scope/vpc.go
+++ b/cloud/scope/vpc.go
@@ -102,3 +102,23 @@ func (s *VPCScope) AddFinalizer(ctx context.Context) error {
 
 	return nil
 }
+
+func (s *VPCScope) AddCredentialsRefFinalizer(ctx context.Context) error {
+	if s.LinodeVPC.Spec.CredentialsRef == nil {
+		return nil
+	}
+
+	return addCredentialsFinalizer(ctx, s.Client,
+		*s.LinodeVPC.Spec.CredentialsRef, s.LinodeVPC.GetNamespace(),
+		toFinalizer(s.LinodeVPC))
+}
+
+func (s *VPCScope) RemoveCredentialsRefFinalizer(ctx context.Context) error {
+	if s.LinodeVPC.Spec.CredentialsRef == nil {
+		return nil
+	}
+
+	return removeCredentialsFinalizer(ctx, s.Client,
+		*s.LinodeVPC.Spec.CredentialsRef, s.LinodeVPC.GetNamespace(),
+		toFinalizer(s.LinodeVPC))
+}

--- a/controller/linodevpc_controller.go
+++ b/controller/linodevpc_controller.go
@@ -175,6 +175,11 @@ func (r *LinodeVPCReconciler) reconcile(
 func (r *LinodeVPCReconciler) reconcileCreate(ctx context.Context, logger logr.Logger, vpcScope *scope.VPCScope) error {
 	logger.Info("creating vpc")
 
+	if err := vpcScope.AddCredentialsRefFinalizer(ctx); err != nil {
+		logger.Error(err, "Failed to update credentials secret")
+		return err
+	}
+
 	if err := r.reconcileVPC(ctx, vpcScope, logger); err != nil {
 		logger.Error(err, "Failed to create VPC")
 
@@ -260,6 +265,11 @@ func (r *LinodeVPCReconciler) reconcileDelete(ctx context.Context, logger logr.L
 	r.Recorder.Event(vpcScope.LinodeVPC, corev1.EventTypeNormal, clusterv1.DeletedReason, "VPC has cleaned up")
 
 	vpcScope.LinodeVPC.Spec.VPCID = nil
+
+	if err := vpcScope.RemoveCredentialsRefFinalizer(ctx); err != nil {
+		logger.Error(err, "Failed to update credentials secret")
+		return res, err
+	}
 	controllerutil.RemoveFinalizer(vpcScope.LinodeVPC, infrav1alpha1.GroupVersion.String())
 
 	return res, nil


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
Adds a unique finalizer to the credentials reference Secret (if `.spec.CredentialsRef` is set) when creating `Linode{Cluster,Machine,VPC}` resources and removes it upon deletion. The finalizer is unique in case you have a shared Secret (e.g. `KIND.GROUP/NAMESPACE.NAME`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This allows users to use `kubectl delete` with the output of `clusterctl generate`, e.g.:

```sh
clusterctl generate cluster $CLUSTER_NAME \
  --kubernetes-version v1.29.1 \
  --infrastructure akamai-linode:v0.0.0 \
  --flavor clusterclass-kubeadm \
  | kubectl delete -f -
```

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Testing**:
1. Create a cluster:

  ```sh
  $ clusterctl generate cluster $CLUSTER_NAME \
    --kubernetes-version v1.29.1 \
    --infrastructure linode:0.0.0 \
    | kubectl apply -f -
  ```

2. Check the cluster credentials Secret for an object finalizer:

  ```sh
  $ kubectl get secret ${CLUSTER_NAME}-credentials -o yaml | yq .metadata.finalizers
  - linodecluster.infrastructure.cluster.x-k8s.io/default.${CLUSTER_NAME}
  ```

3. Delete the cluster:
  ```sh
  $ clusterctl generate cluster $CLUSTER_NAME \
    --kubernetes-version v1.29.1 \
    --infrastructure linode:0.0.0 \
    | kubectl delete -f -
  ```

4. All cluster resources should clean up successfully:
  ```sh
  $ kubectl get cluster-api,secrets
  No resources found in default namespace.
  ```
