### PR TITLE
[feat]: linodeobjectstoragebucket: add validating admission webhook on create

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -69,4 +69,7 @@ resources:
   kind: LinodeObjectStorageBucket
   path: github.com/linode/cluster-api-provider-linode/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/api/v1alpha1/linodeobjectstoragebucket_webhook.go
+++ b/api/v1alpha1/linodeobjectstoragebucket_webhook.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 Akamai Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var linodeobjectstoragebucketlog = logf.Log.WithName("linodeobjectstoragebucket-resource")
+
+// SetupWebhookWithManager will setup the manager to manage the webhooks
+func (r *LinodeObjectStorageBucket) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodeobjectstoragebucket,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=linodeobjectstoragebuckets,verbs=create;update,versions=v1alpha1,name=vlinodeobjectstoragebucket.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &LinodeObjectStorageBucket{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *LinodeObjectStorageBucket) ValidateCreate() (admission.Warnings, error) {
+	linodeobjectstoragebucketlog.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *LinodeObjectStorageBucket) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+	linodeobjectstoragebucketlog.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *LinodeObjectStorageBucket) ValidateDelete() (admission.Warnings, error) {
+	linodeobjectstoragebucketlog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil, nil
+}

--- a/api/v1alpha1/linodeobjectstoragebucket_webhook_test.go
+++ b/api/v1alpha1/linodeobjectstoragebucket_webhook_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 Akamai Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("LinodeObjectStorageBucket Webhook", func() {
+
+	Context("When creating LinodeObjectStorageBucket under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/api/v1alpha1/webhook_helpers.go
+++ b/api/v1alpha1/webhook_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"time"
 
@@ -47,4 +48,25 @@ func validateLinodeType(ctx context.Context, client LinodeClient, id string, pat
 	}
 
 	return plan, nil
+}
+
+// validateObjectStorageCluster validates an Object Storage deployment's cluster ID via the following rules:
+//   - The cluster ID is in the form: REGION_ID-ORDINAL.
+//   - The region has Object Storage support.
+//
+// NOTE: This implementation intended to bypass the authentication requirement for the [Clusters List] and [Cluster
+// View] endpoints in the Linode API, thereby reusing a [github.com/linode/linodego.Client] (and its caching if enabled)
+// across many admission requests.
+//
+// [Clusters List]: https://www.linode.com/docs/api/object-storage/#clusters-list
+// [Cluster View]: https://www.linode.com/docs/api/object-storage/#cluster-view
+func validateObjectStorageCluster(ctx context.Context, client LinodeClient, id string, path *field.Path) *field.Error {
+	//nolint:gocritic // prefer no escapes
+	cexp := regexp.MustCompile("^(([[:lower:]]+-)*[[:lower:]]+)-[[:digit:]]+$")
+	if !cexp.MatchString(id) {
+		return field.Invalid(path, id, "must be in form: region_id-ordinal")
+	}
+
+	region := cexp.FindStringSubmatch(id)[1]
+	return validateRegion(ctx, client, region, path, LinodeObjectStorageCapability)
 }

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -123,6 +123,9 @@ var _ = BeforeSuite(func() {
 	err = (&LinodeVPC{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&LinodeObjectStorageBucket{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -163,6 +163,12 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&infrastructurev1alpha1.LinodeObjectStorageBucket{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeObjectStorageBucket")
+			os.Exit(1)
+		}
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+//nolint:cyclop // main
 func main() {
 	var (
 		// Environment variables
@@ -162,8 +163,6 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeVPC")
 			os.Exit(1)
 		}
-	}
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&infrastructurev1alpha1.LinodeObjectStorageBucket{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "LinodeObjectStorageBucket")
 			os.Exit(1)

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- path: patches/webhook_in_linodeclusters.yaml
+- path: patches/webhook_in_linodeclusters.yaml
 - path: patches/webhook_in_linodemachines.yaml
 #- path: patches/webhook_in_linodemachinetemplates.yaml
 #- path: patches/webhook_in_linodeclustertemplates.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -26,7 +26,7 @@ patches:
 #- path: patches/webhook_in_linodemachinetemplates.yaml
 #- path: patches/webhook_in_linodeclustertemplates.yaml
 - path: patches/webhook_in_linodevpcs.yaml
-#- path: patches/webhook_in_linodeobjectstoragebuckets.yaml
+- path: patches/webhook_in_linodeobjectstoragebuckets.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
@@ -36,7 +36,7 @@ patches:
 #- path: patches/cainjection_in_linodemachinetemplates.yaml
 #- path: patches/cainjection_in_linodeclustertemplates.yaml
 - path: patches/cainjection_in_linodevpcs.yaml
-#- path: patches/cainjection_in_linodeobjectstoragebuckets.yaml
+- path: patches/cainjection_in_linodeobjectstoragebuckets.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [VALIDATION]

--- a/config/crd/patches/cainjection_in_linodeobjectstoragebuckets.yaml
+++ b/config/crd/patches/cainjection_in_linodeobjectstoragebuckets.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+  name: linodeobjectstoragebuckets.infrastructure.cluster.x-k8s.io

--- a/config/crd/patches/webhook_in_linodeobjectstoragebuckets.yaml
+++ b/config/crd/patches/webhook_in_linodeobjectstoragebuckets.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: linodeobjectstoragebuckets.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -58,7 +58,6 @@ webhooks:
     - v1alpha1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - linodeobjectstoragebuckets
   sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -48,6 +48,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodeobjectstoragebucket
+  failurePolicy: Fail
+  name: vlinodeobjectstoragebucket.kb.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - linodeobjectstoragebuckets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-linodevpc
   failurePolicy: Fail
   name: vlinodevpc.kb.io


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind testing
-->

**What this PR does / why we need it**:
Adds a validating admission webhook for `infrastructure.cluster.x-k8s.io/v1alpha1/linodeobjectstoragebucket` resources on creation.

This initial validation webhook validates the following LinodeCluster resource fields on object creation:


| **Field**       | **Validation(s)**                                                                                                                                    |
| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| `.spec.cluster` | - Format: REGION_ID-ORDINAL<br>- Region:  Valid, [Object Storage support](https://www.linode.com/docs/products/storage/object-storage/#availability) |

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The implementation of the `.spec.Cluster` validation is intended to bypass the authentication requirement for the [Clusters List](https://www.linode.com/docs/api/object-storage/#clusters-list) and [Cluster View](https://www.linode.com/docs/api/object-storage/#cluster-view) endpoints in the Linode API, thereby allowing the reuse of a [linodego.Client](https://pkg.go.dev/github.com/linode/linodego#Client) (and its caching if enabled) across many admission requests.

An Object Storage deployment's cluster ID is validated according to the following rules:
  - The cluster ID is in the form: REGION_ID-ORDINAL.
  - The region has Object Storage support.
  
NOTE: The ordinal _value_ is NOT validated.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests


**Testing**:
1. Create an invalid `LinodeObjectStorageBucket` resource:
```sh
$ kubectl apply -f - <<EOF
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: LinodeObjectStorageBucket
metadata:
  name: test
spec:
  cluster: test
EOF

The LinodeObjectStorageBucket "test" is invalid: spec.cluster: Invalid value: "test": must be in form: region_id-ordinal

$ kubectl apply -f - <<EOF
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
kind: LinodeObjectStorageBucket
metadata:
  name: test
spec:
  cluster: eu-west-1
EOF

The LinodeObjectStorageBucket "test" is invalid: spec.cluster: Invalid value: "eu-west": no capability: Object Storage
```