### PR TITLE
[fix] : fix konnectivity installs as we are now installing packages from tar files

### DIFF
--- a/templates/flavors/kubeadm/konnectivity/kustomization.yaml
+++ b/templates/flavors/kubeadm/konnectivity/kustomization.yaml
@@ -18,9 +18,7 @@ patches:
       spec:
         kubeadmConfigSpec:
           preKubeadmCommands:
-            - /kubeadm-pre-init.sh ${KUBERNETES_VERSION}
-            - sed -i '/swap/d' /etc/fstab
-            - swapoff -a
+            - curl -fsSL https://raw.githubusercontent.com/linode/cluster-api-provider-linode/1981a4934753c10bfe9042c0b24ed4d02392ee0e/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}
             - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
             - mkdir -p -m 755 /etc/kubernetes/konnectivity
             - curl -s -L https://raw.githubusercontent.com/linode/konnectivity/876b00f976975833929723ad9e247d0c124124bd/config/egress-selector-configuration.yaml > /etc/kubernetes/konnectivity/egress-selector-configuration.yaml


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We moved away from apt and started installing packages from tar files in PR https://github.com/linode/cluster-api-provider-linode/pull/366. We missed doing that change for konnectivity and its broken because of it. This PR fixes installs for kubeadm-konnectivity flavor.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


