### PR TITLE
feat: linodecluster: add validating admission webhook on create

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -17,6 +17,9 @@ resources:
   kind: LinodeCluster
   path: github.com/linode/cluster-api-provider-linode/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/v1alpha1/linodecluster_types.go
+++ b/api/v1alpha1/linodecluster_types.go
@@ -26,6 +26,7 @@ import (
 // LinodeClusterSpec defines the desired state of LinodeCluster
 type LinodeClusterSpec struct {
 	// The Linode Region the LinodeCluster lives in.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	Region string `json:"region"`
 
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the LinodeCluster control plane.

--- a/api/v1alpha1/linodecluster_webhook.go
+++ b/api/v1alpha1/linodecluster_webhook.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 Akamai Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var linodeclusterlog = logf.Log.WithName("linodecluster-resource")
+
+// SetupWebhookWithManager will setup the manager to manage the webhooks
+func (r *LinodeCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=linodeclusters,verbs=create;update,versions=v1alpha1,name=vlinodecluster.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &LinodeCluster{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *LinodeCluster) ValidateCreate() (admission.Warnings, error) {
+	linodeclusterlog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *LinodeCluster) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+	linodeclusterlog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *LinodeCluster) ValidateDelete() (admission.Warnings, error) {
+	linodeclusterlog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil, nil
+}

--- a/api/v1alpha1/linodecluster_webhook.go
+++ b/api/v1alpha1/linodecluster_webhook.go
@@ -17,11 +17,19 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
+	"slices"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	. "github.com/linode/cluster-api-provider-linode/clients"
 )
 
 // log is for logging in this package.
@@ -34,10 +42,8 @@ func (r *LinodeCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=linodeclusters,verbs=create;update,versions=v1alpha1,name=vlinodecluster.kb.io,admissionReviewVersions=v1
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable updation and deletion validation.
+//+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodecluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=linodeclusters,verbs=create,versions=v1alpha1,name=vlinodecluster.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &LinodeCluster{}
 
@@ -45,8 +51,10 @@ var _ webhook.Validator = &LinodeCluster{}
 func (r *LinodeCluster) ValidateCreate() (admission.Warnings, error) {
 	linodeclusterlog.Info("validate create", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object creation.
-	return nil, nil
+	ctx, cancel := context.WithTimeout(context.Background(), defaultWebhookTimeout)
+	defer cancel()
+
+	return nil, r.validateLinodeCluster(ctx, &defaultLinodeClient)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -63,4 +71,32 @@ func (r *LinodeCluster) ValidateDelete() (admission.Warnings, error) {
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil
+}
+
+func (r *LinodeCluster) validateLinodeCluster(ctx context.Context, client LinodeClient) error {
+	var errs field.ErrorList
+
+	if err := r.validateLinodeClusterSpec(ctx, client); err != nil {
+		errs = slices.Concat(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "infrastructure.cluster.x-k8s.io", Kind: "LinodeCluster"},
+		r.Name, errs)
+}
+
+func (r *LinodeCluster) validateLinodeClusterSpec(ctx context.Context, client LinodeClient) field.ErrorList {
+	var errs field.ErrorList
+
+	if err := validateRegion(ctx, client, r.Spec.Region, field.NewPath("spec").Child("region")); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs
 }

--- a/api/v1alpha1/linodecluster_webhook_test.go
+++ b/api/v1alpha1/linodecluster_webhook_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 Akamai Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("LinodeCluster Webhook", func() {
+
+	Context("When creating LinodeCluster under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -114,6 +114,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&LinodeCluster{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = (&LinodeMachine{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -150,14 +150,12 @@ func main() {
 		os.Exit(1)
 	}
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err = (&infrastructurev1alpha1.LinodeMachine{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeMachine")
-			os.Exit(1)
-		}
-	}
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&infrastructurev1alpha1.LinodeCluster{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeCluster")
+			os.Exit(1)
+		}
+		if err = (&infrastructurev1alpha1.LinodeMachine{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeMachine")
 			os.Exit(1)
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -155,6 +155,12 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&infrastructurev1alpha1.LinodeCluster{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeCluster")
+			os.Exit(1)
+		}
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
@@ -116,6 +116,9 @@ spec:
               region:
                 description: The Linode Region the LinodeCluster lives in.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
               vpcRef:
                 description: |-
                   ObjectReference contains enough information to let you inspect or modify the referred object.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclustertemplates.yaml
@@ -110,6 +110,9 @@ spec:
                       region:
                         description: The Linode Region the LinodeCluster lives in.
                         type: string
+                        x-kubernetes-validations:
+                        - message: Value is immutable
+                          rule: self == oldSelf
                       vpcRef:
                         description: |-
                           ObjectReference contains enough information to let you inspect or modify the referred object.

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- path: patches/webhook_in_linodeclusters.yaml
+- path: patches/webhook_in_linodeclusters.yaml
 - path: patches/webhook_in_linodemachines.yaml
 #- path: patches/webhook_in_linodemachinetemplates.yaml
 #- path: patches/webhook_in_linodeclustertemplates.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- path: patches/cainjection_in_linodeclusters.yaml
+- path: patches/cainjection_in_linodeclusters.yaml
 - path: patches/cainjection_in_linodemachines.yaml
 #- path: patches/cainjection_in_linodemachinetemplates.yaml
 #- path: patches/cainjection_in_linodeclustertemplates.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,6 +10,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodecluster
+  failurePolicy: Fail
+  name: vlinodecluster.kb.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linodeclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodemachine
   failurePolicy: Fail
   name: vlinodemachine.kb.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -20,7 +20,6 @@ webhooks:
     - v1alpha1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - linodeclusters
   sideEffects: None


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
Adds a validating admission webhook for `infrastructure.cluster.x-k8s.io/v1alpha1/linodecluster` resources on creation.

This initial validation webhook validates the following LinodeCluster resource fields on object creation:

| **Field**      | **Validation(s)** |
| -------------- | ----------------- |
| `.spec.region` | Valid region      |

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests

**Testing**:
1. Create an invalid `LinodeCluster` resource:
```sh
$ kubectl apply -f - <<EOF
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: LinodeCluster
metadata:
  name: test
spec:
  region: test
EOF

The LinodeCluster "test" is invalid: spec.region: Not found: "test"
```