### PR TITLE
[fix] flavors beside clusterclass that were missing cilium host FW

### DIFF
--- a/templates/flavors/k3s/dual-stack/kustomization.yaml
+++ b/templates/flavors/k3s/dual-stack/kustomization.yaml
@@ -61,6 +61,11 @@ patches:
             valuesContent: |-
               bgpControlPlane:
                 enabled: true
+              policyAuditMode: ${FW_AUDIT_ONLY:=true}
+              hostFirewall:
+                enabled: true
+              extraConfig:
+                allow-localhost: policy
               ipam:
                 mode: kubernetes
               ipv4:

--- a/templates/flavors/k3s/full-vpcless/kustomization.yaml
+++ b/templates/flavors/k3s/full-vpcless/kustomization.yaml
@@ -91,6 +91,11 @@ patches:
             valuesContent: |-
               bgpControlPlane:
                 enabled: true
+              policyAuditMode: ${FW_AUDIT_ONLY:=true}
+              hostFirewall:
+                enabled: true
+              extraConfig:
+                allow-localhost: policy
               ipam:
                 mode: kubernetes
               ipv4:

--- a/templates/flavors/k3s/vpcless/kustomization.yaml
+++ b/templates/flavors/k3s/vpcless/kustomization.yaml
@@ -93,6 +93,11 @@ patches:
             valuesContent: |-
               bgpControlPlane:
                 enabled: true
+              policyAuditMode: ${FW_AUDIT_ONLY:=true}
+              hostFirewall:
+                enabled: true
+              extraConfig:
+                allow-localhost: policy
               ipam:
                 mode: kubernetes
               ipv4:

--- a/templates/flavors/kubeadm/dual-stack/kustomization.yaml
+++ b/templates/flavors/kubeadm/dual-stack/kustomization.yaml
@@ -47,6 +47,11 @@ patches:
         value: |
           bgpControlPlane:
             enabled: true
+          policyAuditMode: ${FW_AUDIT_ONLY:=true}
+          hostFirewall:
+            enabled: true
+          extraConfig:
+            allow-localhost: policy
           ipv6:
             enabled: true
           ipam:

--- a/templates/flavors/kubeadm/full-vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/full-vpcless/kustomization.yaml
@@ -52,6 +52,11 @@ patches:
         value: |
           bgpControlPlane:
             enabled: true
+          policyAuditMode: ${FW_AUDIT_ONLY:=true}
+          hostFirewall:
+            enabled: true
+          extraConfig:
+            allow-localhost: policy
           ipv6:
             enabled: true
           ipam:

--- a/templates/flavors/kubeadm/vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/vpcless/kustomization.yaml
@@ -13,6 +13,11 @@ patches:
         value: |
           bgpControlPlane:
             enabled: true
+          policyAuditMode: ${FW_AUDIT_ONLY:=true}
+          hostFirewall:
+            enabled: true
+          extraConfig:
+            allow-localhost: policy
           ipam:
             mode: kubernetes
           k8s:

--- a/templates/flavors/rke2/vpcless/kustomization.yaml
+++ b/templates/flavors/rke2/vpcless/kustomization.yaml
@@ -13,6 +13,11 @@ patches:
         value: |
           bgpControlPlane:
             enabled: true
+          policyAuditMode: ${FW_AUDIT_ONLY:=true}
+          hostFirewall:
+            enabled: true
+          extraConfig:
+            allow-localhost: policy
           ipam:
             mode: kubernetes
           k8s:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: I noticed of our current 28 generated flavors, 8 of them were missing the default cilium host FW. This adds that to 7 of them (not sure about the clusterclass patch needed at this time)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


