### PR TITLE
[fix] add support for filling in controlPlaneEndpoint if only network info is specified

### DIFF
--- a/clients/clients.go
+++ b/clients/clients.go
@@ -50,6 +50,8 @@ type LinodeVPCClient interface {
 type LinodeNodeBalancerClient interface {
 	ListNodeBalancers(ctx context.Context, opts *linodego.ListOptions) ([]linodego.NodeBalancer, error)
 	CreateNodeBalancer(ctx context.Context, opts linodego.NodeBalancerCreateOptions) (*linodego.NodeBalancer, error)
+	GetNodeBalancer(ctx context.Context, nodebalancerID int) (*linodego.NodeBalancer, error)
+	GetNodeBalancerConfig(ctx context.Context, nodebalancerID int, configID int) (*linodego.NodeBalancerConfig, error)
 	CreateNodeBalancerConfig(ctx context.Context, nodebalancerID int, opts linodego.NodeBalancerConfigCreateOptions) (*linodego.NodeBalancerConfig, error)
 	DeleteNodeBalancerNode(ctx context.Context, nodebalancerID int, configID int, nodeID int) error
 	DeleteNodeBalancer(ctx context.Context, nodebalancerID int) error

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -48,7 +48,6 @@ type LinodeVPCClient interface {
 
 // LinodeNodeBalancerClient defines the methods that interact with Linode's Node Balancer service.
 type LinodeNodeBalancerClient interface {
-	ListNodeBalancers(ctx context.Context, opts *linodego.ListOptions) ([]linodego.NodeBalancer, error)
 	CreateNodeBalancer(ctx context.Context, opts linodego.NodeBalancerCreateOptions) (*linodego.NodeBalancer, error)
 	GetNodeBalancer(ctx context.Context, nodebalancerID int) (*linodego.NodeBalancer, error)
 	GetNodeBalancerConfig(ctx context.Context, nodebalancerID int, configID int) (*linodego.NodeBalancerConfig, error)

--- a/mock/client.go
+++ b/mock/client.go
@@ -517,21 +517,6 @@ func (mr *MockLinodeClientMockRecorder) ListInstances(ctx, opts any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstances", reflect.TypeOf((*MockLinodeClient)(nil).ListInstances), ctx, opts)
 }
 
-// ListNodeBalancers mocks base method.
-func (m *MockLinodeClient) ListNodeBalancers(ctx context.Context, opts *linodego.ListOptions) ([]linodego.NodeBalancer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodeBalancers", ctx, opts)
-	ret0, _ := ret[0].([]linodego.NodeBalancer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodeBalancers indicates an expected call of ListNodeBalancers.
-func (mr *MockLinodeClientMockRecorder) ListNodeBalancers(ctx, opts any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeBalancers", reflect.TypeOf((*MockLinodeClient)(nil).ListNodeBalancers), ctx, opts)
-}
-
 // ListStackscripts mocks base method.
 func (m *MockLinodeClient) ListStackscripts(ctx context.Context, opts *linodego.ListOptions) ([]linodego.Stackscript, error) {
 	m.ctrl.T.Helper()
@@ -1072,21 +1057,6 @@ func (m *MockLinodeNodeBalancerClient) GetNodeBalancerConfig(ctx context.Context
 func (mr *MockLinodeNodeBalancerClientMockRecorder) GetNodeBalancerConfig(ctx, nodebalancerID, configID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBalancerConfig", reflect.TypeOf((*MockLinodeNodeBalancerClient)(nil).GetNodeBalancerConfig), ctx, nodebalancerID, configID)
-}
-
-// ListNodeBalancers mocks base method.
-func (m *MockLinodeNodeBalancerClient) ListNodeBalancers(ctx context.Context, opts *linodego.ListOptions) ([]linodego.NodeBalancer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodeBalancers", ctx, opts)
-	ret0, _ := ret[0].([]linodego.NodeBalancer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodeBalancers indicates an expected call of ListNodeBalancers.
-func (mr *MockLinodeNodeBalancerClientMockRecorder) ListNodeBalancers(ctx, opts any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeBalancers", reflect.TypeOf((*MockLinodeNodeBalancerClient)(nil).ListNodeBalancers), ctx, opts)
 }
 
 // MockLinodeObjectStorageClient is a mock of LinodeObjectStorageClient interface.

--- a/mock/client.go
+++ b/mock/client.go
@@ -352,6 +352,36 @@ func (mr *MockLinodeClientMockRecorder) GetInstanceIPAddresses(ctx, linodeID any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceIPAddresses", reflect.TypeOf((*MockLinodeClient)(nil).GetInstanceIPAddresses), ctx, linodeID)
 }
 
+// GetNodeBalancer mocks base method.
+func (m *MockLinodeClient) GetNodeBalancer(ctx context.Context, nodebalancerID int) (*linodego.NodeBalancer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeBalancer", ctx, nodebalancerID)
+	ret0, _ := ret[0].(*linodego.NodeBalancer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeBalancer indicates an expected call of GetNodeBalancer.
+func (mr *MockLinodeClientMockRecorder) GetNodeBalancer(ctx, nodebalancerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBalancer", reflect.TypeOf((*MockLinodeClient)(nil).GetNodeBalancer), ctx, nodebalancerID)
+}
+
+// GetNodeBalancerConfig mocks base method.
+func (m *MockLinodeClient) GetNodeBalancerConfig(ctx context.Context, nodebalancerID, configID int) (*linodego.NodeBalancerConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeBalancerConfig", ctx, nodebalancerID, configID)
+	ret0, _ := ret[0].(*linodego.NodeBalancerConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeBalancerConfig indicates an expected call of GetNodeBalancerConfig.
+func (mr *MockLinodeClientMockRecorder) GetNodeBalancerConfig(ctx, nodebalancerID, configID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBalancerConfig", reflect.TypeOf((*MockLinodeClient)(nil).GetNodeBalancerConfig), ctx, nodebalancerID, configID)
+}
+
 // GetObjectStorageBucket mocks base method.
 func (m *MockLinodeClient) GetObjectStorageBucket(ctx context.Context, cluster, label string) (*linodego.ObjectStorageBucket, error) {
 	m.ctrl.T.Helper()
@@ -1012,6 +1042,36 @@ func (m *MockLinodeNodeBalancerClient) DeleteNodeBalancerNode(ctx context.Contex
 func (mr *MockLinodeNodeBalancerClientMockRecorder) DeleteNodeBalancerNode(ctx, nodebalancerID, configID, nodeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeBalancerNode", reflect.TypeOf((*MockLinodeNodeBalancerClient)(nil).DeleteNodeBalancerNode), ctx, nodebalancerID, configID, nodeID)
+}
+
+// GetNodeBalancer mocks base method.
+func (m *MockLinodeNodeBalancerClient) GetNodeBalancer(ctx context.Context, nodebalancerID int) (*linodego.NodeBalancer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeBalancer", ctx, nodebalancerID)
+	ret0, _ := ret[0].(*linodego.NodeBalancer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeBalancer indicates an expected call of GetNodeBalancer.
+func (mr *MockLinodeNodeBalancerClientMockRecorder) GetNodeBalancer(ctx, nodebalancerID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBalancer", reflect.TypeOf((*MockLinodeNodeBalancerClient)(nil).GetNodeBalancer), ctx, nodebalancerID)
+}
+
+// GetNodeBalancerConfig mocks base method.
+func (m *MockLinodeNodeBalancerClient) GetNodeBalancerConfig(ctx context.Context, nodebalancerID, configID int) (*linodego.NodeBalancerConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeBalancerConfig", ctx, nodebalancerID, configID)
+	ret0, _ := ret[0].(*linodego.NodeBalancerConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeBalancerConfig indicates an expected call of GetNodeBalancerConfig.
+func (mr *MockLinodeNodeBalancerClientMockRecorder) GetNodeBalancerConfig(ctx, nodebalancerID, configID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBalancerConfig", reflect.TypeOf((*MockLinodeNodeBalancerClient)(nil).GetNodeBalancerConfig), ctx, nodebalancerID, configID)
 }
 
 // ListNodeBalancers mocks base method.

--- a/observability/wrappers/linodeclient/linodeclient.gen.go
+++ b/observability/wrappers/linodeclient/linodeclient.gen.go
@@ -521,6 +521,53 @@ func (_d LinodeClientWithTracing) GetInstanceIPAddresses(ctx context.Context, li
 	return _d.LinodeClient.GetInstanceIPAddresses(ctx, linodeID)
 }
 
+// GetNodeBalancer implements clients.LinodeClient
+func (_d LinodeClientWithTracing) GetNodeBalancer(ctx context.Context, nodebalancerID int) (np1 *linodego.NodeBalancer, err error) {
+	ctx, _span := tracing.Start(ctx, "clients.LinodeClient.GetNodeBalancer")
+	defer func() {
+		if _d._spanDecorator != nil {
+			_d._spanDecorator(_span, map[string]interface{}{
+				"ctx":            ctx,
+				"nodebalancerID": nodebalancerID}, map[string]interface{}{
+				"np1": np1,
+				"err": err})
+		} else if err != nil {
+			_span.RecordError(err)
+			_span.SetAttributes(
+				attribute.String("event", "error"),
+				attribute.String("message", err.Error()),
+			)
+		}
+
+		_span.End()
+	}()
+	return _d.LinodeClient.GetNodeBalancer(ctx, nodebalancerID)
+}
+
+// GetNodeBalancerConfig implements clients.LinodeClient
+func (_d LinodeClientWithTracing) GetNodeBalancerConfig(ctx context.Context, nodebalancerID int, configID int) (np1 *linodego.NodeBalancerConfig, err error) {
+	ctx, _span := tracing.Start(ctx, "clients.LinodeClient.GetNodeBalancerConfig")
+	defer func() {
+		if _d._spanDecorator != nil {
+			_d._spanDecorator(_span, map[string]interface{}{
+				"ctx":            ctx,
+				"nodebalancerID": nodebalancerID,
+				"configID":       configID}, map[string]interface{}{
+				"np1": np1,
+				"err": err})
+		} else if err != nil {
+			_span.RecordError(err)
+			_span.SetAttributes(
+				attribute.String("event", "error"),
+				attribute.String("message", err.Error()),
+			)
+		}
+
+		_span.End()
+	}()
+	return _d.LinodeClient.GetNodeBalancerConfig(ctx, nodebalancerID, configID)
+}
+
 // GetObjectStorageBucket implements clients.LinodeClient
 func (_d LinodeClientWithTracing) GetObjectStorageBucket(ctx context.Context, cluster string, label string) (op1 *linodego.ObjectStorageBucket, err error) {
 	ctx, _span := tracing.Start(ctx, "clients.LinodeClient.GetObjectStorageBucket")

--- a/observability/wrappers/linodeclient/linodeclient.gen.go
+++ b/observability/wrappers/linodeclient/linodeclient.gen.go
@@ -778,29 +778,6 @@ func (_d LinodeClientWithTracing) ListInstances(ctx context.Context, opts *linod
 	return _d.LinodeClient.ListInstances(ctx, opts)
 }
 
-// ListNodeBalancers implements clients.LinodeClient
-func (_d LinodeClientWithTracing) ListNodeBalancers(ctx context.Context, opts *linodego.ListOptions) (na1 []linodego.NodeBalancer, err error) {
-	ctx, _span := tracing.Start(ctx, "clients.LinodeClient.ListNodeBalancers")
-	defer func() {
-		if _d._spanDecorator != nil {
-			_d._spanDecorator(_span, map[string]interface{}{
-				"ctx":  ctx,
-				"opts": opts}, map[string]interface{}{
-				"na1": na1,
-				"err": err})
-		} else if err != nil {
-			_span.RecordError(err)
-			_span.SetAttributes(
-				attribute.String("event", "error"),
-				attribute.String("message", err.Error()),
-			)
-		}
-
-		_span.End()
-	}()
-	return _d.LinodeClient.ListNodeBalancers(ctx, opts)
-}
-
 // ListStackscripts implements clients.LinodeClient
 func (_d LinodeClientWithTracing) ListStackscripts(ctx context.Context, opts *linodego.ListOptions) (sa1 []linodego.Stackscript, err error) {
 	ctx, _span := tracing.Start(ctx, "clients.LinodeClient.ListStackscripts")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: Currently if a `LinodeCluster` resource is created and the nodebalancer ID/nodebalancer Config ID is specified but not the control-plane endpoint CAPL cannot handle this case, e.g.:
```
spec:
  controlPlaneEndpoint:
    host: ""
    port: 0
  network:
    nodeBalancerConfigID: 12345
    nodeBalancerID: 67890
  region: us-ord 
```
This instead gets the NB and NB config ID if specified and uses those to fill out the controlPlaneEndpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


