### PR TITLE
[improvement]: add static files required by kubeadm using script than cloud-init

### DIFF
--- a/scripts/add-kubeadm-required-files.sh
+++ b/scripts/add-kubeadm-required-files.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p -m 755 /etc/containerd
+cat > /etc/containerd/config.toml << EOF
+version = 2
+imports = ["/etc/containerd/conf.d/*.toml"]
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.9"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true
+EOF
+
+chmod 644 /etc/containerd/config.toml
+
+mkdir -p -m 755 /etc/modules-load.d
+cat > /etc/modules-load.d/k8s.conf << EOF
+overlay
+br_netfilter
+EOF
+
+chmod 644 /etc/modules-load.d/k8s.conf
+
+mkdir -p -m 755 /etc/sysctl.d
+cat > /etc/sysctl.d/k8s.conf << EOF
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+net.ipv6.conf.all.forwarding        = 1
+EOF
+
+chmod 644 /etc/sysctl.d/k8s.conf
+
+modprobe overlay
+modprobe br_netfilter
+sysctl --system


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
cloud-init has a limit of 16k bytes. With current changes, our generated cloud-init user-data for kubeadm default flavor is close to 16k bytes. We need to reduce the usage of user-data and one option is to have the script downloaded in cloud-init to generate static files than uploading static files via cloud-init.

This PR adds script which can be used to generate the static files. We intentionally don't remove config from cloud-init in this PR as that will be removed in subsequent PRs which starts using the newly added script. This script is a temporary workaround until we have golden images where we can have containerd and other required settings configured by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


