### PR TITLE
fix: increase upsert timeout to 120 seconds

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,7 +2,7 @@ load("ext://k8s_attach", "k8s_attach")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 load("ext://namespace", "namespace_create")
 load("ext://restart_process", "docker_build_with_restart")
-update_settings(k8s_upsert_timeout_secs=60)
+update_settings(k8s_upsert_timeout_secs=120)
 
 helm_repo(
     "capi-operator-repo",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Deploying prometheus using Tilt sometimes take more than 60 seconds. In my case, it usually took 90 seconds.
```
   prometheus │      NAME: prometheus
   prometheus │      LAST DEPLOYED: Fri Jun 21 01:53:59 2024
   prometheus │      NAMESPACE: monitoring
   prometheus │      STATUS: deployed
   prometheus │      REVISION: 1
   prometheus │      NOTES:
   prometheus │      kube-prometheus-stack has been installed. Check its status by running:
   prometheus │        kubectl --namespace monitoring get pods -l "release=prometheus"
   prometheus │
   prometheus │      Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
   prometheus │      Running cmd: ['helm', 'get', 'manifest', '--namespace', 'monitoring', 'prometheus']
   prometheus │      Running cmd: ['kubectl', 'get', '-oyaml', '-f', '-']


   prometheus │      Objects applied to cluster:
   prometheus │        → grafana:serviceaccount
   prometheus │        → kube-state-metrics:serviceaccount
   prometheus │        → prometheus-operator:serviceaccount
   prometheus │        → prometheus-prometheus:serviceaccount
   prometheus │        → grafana:secret
   prometheus │        → prometheus-prometheus-scrape-confg:secret
   prometheus │        → grafana-config-dashboards:configmap
   prometheus │        → grafana:configmap
   prometheus │        → prometheus-grafana-datasource:configmap
   prometheus │        → grafana-clusterrole:clusterrole
   prometheus │        → kube-state-metrics:clusterrole
   prometheus │        → prometheus-operator:clusterrole
   prometheus │        → prometheus-prometheus:clusterrole
   prometheus │        → grafana-clusterrolebinding:clusterrolebinding
   prometheus │        → kube-state-metrics:clusterrolebinding
   prometheus │        → prometheus-operator:clusterrolebinding
   prometheus │        → prometheus-prometheus:clusterrolebinding
   prometheus │        → grafana:role
   prometheus │        → grafana:rolebinding
   prometheus │        → grafana:service
   prometheus │        → kube-state-metrics:service
   prometheus │        → prometheus-operator:service
   prometheus │        → prometheus-prometheus:service
   prometheus │        → grafana:deployment
   prometheus │        → kube-state-metrics:deployment
   prometheus │        → prometheus-operator:deployment
   prometheus │        → prometheus-admission:mutatingwebhookconfiguration
   prometheus │        → prometheus-prometheus:prometheus
   prometheus │        → prometheus-alertmanager.rules:prometheusrule
   prometheus │        → prometheus-config-reloaders:prometheusrule
   prometheus │        → prometheus-general.rules:prometheusrule
   prometheus │        → prometheus-k8s.rules.container-cpu-usage-seconds-total:prometheusrule
   prometheus │        → prometheus-k8s.rules.container-memory-cache:prometheusrule
   prometheus │        → prometheus-k8s.rules.container-memory-rss:prometheusrule
   prometheus │        → prometheus-k8s.rules.container-memory-swap:prometheusrule
   prometheus │        → prometheus-k8s.rules.container-memory-working-set-bytes:prometheusrule
   prometheus │        → prometheus-k8s.rules.container-resource:prometheusrule
   prometheus │        → prometheus-k8s.rules.pod-owner:prometheusrule
   prometheus │        → prometheus-kube-apiserver-availability.rules:prometheusrule
   prometheus │        → prometheus-kube-apiserver-burnrate.rules:prometheusrule
   prometheus │        → prometheus-kube-apiserver-histogram.rules:prometheusrule
   prometheus │        → prometheus-kube-apiserver-slos:prometheusrule
   prometheus │        → prometheus-kube-prometheus-general.rules:prometheusrule
   prometheus │        → prometheus-kube-prometheus-node-recording.rules:prometheusrule
   prometheus │        → prometheus-kube-state-metrics:prometheusrule
   prometheus │        → prometheus-kubernetes-apps:prometheusrule
   prometheus │        → prometheus-kubernetes-resources:prometheusrule
   prometheus │        → prometheus-kubernetes-storage:prometheusrule
   prometheus │        → prometheus-kubernetes-system-apiserver:prometheusrule
   prometheus │        → prometheus-kubernetes-system-kubelet:prometheusrule
   prometheus │        → prometheus-kubernetes-system:prometheusrule
   prometheus │        → prometheus-node-exporter.rules:prometheusrule
   prometheus │        → prometheus-node-exporter:prometheusrule
   prometheus │        → prometheus-node-network:prometheusrule
   prometheus │        → prometheus-node.rules:prometheusrule
   prometheus │        → prometheus-prometheus-operator:prometheusrule
   prometheus │        → prometheus-prometheus:prometheusrule
   prometheus │        → grafana:servicemonitor
   prometheus │        → kube-state-metrics:servicemonitor
   prometheus │        → prometheus-apiserver:servicemonitor
   prometheus │        → prometheus-operator:servicemonitor
   prometheus │        → prometheus-prometheus:servicemonitor
   prometheus │        → prometheus-admission:validatingwebhookconfiguration
   prometheus │
   prometheus │      Step 1 - 9.42s (Force update)
   prometheus │      Step 2 - 82.31s (Deploying)
   prometheus │      DONE IN: 91.73s
   prometheus │
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


