### PR TITLE
[cleanup] switch to not using apt for kubeadm, kubelet, and kubectl, curl kubeadm pre-init script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,6 @@ jobs:
       - name: Upload Release Artifacts
         uses: softprops/action-gh-release@v2
         with:
-          files: ./infrastructure-linode/*
+          files: |
+            ./infrastructure-linode/*
+            scripts/pre-kubeadminit.sh

--- a/scripts/pre-kubeadminit.sh
+++ b/scripts/pre-kubeadminit.sh
@@ -70,4 +70,17 @@ ExecStart=
 ExecStart=/usr/local/bin/kubelet \$KUBELET_KUBECONFIG_ARGS \$KUBELET_CONFIG_ARGS \$KUBELET_KUBEADM_ARGS \$KUBELET_EXTRA_ARGS
 EOF
 
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+sed -i '/swap/d' /etc/fstab
+swapoff -a
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y containerd socat conntrack
+
+PATCH_VERSION=${1#[v]}
+VERSION=${PATCH_VERSION%.*}
+curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${VERSION}.0/crictl-v${VERSION}.0-linux-amd64.tar.gz" | tar -C /usr/local/bin -xz
+cd /usr/local/bin
+curl -L --remote-name-all https://dl.k8s.io/release/$1/bin/linux/amd64/{kubeadm,kubelet}
+curl -LO "https://dl.k8s.io/release/v${VERSION}.0/bin/linux/amd64/kubectl"
+chmod +x {kubeadm,kubelet,kubectl}

--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -11,16 +11,23 @@ spec:
           content: |
             #!/bin/bash
             set -euo pipefail
-            export DEBIAN_FRONTEND=noninteractive
-            mkdir -p -m 755 /etc/apt/keyrings
             PATCH_VERSION=$${1#[v]}
             VERSION=$${PATCH_VERSION%.*}
             curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/869bcdad9cf7daae533023c7869f62683d2a7f47/scripts/add-kubeadm-required-files.sh | bash
-            curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+            export DEBIAN_FRONTEND=noninteractive
             apt-get update -y
-            apt-get install -y kubelet=$PATCH_VERSION* kubeadm=$PATCH_VERSION* kubectl=$PATCH_VERSION* containerd
-            apt-mark hold kubelet kubeadm kubectl containerd
+            apt-get install -y containerd socat conntrack
+
+            DOWNLOAD_DIR="/usr/local/bin"
+            curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$${VERSION}.0/crictl-v$${VERSION}.0-linux-amd64.tar.gz" | tar -C $$DOWNLOAD_DIR -xz
+            cd $${DOWNLOAD_DIR}
+            curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
+            chmod +x {kubeadm,kubelet}
+            curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubelet/kubelet.service | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service
+            mkdir -p /usr/lib/systemd/system/kubelet.service.d
+            curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           permissions: "0500"
       preKubeadmCommands:
         - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -11,23 +11,18 @@ spec:
           content: |
             #!/bin/bash
             set -euo pipefail
-            PATCH_VERSION=$${1#[v]}
-            VERSION=$${PATCH_VERSION%.*}
-            curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/869bcdad9cf7daae533023c7869f62683d2a7f47/scripts/add-kubeadm-required-files.sh | bash
-
             export DEBIAN_FRONTEND=noninteractive
             apt-get update -y
             apt-get install -y containerd socat conntrack
 
+            PATCH_VERSION=$${1#[v]}
+            VERSION=$${PATCH_VERSION%.*}
             DOWNLOAD_DIR="/usr/local/bin"
             curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$${VERSION}.0/crictl-v$${VERSION}.0-linux-amd64.tar.gz" | tar -C $$DOWNLOAD_DIR -xz
             cd $${DOWNLOAD_DIR}
             curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
             chmod +x {kubeadm,kubelet}
-            curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubelet/kubelet.service | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service
-            mkdir -p /usr/lib/systemd/system/kubelet.service.d
-            curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
-            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/788018085cedd6534452feccfbeb942face3339d/scripts/add-kubeadm-required-files.sh | bash
           permissions: "0500"
       preKubeadmCommands:
         - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     spec:
       preKubeadmCommands:
-        - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/f713c596f21e2744d33be633682aff9dfcdc0418/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
+        - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/1981a4934753c10bfe9042c0b24ed4d02392ee0e/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
         - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
       joinConfiguration:
         nodeRegistration:

--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -22,7 +22,7 @@ spec:
             cd $${DOWNLOAD_DIR}
             curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
             chmod +x {kubeadm,kubelet}
-            curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/788018085cedd6534452feccfbeb942face3339d/scripts/add-kubeadm-required-files.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/e54a83afa86b34e08efe09f5de69bc40978942d3/scripts/add-kubeadm-required-files.sh | bash
           permissions: "0500"
       preKubeadmCommands:
         - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -6,28 +6,8 @@ metadata:
 spec:
   template:
     spec:
-      files:
-        - path: /kubeadm-pre-init.sh
-          content: |
-            #!/bin/bash
-            set -euo pipefail
-            export DEBIAN_FRONTEND=noninteractive
-            apt-get update -y
-            apt-get install -y containerd socat conntrack
-
-            PATCH_VERSION=$${1#[v]}
-            VERSION=$${PATCH_VERSION%.*}
-            DOWNLOAD_DIR="/usr/local/bin"
-            curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$${VERSION}.0/crictl-v$${VERSION}.0-linux-amd64.tar.gz" | tar -C $$DOWNLOAD_DIR -xz
-            cd $${DOWNLOAD_DIR}
-            curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
-            chmod +x {kubeadm,kubelet}
-            curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/e54a83afa86b34e08efe09f5de69bc40978942d3/scripts/add-kubeadm-required-files.sh | bash
-          permissions: "0500"
       preKubeadmCommands:
-        - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
-        - sed -i '/swap/d' /etc/fstab
-        - swapoff -a
+        - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/f713c596f21e2744d33be633682aff9dfcdc0418/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
         - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
       joinConfiguration:
         nodeRegistration:

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -16,16 +16,23 @@ spec:
         content: |
           #!/bin/bash
           set -euo pipefail
-          export DEBIAN_FRONTEND=noninteractive
-          mkdir -p -m 755 /etc/apt/keyrings
           PATCH_VERSION=$${1#[v]}
           VERSION=$${PATCH_VERSION%.*}
           curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/869bcdad9cf7daae533023c7869f62683d2a7f47/scripts/add-kubeadm-required-files.sh | bash
-          curl -fsSL "https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/Release.key" | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v$VERSION/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+          export DEBIAN_FRONTEND=noninteractive
           apt-get update -y
-          apt-get install -y kubelet=$PATCH_VERSION* kubeadm=$PATCH_VERSION* kubectl=$PATCH_VERSION* containerd
-          apt-mark hold kubelet kubeadm kubectl containerd
+          apt-get install -y containerd socat conntrack
+
+          DOWNLOAD_DIR="/usr/local/bin"
+          curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$${VERSION}.0/crictl-v$${VERSION}.0-linux-amd64.tar.gz" | tar -C $$DOWNLOAD_DIR -xz
+          cd $${DOWNLOAD_DIR}
+          curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
+          chmod +x {kubeadm,kubelet}
+          curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubelet/kubelet.service | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service
+          mkdir -p /usr/lib/systemd/system/kubelet.service.d
+          curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         permissions: "0500"
     preKubeadmCommands:
       - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -16,23 +16,18 @@ spec:
         content: |
           #!/bin/bash
           set -euo pipefail
-          PATCH_VERSION=$${1#[v]}
-          VERSION=$${PATCH_VERSION%.*}
-          curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/869bcdad9cf7daae533023c7869f62683d2a7f47/scripts/add-kubeadm-required-files.sh | bash
-
           export DEBIAN_FRONTEND=noninteractive
           apt-get update -y
           apt-get install -y containerd socat conntrack
 
+          PATCH_VERSION=$${1#[v]}
+          VERSION=$${PATCH_VERSION%.*}
           DOWNLOAD_DIR="/usr/local/bin"
           curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$${VERSION}.0/crictl-v$${VERSION}.0-linux-amd64.tar.gz" | tar -C $$DOWNLOAD_DIR -xz
           cd $${DOWNLOAD_DIR}
           curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
           chmod +x {kubeadm,kubelet}
-          curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubelet/kubelet.service | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service
-          mkdir -p /usr/lib/systemd/system/kubelet.service.d
-          curl -sSL https://raw.githubusercontent.com/kubernetes/release/v0.16.2/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf | sed "s:/usr/bin:$${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/788018085cedd6534452feccfbeb942face3339d/scripts/add-kubeadm-required-files.sh | bash
         permissions: "0500"
     preKubeadmCommands:
       - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -12,7 +12,7 @@ spec:
       name: ${CLUSTER_NAME}-control-plane
   kubeadmConfigSpec:
     preKubeadmCommands:
-      - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/f713c596f21e2744d33be633682aff9dfcdc0418/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
+      - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/1981a4934753c10bfe9042c0b24ed4d02392ee0e/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
       - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
     clusterConfiguration:
       etcd:

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -27,7 +27,7 @@ spec:
           cd $${DOWNLOAD_DIR}
           curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
           chmod +x {kubeadm,kubelet}
-          curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/788018085cedd6534452feccfbeb942face3339d/scripts/add-kubeadm-required-files.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/e54a83afa86b34e08efe09f5de69bc40978942d3/scripts/add-kubeadm-required-files.sh | bash
         permissions: "0500"
     preKubeadmCommands:
       - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -11,28 +11,8 @@ spec:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
       name: ${CLUSTER_NAME}-control-plane
   kubeadmConfigSpec:
-    files:
-      - path: /kubeadm-pre-init.sh
-        content: |
-          #!/bin/bash
-          set -euo pipefail
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get update -y
-          apt-get install -y containerd socat conntrack
-
-          PATCH_VERSION=$${1#[v]}
-          VERSION=$${PATCH_VERSION%.*}
-          DOWNLOAD_DIR="/usr/local/bin"
-          curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/v$${VERSION}.0/crictl-v$${VERSION}.0-linux-amd64.tar.gz" | tar -C $$DOWNLOAD_DIR -xz
-          cd $${DOWNLOAD_DIR}
-          curl -L --remote-name-all https://dl.k8s.io/release/${KUBERNETES_VERSION}/bin/linux/amd64/{kubeadm,kubelet}
-          chmod +x {kubeadm,kubelet}
-          curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/e54a83afa86b34e08efe09f5de69bc40978942d3/scripts/add-kubeadm-required-files.sh | bash
-        permissions: "0500"
     preKubeadmCommands:
-      - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
-      - sed -i '/swap/d' /etc/fstab
-      - swapoff -a
+      - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/f713c596f21e2744d33be633682aff9dfcdc0418/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
       - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
     clusterConfiguration:
       etcd:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: This switches to installing the kubeadm packages with tar files intead of apt and moves kubeadm setup into a single script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


