### PR TITLE
[bugfix] cannot use kubelet-arg to set node-ip for k3s

### DIFF
--- a/templates/flavors/k3s/dual-stack/kustomization.yaml
+++ b/templates/flavors/k3s/dual-stack/kustomization.yaml
@@ -89,9 +89,7 @@ patches:
         value:
           - |
             mkdir -p /etc/rancher/k3s/config.yaml.d/
-            echo -n "kubelet-arg: \"--node-ip=" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo -n "$(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo ",$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')\"" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
+            echo "node-ip: $(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168'),$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
           - sed -i '/swap/d' /etc/fstab
           - swapoff -a
           - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
@@ -105,9 +103,7 @@ patches:
         value:
           - |
             mkdir -p /etc/rancher/k3s/config.yaml.d/
-            echo -n "kubelet-arg: \"--node-ip=" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo -n "$(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo ",$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')\"" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
+            echo "node-ip: $(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168'),$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
           - sed -i '/swap/d' /etc/fstab
           - swapoff -a
           - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname

--- a/templates/flavors/k3s/full-vpcless/kustomization.yaml
+++ b/templates/flavors/k3s/full-vpcless/kustomization.yaml
@@ -145,9 +145,7 @@ patches:
         value:
           - |
             mkdir -p /etc/rancher/k3s/config.yaml.d/
-            echo -n "kubelet-arg: \"--node-ip=" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo -n "$(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo ",$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')\"" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
+            echo "node-ip: $(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168'),$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
           - sed -i '/swap/d' /etc/fstab
           - swapoff -a
           - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
@@ -161,9 +159,7 @@ patches:
         value:
           - |
             mkdir -p /etc/rancher/k3s/config.yaml.d/
-            echo -n "kubelet-arg: \"--node-ip=" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo -n "$(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
-            echo ",$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')\"" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
+            echo "node-ip: $(ip a s eth0 |grep -E 'inet '  |cut -d' ' -f6|cut -d/ -f1 | grep -E '192.168'),$(ip a s eth0 |grep -E 'inet6 '  |cut -d' ' -f6|cut -d/ -f1 | grep -vE 'fe80')" >> /etc/rancher/k3s/config.yaml.d/capi-config.yaml
           - sed -i '/swap/d' /etc/fstab
           - swapoff -a
           - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: In VPC-less environments we need to manually set the node-ip until the CCM can take over. This cannot be done with `kubelet-arg` since that prevents the nodes from getting the externalIP set from the CCM. Instead, this uses `node-ip` like before, but includes the ipv6 address needed for k3s not to complain about a dual-stack cluster-cidr but an ipv4-only `node-ip`.

With this change for k3s-dual-stack:
```
(⎈|test-cluster-admin@test-cluster:N/A) ~  k get no -o wide
NAME                               STATUS   ROLES                       AGE   VERSION        INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
test-cluster-control-plane-pwwg8   Ready    control-plane,etcd,master   88s   v1.29.1+k3s2   <none>        <none>        Ubuntu 22.04.4 LTS   5.15.0-94-generic   containerd://1.7.11-k3s2
(⎈|test-cluster-admin@test-cluster:N/A) ~  k get no -o wide
NAME                               STATUS   ROLES                       AGE   VERSION        INTERNAL-IP      EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
test-cluster-control-plane-pwwg8   Ready    control-plane,etcd,master   90s   v1.29.1+k3s2   192.168.XX.XX   172.232.XX.XXX   Ubuntu 22.04.4 LTS   5.15.0-94-generic   containerd://1.7.11-k3s2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


