### PR TITLE
[tweak] - set timeout for default http clients, reduce webhook timeout

### DIFF
--- a/api/v1alpha1/webhook_helpers.go
+++ b/api/v1alpha1/webhook_helpers.go
@@ -13,12 +13,14 @@ import (
 
 const (
 	// defaultWebhookTimeout is the default timeout for an admission request
-	defaultWebhookTimeout = time.Minute
+	defaultWebhookTimeout = time.Second * 10
+	// defaultClientTimeout is the default timeout for a client Linode API call
+	defaultClientTimeout = time.Second * 10
 )
 
 var (
 	// defaultLinodeClient is an unauthenticated Linode client
-	defaultLinodeClient = linodego.NewClient(http.DefaultClient)
+	defaultLinodeClient = linodego.NewClient(&http.Client{Timeout: defaultClientTimeout})
 )
 
 func validateRegion(ctx context.Context, client LinodeClient, id string, path *field.Path) *field.Error {

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -63,7 +63,7 @@ func NewClusterScope(ctx context.Context, apiKey string, params ClusterScopePara
 		}
 		apiKey = string(data)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey)
+	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}

--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -21,10 +21,10 @@ import (
 
 const (
 	// defaultClientTimeout is the default timeout for a client Linode API call
-	defaultClientTimeout = time.Second * 20
+	defaultClientTimeout = time.Second * 10
 )
 
-func CreateLinodeClient(apiKey string) (*linodego.Client, error) {
+func CreateLinodeClient(apiKey string, timeout time.Duration) (*linodego.Client, error) {
 	if apiKey == "" {
 		return nil, errors.New("missing Linode API key")
 	}
@@ -35,7 +35,7 @@ func CreateLinodeClient(apiKey string) (*linodego.Client, error) {
 		Transport: &oauth2.Transport{
 			Source: tokenSource,
 		},
-		Timeout: defaultClientTimeout,
+		Timeout: timeout,
 	}
 	linodeClient := linodego.NewClient(oauth2Client)
 

--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/linode/linodego"
 	"golang.org/x/oauth2"
@@ -16,6 +17,11 @@ import (
 	"github.com/linode/cluster-api-provider-linode/version"
 
 	. "github.com/linode/cluster-api-provider-linode/clients"
+)
+
+const (
+	// defaultClientTimeout is the default timeout for a client Linode API call
+	defaultClientTimeout = time.Second * 20
 )
 
 func CreateLinodeClient(apiKey string) (*linodego.Client, error) {
@@ -29,6 +35,7 @@ func CreateLinodeClient(apiKey string) (*linodego.Client, error) {
 		Transport: &oauth2.Transport{
 			Source: tokenSource,
 		},
+		Timeout: defaultClientTimeout,
 	}
 	linodeClient := linodego.NewClient(oauth2Client)
 

--- a/cloud/scope/common_test.go
+++ b/cloud/scope/common_test.go
@@ -43,7 +43,7 @@ func TestCreateLinodeClient(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := CreateLinodeClient(testCase.apiKey)
+			got, err := CreateLinodeClient(testCase.apiKey, defaultClientTimeout)
 
 			if testCase.expectedErr != nil {
 				assert.EqualError(t, err, testCase.expectedErr.Error())

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -83,7 +83,7 @@ func NewMachineScope(ctx context.Context, apiKey string, params MachineScopePara
 		}
 		apiKey = string(data)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey)
+	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}

--- a/cloud/scope/object_storage_bucket.go
+++ b/cloud/scope/object_storage_bucket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/linode/linodego"
@@ -47,8 +48,11 @@ type ObjectStorageBucketScope struct {
 	PatchHelper  *patch.Helper
 }
 
-const AccessKeyNameTemplate = "%s-bucket-details"
-const NumAccessKeys = 2
+const (
+	AccessKeyNameTemplate = "%s-bucket-details"
+	NumAccessKeys         = 2
+	clientTimeout         = 20 * time.Second
+)
 
 func validateObjectStorageBucketScopeParams(params ObjectStorageBucketScopeParams) error {
 	if params.Bucket == nil {
@@ -74,7 +78,7 @@ func NewObjectStorageBucketScope(ctx context.Context, apiKey string, params Obje
 		}
 		apiKey = string(data)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey)
+	linodeClient, err := CreateLinodeClient(apiKey, clientTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}

--- a/cloud/scope/vpc.go
+++ b/cloud/scope/vpc.go
@@ -67,7 +67,7 @@ func NewVPCScope(ctx context.Context, apiKey string, params VPCScopeParams) (*VP
 		}
 		apiKey = string(data)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey)
+	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->
/kind cleanup

**What this PR does / why we need it**: [The default http client should not be used in production since there is no timeout configured](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779). This instead configures the unauthenticated client to use a timeout and also adds that timeout setting to the linode client created for the other resources. This also changes the default webhook timeout from a minute to 30s. 10 seconds is the default: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


