### PR TITLE
[CI] e2e: add validating admission webhooks test

### DIFF
--- a/e2e/admission-webhooks/validating/assert-capl-resources.yaml
+++ b/e2e/admission-webhooks/validating/assert-capl-resources.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+  namespace: capl-system
+status:
+  availableReplicas: 1
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: capl-validating-webhook-configuration

--- a/e2e/admission-webhooks/validating/chainsaw-test.yaml
+++ b/e2e/admission-webhooks/validating/chainsaw-test.yaml
@@ -1,0 +1,56 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: validating-admission-webhooks
+  # Label to trigger the test on every PR
+  labels:
+    all:
+    webhook:
+spec:
+  bindings:
+    # A short identifier for the E2E test run
+    - name: run
+      value: (join('-', ['e2e', 'validating-webhooks', env('GIT_REF')]))
+    - name: name
+      # Format a generic resource name
+      value: (trim((truncate(($run), `32`)), '-'))
+  template: true
+  steps:
+    - name: Check if CAPL provider resources exist
+      try:
+        - assert:
+            file: assert-capl-resources.yaml
+    - name: Invalid LinodeCluster
+      try:
+        - apply:
+            file: invalid-linodecluster.yaml
+            expect:
+              - check:
+                  ($error != null): true
+                  (contains($error, $name)): true
+    - name: Invalid LinodeMachine
+      try:
+        - apply:
+            file: invalid-linodemachine.yaml
+            expect:
+              - check:
+                  ($error != null): true
+                  (contains($error, $name)): true
+    - name: Invalid LinodeVPC
+      try:
+        - apply:
+            file: invalid-linodevpc.yaml
+            expect:
+              - check:
+                  ($error != null): true
+                  (contains($error, $name)): true
+    - name: Invalid LinodeObjectStorageBucket
+      try:
+        - apply:
+            file: invalid-linodeobjectstoragebucket.yaml
+            expect:
+              - check:
+                  ($error != null): true
+                  (contains($error, $name)): true

--- a/e2e/admission-webhooks/validating/invalid-linodecluster.yaml
+++ b/e2e/admission-webhooks/validating/invalid-linodecluster.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeCluster
+metadata:
+  name: ($name)
+spec:
+  region: invalid

--- a/e2e/admission-webhooks/validating/invalid-linodemachine.yaml
+++ b/e2e/admission-webhooks/validating/invalid-linodemachine.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeMachine
+metadata:
+  name: ($name)
+spec:
+  region: invalid
+  type: invalid

--- a/e2e/admission-webhooks/validating/invalid-linodeobjectstoragebucket.yaml
+++ b/e2e/admission-webhooks/validating/invalid-linodeobjectstoragebucket.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeObjectStorageBucket
+metadata:
+  name: ($name)
+spec:
+  cluster: invalid-1

--- a/e2e/admission-webhooks/validating/invalid-linodevpc.yaml
+++ b/e2e/admission-webhooks/validating/invalid-linodevpc.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: LinodeVPC
+metadata:
+  name: ($name)
+spec:
+  region: invalid
+  subnets:
+    - ipv4: 9.9.9.9


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/testing
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
Adds an e2e test against the admission validation of the following resources:
- LinodeCluster
- LinodeMachine
- LinodeVPC
- LinodeObjectStorageBucket

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests


