### PR TITLE
[feat] Add ipv6 support for dns loadbalancing

### DIFF
--- a/templates/flavors/kubeadm/dual-stack-dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/kubeadm/dual-stack-dns-loadbalancing/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../dual-stack
+
+patches:
+  - target:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1alpha2
+      kind: LinodeCluster
+    patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeCluster
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        network:
+          loadBalancerType: dns
+          dnsRootDomain: ${DNS_ROOT_DOMAIN}
+          dnsUniqueIdentifier: ${DNS_UNIQUE_ID}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Adds ipv6 support for dns loadbalancing by taking the SLAAC IPv6 of each CP machine and adds it to the DNS record


