### PR TITLE
[fix] set default value for dns token to be the linode api token

### DIFF
--- a/config/default/linode-token-secret.yaml
+++ b/config/default/linode-token-secret.yaml
@@ -5,4 +5,4 @@ metadata:
   name: manager-credentials
 stringData:
   apiToken: ${LINODE_TOKEN}
-  dnsToken: ${LINODE_DNS_TOKEN}
+  dnsToken: ${LINODE_DNS_TOKEN:=${LINODE_TOKEN}}

--- a/templates/infra/secret.yaml
+++ b/templates/infra/secret.yaml
@@ -7,4 +7,4 @@ metadata:
     clusterctl.cluster.x-k8s.io/move: "true"
 stringData:
   apiToken: ${LINODE_TOKEN}
-  dnsToken: ${LINODE_DNS_TOKEN:-""}
+  dnsToken: ${LINODE_DNS_TOKEN:=${LINODE_TOKEN}}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
If LINODE_DNS_TOKEN is not set in the env, we see
```
clusterctl init --infrastructure linode-linode --addon helm  --bootstrap k3s --control-plane k3s 
Fetching providers
Error: failed to get provider components for the "linode-linode" provider: failed to perform variable substitution: value for variables [LINODE_DNS_TOKEN] is not set. Please set the value using os environment variables or the clusterctl config file
```
This fix defaults the LINODE_DNS_TOKEN in controller secret to LINODE_TOKEN if not set in the env

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


