### PR TITLE
[fix] Create new ccnp for etcd ports

### DIFF
--- a/templates/addons/cilium-network-policies/ciliumNetworkPolicies.yaml
+++ b/templates/addons/cilium-network-policies/ciliumNetworkPolicies.yaml
@@ -23,7 +23,7 @@ data:
     metadata:
       name: "default-external-policy"
     spec:
-      description: "allow etcd & api server traffic"
+      description: "allow api server traffic"
       nodeSelector: {}
       ingress:
         - fromEntities:

--- a/templates/flavors/kubeadm/default/allow-etcd-policy.yaml
+++ b/templates/flavors/kubeadm/default/allow-etcd-policy.yaml
@@ -10,7 +10,7 @@ data:
     metadata:
       name: "allow-etcd-policy"
     spec:
-      description: "allow etcd & api server traffic"
+      description: "allow etcd traffic"
       nodeSelector: {}
       ingress:
         - fromEntities:

--- a/templates/flavors/kubeadm/default/allow-etcd-policy.yaml
+++ b/templates/flavors/kubeadm/default/allow-etcd-policy.yaml
@@ -14,10 +14,6 @@ data:
       nodeSelector: {}
       ingress:
         - fromEntities:
-            - cluster
-        - fromCIDR:
-            - 10.0.0.0/8
-        - fromEntities:
             - world
           toPorts:
             - ports:

--- a/templates/flavors/kubeadm/default/allow-etcd-policy.yaml
+++ b/templates/flavors/kubeadm/default/allow-etcd-policy.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${CLUSTER_NAME}-etcd-cilium-policy
+data:
+  cilium-policy.yaml: |-
+    apiVersion: "cilium.io/v2"
+    kind: CiliumClusterwideNetworkPolicy
+    metadata:
+      name: "allow-etcd-policy"
+    spec:
+      description: "allow etcd & api server traffic"
+      nodeSelector: {}
+      ingress:
+        - fromEntities:
+            - cluster
+        - fromCIDR:
+            - 10.0.0.0/8
+        - fromEntities:
+            - world
+          toPorts:
+            - ports:
+                - port: "2379"
+                - port: "2380"
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-etcd-cilium-policy
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster: ${CLUSTER_NAME}
+  resources:
+    - kind: ConfigMap
+      name: ${CLUSTER_NAME}-etcd-cilium-policy
+  strategy: Reconcile

--- a/templates/flavors/kubeadm/default/kustomization.yaml
+++ b/templates/flavors/kubeadm/default/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../../infra
   - kubeadmConfigTemplate.yaml
   - kubeadmControlPlane.yaml
+  - allow-etcd-policy.yaml
   - ../../../addons/cilium
   - ../../../addons/cilium-network-policies
   - ../../../addons/csi-driver-linode
@@ -41,47 +42,3 @@ patches:
             ccm: ${CLUSTER_NAME}-linode
             csi: ${CLUSTER_NAME}-linode
             crs: ${CLUSTER_NAME}-crs
-  - target:
-      version: v1
-      kind: ConfigMap
-      name: ${CLUSTER_NAME}-cilium-policy
-    patch: |-
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: ${CLUSTER_NAME}-cilium-policy
-      data:
-        cilium-policy.yaml: |-
-          apiVersion: "cilium.io/v2"
-          kind: CiliumClusterwideNetworkPolicy
-          metadata:
-            name: "default-cluster-policy"
-          spec:
-            description: "allow cluster intra cluster traffic"
-            endpointSelector: {}
-            ingress:
-              - fromEntities:
-                  - cluster
-              - fromCIDR:
-                  - 10.0.0.0/8
-                  - 192.168.128.0/17
-          ---
-          apiVersion: "cilium.io/v2"
-          kind: CiliumClusterwideNetworkPolicy
-          metadata:
-            name: "default-external-policy"
-          spec:
-            description: "allow etcd & api server traffic"
-            nodeSelector: {}
-            ingress:
-              - fromEntities:
-                  - cluster
-              - fromCIDR:
-                  - 10.0.0.0/8
-              - fromEntities:
-                  - world
-                toPorts:
-                  - ports:
-                      - port: "6443"
-                      - port: "2379"
-                      - port: "2380"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
kustomize is currently not detecting the ccnp patch for kubeadm to add etcd ports. This is down to kustomize not using env vars and failing to find a matching resources. Se we are now adding a etcd specific policy for kubeadm

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


