### PR TITLE
[improvement]: reduce cloud-init size, use script for kubeadm

### DIFF
--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -7,27 +7,6 @@ spec:
   template:
     spec:
       files:
-        - path: /etc/containerd/config.toml
-          content: |
-            version = 2
-            imports = ["/etc/containerd/conf.d/*.toml"]
-            [plugins]
-              [plugins."io.containerd.grpc.v1.cri"]
-                sandbox_image = "registry.k8s.io/pause:3.9"
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-                runtime_type = "io.containerd.runc.v2"
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-                SystemdCgroup = true
-        - path: /etc/modules-load.d/k8s.conf
-          content: |
-            overlay
-            br_netfilter
-        - path: /etc/sysctl.d/k8s.conf
-          content: |
-            net.bridge.bridge-nf-call-iptables  = 1
-            net.bridge.bridge-nf-call-ip6tables = 1
-            net.ipv4.ip_forward                 = 1
-            net.ipv6.conf.all.forwarding        = 1
         - path: /kubeadm-pre-init.sh
           content: |
             #!/bin/bash
@@ -36,14 +15,12 @@ spec:
             mkdir -p -m 755 /etc/apt/keyrings
             PATCH_VERSION=$${1#[v]}
             VERSION=$${PATCH_VERSION%.*}
+            curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/869bcdad9cf7daae533023c7869f62683d2a7f47/scripts/add-kubeadm-required-files.sh | bash
             curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
             echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
             apt-get update -y
             apt-get install -y kubelet=$PATCH_VERSION* kubeadm=$PATCH_VERSION* kubectl=$PATCH_VERSION* containerd
             apt-mark hold kubelet kubeadm kubectl containerd
-            modprobe overlay
-            modprobe br_netfilter
-            sysctl --system
             if [ -d "/sys/class/net/eth1" ]; then
                 IPADDR=$(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)
                 sed -i "s/kubeletExtraArgs:/kubeletExtraArgs:\n    node-ip: $IPADDR/g" /run/kubeadm/kubeadm.yaml

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -12,27 +12,6 @@ spec:
       name: ${CLUSTER_NAME}-control-plane
   kubeadmConfigSpec:
     files:
-      - path: /etc/containerd/config.toml
-        content: |
-          version = 2
-          imports = ["/etc/containerd/conf.d/*.toml"]
-          [plugins]
-            [plugins."io.containerd.grpc.v1.cri"]
-              sandbox_image = "registry.k8s.io/pause:3.9"
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-              runtime_type = "io.containerd.runc.v2"
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              SystemdCgroup = true
-      - path: /etc/modules-load.d/k8s.conf
-        content: |
-          overlay
-          br_netfilter
-      - path: /etc/sysctl.d/k8s.conf
-        content: |
-          net.bridge.bridge-nf-call-iptables  = 1
-          net.bridge.bridge-nf-call-ip6tables = 1
-          net.ipv4.ip_forward                 = 1
-          net.ipv6.conf.all.forwarding        = 1
       - path: /kubeadm-pre-init.sh
         content: |
           #!/bin/bash
@@ -41,14 +20,12 @@ spec:
           mkdir -p -m 755 /etc/apt/keyrings
           PATCH_VERSION=$${1#[v]}
           VERSION=$${PATCH_VERSION%.*}
+          curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/869bcdad9cf7daae533023c7869f62683d2a7f47/scripts/add-kubeadm-required-files.sh | bash
           curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
           apt-get update -y
           apt-get install -y kubelet=$PATCH_VERSION* kubeadm=$PATCH_VERSION* kubectl=$PATCH_VERSION* containerd
           apt-mark hold kubelet kubeadm kubectl containerd
-          modprobe overlay
-          modprobe br_netfilter
-          sysctl --system
           if [ -d "/sys/class/net/eth1" ]; then
               IPADDR=$(ip a s eth1 |grep 'inet ' |cut -d' ' -f6|cut -d/ -f1)
               sed -i "s/kubeletExtraArgs:/kubeletExtraArgs:\n    node-ip: $IPADDR/g" /run/kubeadm/kubeadm.yaml


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We are hitting cloud-init limits of 16k for kubeadm flavor clusters and would like to reduce the size of cloud-init userdata. This PR enables us to use script instead of hardcoding data into cloud-init's userdata.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


