### PR TITLE
[feat] Support usage of separate Linode API for the domain client

### DIFF
--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -50,7 +50,7 @@ func validateClusterScopeParams(params ClusterScopeParams) error {
 
 // NewClusterScope creates a new Scope from the supplied parameters.
 // This is meant to be called for each reconcile iteration.
-func NewClusterScope(ctx context.Context, apiKey string, params ClusterScopeParams) (*ClusterScope, error) {
+func NewClusterScope(ctx context.Context, linodeClientConfig ClientConfig, params ClusterScopeParams) (*ClusterScope, error) {
 	if err := validateClusterScopeParams(params); err != nil {
 		return nil, err
 	}
@@ -62,9 +62,9 @@ func NewClusterScope(ctx context.Context, apiKey string, params ClusterScopePara
 		if err != nil {
 			return nil, fmt.Errorf("credentials from secret ref: %w", err)
 		}
-		apiKey = string(apiToken)
+		linodeClientConfig.Token = string(apiToken)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout)
+	linodeClient, err := CreateLinodeClient(linodeClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}

--- a/cloud/scope/cluster_test.go
+++ b/cloud/scope/cluster_test.go
@@ -157,7 +157,7 @@ func TestClusterScopeMethods(t *testing.T) {
 
 			cScope, err := NewClusterScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				ClusterScopeParams{
 					Cluster:       testcase.fields.Cluster,
 					LinodeCluster: testcase.fields.LinodeCluster,
@@ -297,7 +297,7 @@ func TestNewClusterScope(t *testing.T) {
 					LinodeCluster: &infrav1alpha2.LinodeCluster{},
 				},
 			},
-			expectedError: fmt.Errorf("failed to create linode client: missing Linode API key"),
+			expectedError: fmt.Errorf("failed to create linode client: token cannot be empty"),
 			expects:       func(mock *mock.MockK8sClient) {},
 		},
 	}
@@ -316,7 +316,7 @@ func TestNewClusterScope(t *testing.T) {
 
 			testcase.args.params.Client = mockK8sClient
 
-			got, err := NewClusterScope(context.Background(), testcase.args.apiKey, testcase.args.params)
+			got, err := NewClusterScope(context.Background(), ClientConfig{Token: testcase.args.apiKey}, testcase.args.params)
 
 			if testcase.expectedError != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())
@@ -411,7 +411,7 @@ func TestClusterAddCredentialsRefFinalizer(t *testing.T) {
 
 			cScope, err := NewClusterScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				ClusterScopeParams{
 					Cluster:       testcase.fields.Cluster,
 					LinodeCluster: testcase.fields.LinodeCluster,
@@ -512,7 +512,7 @@ func TestRemoveCredentialsRefFinalizer(t *testing.T) {
 
 			cScope, err := NewClusterScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				ClusterScopeParams{
 					Cluster:       testcase.fields.Cluster,
 					LinodeCluster: testcase.fields.LinodeCluster,

--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v8/pkg/edgegrid"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v8/pkg/session"
 	"github.com/linode/linodego"
-	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -49,16 +47,8 @@ func CreateLinodeClient(apiKey string, timeout time.Duration, opts ...Option) (L
 		return nil, errors.New("missing Linode API key")
 	}
 
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiKey})
-
-	oauth2Client := &http.Client{
-		Transport: &oauth2.Transport{
-			Source: tokenSource,
-		},
-		Timeout: timeout,
-	}
-	linodeClient := linodego.NewClient(oauth2Client)
-
+	linodeClient := linodego.NewClient(nil)
+	linodeClient.SetToken(apiKey)
 	linodeClient.SetUserAgent(fmt.Sprintf("CAPL/%s", version.GetVersion()))
 
 	for _, opt := range opts {

--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -47,16 +47,16 @@ func CreateLinodeClient(apiKey string, timeout time.Duration, opts ...Option) (L
 		return nil, errors.New("missing Linode API key")
 	}
 
-	linodeClient := linodego.NewClient(nil)
-	linodeClient.SetToken(apiKey)
-	linodeClient.SetUserAgent(fmt.Sprintf("CAPL/%s", version.GetVersion()))
+	newClient := linodego.NewClient(nil)
+	newClient.SetToken(apiKey)
+	newClient.SetUserAgent(fmt.Sprintf("CAPL/%s", version.GetVersion()))
 
 	for _, opt := range opts {
-		opt.set(&linodeClient)
+		opt.set(&newClient)
 	}
 
 	return linodeclient.NewLinodeClientWithTracing(
-		&linodeClient,
+		&newClient,
 		linodeclient.DefaultDecorator(),
 	), nil
 }

--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -47,7 +48,11 @@ func CreateLinodeClient(apiKey string, timeout time.Duration, opts ...Option) (L
 		return nil, errors.New("missing Linode API key")
 	}
 
-	newClient := linodego.NewClient(nil)
+	httpClient := &http.Client{
+		Timeout: timeout,
+	}
+
+	newClient := linodego.NewClient(httpClient)
 	newClient.SetToken(apiKey)
 	newClient.SetUserAgent(fmt.Sprintf("CAPL/%s", version.GetVersion()))
 

--- a/cloud/scope/common_test.go
+++ b/cloud/scope/common_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -22,19 +23,28 @@ func TestCreateLinodeClient(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		apiKey      string
-		expectedErr error
+		name                string
+		token               string
+		baseUrl             string
+		rootCertificatePath string
+		timeout             time.Duration
+		expectedErr         error
 	}{
 		{
-			"Success - Valid API Key",
+			"Success - Valid API token",
 			"test-key",
+			"",
+			"",
+			0,
 			nil,
 		},
 		{
-			"Error - Empty API Key",
+			"Error - Empty API token",
 			"",
-			errors.New("missing Linode API key"),
+			"",
+			"",
+			0,
+			errors.New("token cannot be empty"),
 		},
 	}
 
@@ -42,9 +52,13 @@ func TestCreateLinodeClient(t *testing.T) {
 		testCase := tt
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-
-			got, err := CreateLinodeClient(testCase.apiKey, defaultClientTimeout)
-
+			clientConfig := ClientConfig{
+				Token:               testCase.token,
+				Timeout:             testCase.timeout,
+				BaseUrl:             testCase.baseUrl,
+				RootCertificatePath: testCase.rootCertificatePath,
+			}
+			got, err := CreateLinodeClient(clientConfig)
 			if testCase.expectedErr != nil {
 				assert.EqualError(t, err, testCase.expectedErr.Error())
 			} else {

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -53,7 +53,7 @@ func validateMachineScopeParams(params MachineScopeParams) error {
 	return nil
 }
 
-func NewMachineScope(ctx context.Context, apiKey, dnsKey, dnsUrl, dnsCa string, params MachineScopeParams) (*MachineScope, error) {
+func NewMachineScope(ctx context.Context, linodeClientConfig, dnsClientConfig ClientConfig, params MachineScopeParams) (*MachineScope, error) {
 	if err := validateMachineScopeParams(params); err != nil {
 		return nil, err
 	}
@@ -84,23 +84,23 @@ func NewMachineScope(ctx context.Context, apiKey, dnsKey, dnsUrl, dnsCa string, 
 		if err != nil {
 			return nil, fmt.Errorf("credentials from secret ref: %w", err)
 		}
-		apiKey = string(apiToken)
+		linodeClientConfig.Token = string(apiToken)
 
 		dnsToken, err := getCredentialDataFromRef(ctx, params.Client, *credentialRef, defaultNamespace, "dnsToken")
 		if err != nil || len(dnsToken) == 0 {
 			dnsToken = apiToken
 		}
-		dnsKey = string(dnsToken)
+		dnsClientConfig.Token = string(dnsToken)
 	}
 
-	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout,
+	linodeClient, err := CreateLinodeClient(linodeClientConfig,
 		WithRetryCount(0),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}
-	linodeDomainsClient, err := CreateLinodeClient(dnsKey, defaultClientTimeout,
-		WithRetryCount(0), WithBaseUrl(dnsUrl), WithRootCertificate(dnsCa),
+	linodeDomainsClient, err := CreateLinodeClient(dnsClientConfig,
+		WithRetryCount(0),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)

--- a/cloud/scope/machine.go
+++ b/cloud/scope/machine.go
@@ -53,7 +53,7 @@ func validateMachineScopeParams(params MachineScopeParams) error {
 	return nil
 }
 
-func NewMachineScope(ctx context.Context, apiKey, dnsKey string, params MachineScopeParams) (*MachineScope, error) {
+func NewMachineScope(ctx context.Context, apiKey, dnsKey, dnsUrl, dnsCa string, params MachineScopeParams) (*MachineScope, error) {
 	if err := validateMachineScopeParams(params); err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func NewMachineScope(ctx context.Context, apiKey, dnsKey string, params MachineS
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}
 	linodeDomainsClient, err := CreateLinodeClient(dnsKey, defaultClientTimeout,
-		WithRetryCount(0),
+		WithRetryCount(0), WithBaseUrl(dnsUrl), WithRootCertificate(dnsCa),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)

--- a/cloud/scope/machine_test.go
+++ b/cloud/scope/machine_test.go
@@ -130,17 +130,19 @@ func TestMachineScopeAddFinalizer(t *testing.T) {
 				})
 			})),
 			Path(Result("has finalizer", func(ctx context.Context, mck Mock) {
-				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{
-					Client:        mck.K8sClient,
-					Cluster:       &clusterv1.Cluster{},
-					Machine:       &clusterv1.Machine{},
-					LinodeCluster: &infrav1alpha2.LinodeCluster{},
-					LinodeMachine: &infrav1alpha2.LinodeMachine{
-						ObjectMeta: metav1.ObjectMeta{
-							Finalizers: []string{infrav1alpha2.MachineFinalizer},
+				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath",
+					MachineScopeParams{
+						Client:        mck.K8sClient,
+						Cluster:       &clusterv1.Cluster{},
+						Machine:       &clusterv1.Machine{},
+						LinodeCluster: &infrav1alpha2.LinodeCluster{},
+						LinodeMachine: &infrav1alpha2.LinodeMachine{
+							ObjectMeta: metav1.ObjectMeta{
+								Finalizers: []string{infrav1alpha2.MachineFinalizer},
+							},
 						},
 					},
-				})
+				)
 				require.NoError(t, err)
 				assert.NoError(t, mScope.AddFinalizer(ctx))
 				require.Len(t, mScope.LinodeMachine.Finalizers, 1)
@@ -153,13 +155,14 @@ func TestMachineScopeAddFinalizer(t *testing.T) {
 					mck.K8sClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil)
 				}),
 				Result("finalizer added", func(ctx context.Context, mck Mock) {
-					mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{
-						Client:        mck.K8sClient,
-						Cluster:       &clusterv1.Cluster{},
-						Machine:       &clusterv1.Machine{},
-						LinodeCluster: &infrav1alpha2.LinodeCluster{},
-						LinodeMachine: &infrav1alpha2.LinodeMachine{},
-					})
+					mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath",
+						MachineScopeParams{
+							Client:        mck.K8sClient,
+							Cluster:       &clusterv1.Cluster{},
+							Machine:       &clusterv1.Machine{},
+							LinodeCluster: &infrav1alpha2.LinodeCluster{},
+							LinodeMachine: &infrav1alpha2.LinodeMachine{},
+						})
 					require.NoError(t, err)
 					assert.NoError(t, mScope.AddFinalizer(ctx))
 					require.Len(t, mScope.LinodeMachine.Finalizers, 1)
@@ -171,13 +174,14 @@ func TestMachineScopeAddFinalizer(t *testing.T) {
 					mck.K8sClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(errors.New("fail"))
 				}),
 				Result("error", func(ctx context.Context, mck Mock) {
-					mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{
-						Client:        mck.K8sClient,
-						Cluster:       &clusterv1.Cluster{},
-						Machine:       &clusterv1.Machine{},
-						LinodeCluster: &infrav1alpha2.LinodeCluster{},
-						LinodeMachine: &infrav1alpha2.LinodeMachine{},
-					})
+					mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath",
+						MachineScopeParams{
+							Client:        mck.K8sClient,
+							Cluster:       &clusterv1.Cluster{},
+							Machine:       &clusterv1.Machine{},
+							LinodeCluster: &infrav1alpha2.LinodeCluster{},
+							LinodeMachine: &infrav1alpha2.LinodeMachine{},
+						})
 					require.NoError(t, err)
 
 					assert.Error(t, mScope.AddFinalizer(ctx))
@@ -193,12 +197,12 @@ func TestNewMachineScope(t *testing.T) {
 	NewSuite(t, mock.MockK8sClient{}).Run(
 		OneOf(
 			Path(Result("invalid params", func(ctx context.Context, mck Mock) {
-				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{})
+				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath", MachineScopeParams{})
 				require.ErrorContains(t, err, "is required")
 				assert.Nil(t, mScope)
 			})),
 			Path(Result("no token", func(ctx context.Context, mck Mock) {
-				mScope, err := NewMachineScope(ctx, "", "", MachineScopeParams{
+				mScope, err := NewMachineScope(ctx, "", "", "dnsUrl", "dnsCaPath", MachineScopeParams{
 					Client:        mck.K8sClient,
 					Cluster:       &clusterv1.Cluster{},
 					Machine:       &clusterv1.Machine{},
@@ -213,7 +217,7 @@ func TestNewMachineScope(t *testing.T) {
 					mck.K8sClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "example"))
 				}),
 				Result("error", func(ctx context.Context, mck Mock) {
-					mScope, err := NewMachineScope(ctx, "", "", MachineScopeParams{
+					mScope, err := NewMachineScope(ctx, "", "", "dnsUrl", "dnsCaPath", MachineScopeParams{
 						Client:        mck.K8sClient,
 						Cluster:       &clusterv1.Cluster{},
 						Machine:       &clusterv1.Machine{},
@@ -245,7 +249,7 @@ func TestNewMachineScope(t *testing.T) {
 					mck.K8sClient.EXPECT().Scheme().Return(runtime.NewScheme())
 				}),
 				Result("cannot init patch helper", func(ctx context.Context, mck Mock) {
-					mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{
+					mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath", MachineScopeParams{
 						Client:        mck.K8sClient,
 						Cluster:       &clusterv1.Cluster{},
 						Machine:       &clusterv1.Machine{},
@@ -270,7 +274,7 @@ func TestNewMachineScope(t *testing.T) {
 					}).AnyTimes()
 			})),
 			Path(Result("default credentials", func(ctx context.Context, mck Mock) {
-				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{
+				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath", MachineScopeParams{
 					Client:        mck.K8sClient,
 					Cluster:       &clusterv1.Cluster{},
 					Machine:       &clusterv1.Machine{},
@@ -283,7 +287,7 @@ func TestNewMachineScope(t *testing.T) {
 		),
 		OneOf(
 			Path(Result("credentials from LinodeMachine credentialsRef", func(ctx context.Context, mck Mock) {
-				mScope, err := NewMachineScope(ctx, "", "", MachineScopeParams{
+				mScope, err := NewMachineScope(ctx, "", "", "dnsUrl", "dnsCaPath", MachineScopeParams{
 					Client:        mck.K8sClient,
 					Cluster:       &clusterv1.Cluster{},
 					Machine:       &clusterv1.Machine{},
@@ -301,7 +305,7 @@ func TestNewMachineScope(t *testing.T) {
 				assert.NotNil(t, mScope)
 			})),
 			Path(Result("credentials from LinodeCluster credentialsRef", func(ctx context.Context, mck Mock) {
-				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", MachineScopeParams{
+				mScope, err := NewMachineScope(ctx, "apiToken", "dnsToken", "dnsUrl", "dnsCaPath", MachineScopeParams{
 					Client:  mck.K8sClient,
 					Cluster: &clusterv1.Cluster{},
 					Machine: &clusterv1.Machine{},
@@ -470,6 +474,8 @@ func TestMachineAddCredentialsRefFinalizer(t *testing.T) {
 				context.Background(),
 				"apiToken",
 				"dnsToken",
+				"dnsUrl",
+				"dnsCaPath",
 				MachineScopeParams{
 					Client:        mockK8sClient,
 					Cluster:       &clusterv1.Cluster{},
@@ -564,6 +570,8 @@ func TestMachineRemoveCredentialsRefFinalizer(t *testing.T) {
 				context.Background(),
 				"apiToken",
 				"dnsToken",
+				"dnsUrl",
+				"dnsCaPath",
 				MachineScopeParams{
 					Client:        mockK8sClient,
 					Cluster:       &clusterv1.Cluster{},

--- a/cloud/scope/object_storage_bucket.go
+++ b/cloud/scope/object_storage_bucket.go
@@ -65,7 +65,7 @@ func validateObjectStorageBucketScopeParams(params ObjectStorageBucketScopeParam
 	return nil
 }
 
-//nolint:dupl // TODO: Remove fields related to key provisioning from the bucket resource.
+// TODO: Remove fields related to key provisioning from the bucket resource.
 func NewObjectStorageBucketScope(ctx context.Context, linodeClientConfig ClientConfig, params ObjectStorageBucketScopeParams) (*ObjectStorageBucketScope, error) {
 	if err := validateObjectStorageBucketScopeParams(params); err != nil {
 		return nil, err

--- a/cloud/scope/object_storage_bucket.go
+++ b/cloud/scope/object_storage_bucket.go
@@ -66,7 +66,7 @@ func validateObjectStorageBucketScopeParams(params ObjectStorageBucketScopeParam
 }
 
 //nolint:dupl // TODO: Remove fields related to key provisioning from the bucket resource.
-func NewObjectStorageBucketScope(ctx context.Context, apiKey string, params ObjectStorageBucketScopeParams) (*ObjectStorageBucketScope, error) {
+func NewObjectStorageBucketScope(ctx context.Context, linodeClientConfig ClientConfig, params ObjectStorageBucketScopeParams) (*ObjectStorageBucketScope, error) {
 	if err := validateObjectStorageBucketScopeParams(params); err != nil {
 		return nil, err
 	}
@@ -78,9 +78,10 @@ func NewObjectStorageBucketScope(ctx context.Context, apiKey string, params Obje
 		if err != nil {
 			return nil, fmt.Errorf("credentials from secret ref: %w", err)
 		}
-		apiKey = string(apiToken)
+		linodeClientConfig.Token = string(apiToken)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey, clientTimeout)
+	linodeClientConfig.Timeout = clientTimeout
+	linodeClient, err := CreateLinodeClient(linodeClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create linode client: %w", err)
 	}

--- a/cloud/scope/object_storage_bucket_test.go
+++ b/cloud/scope/object_storage_bucket_test.go
@@ -197,7 +197,7 @@ func TestNewObjectStorageBucketScope(t *testing.T) {
 					Logger: &logr.Logger{},
 				},
 			},
-			expectedErr: fmt.Errorf("failed to create linode client: missing Linode API key"),
+			expectedErr: fmt.Errorf("failed to create linode client: token cannot be empty"),
 			expects:     func(mock *mock.MockK8sClient) {},
 		},
 	}
@@ -215,7 +215,7 @@ func TestNewObjectStorageBucketScope(t *testing.T) {
 
 			testcase.args.params.Client = mockK8sClient
 
-			got, err := NewObjectStorageBucketScope(context.Background(), testcase.args.apiKey, testcase.args.params)
+			got, err := NewObjectStorageBucketScope(context.Background(), ClientConfig{Token: testcase.args.apiKey}, testcase.args.params)
 
 			if testcase.expectedErr != nil {
 				assert.ErrorContains(t, err, testcase.expectedErr.Error())
@@ -275,7 +275,7 @@ func TestObjectStorageBucketScopeMethods(t *testing.T) {
 
 			objScope, err := NewObjectStorageBucketScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				ObjectStorageBucketScopeParams{
 					Client: mockK8sClient,
 					Bucket: testcase.Bucket,

--- a/cloud/scope/object_storage_key_test.go
+++ b/cloud/scope/object_storage_key_test.go
@@ -197,7 +197,7 @@ func TestNewObjectStorageKeyScope(t *testing.T) {
 					Logger: &logr.Logger{},
 				},
 			},
-			expectedErr: fmt.Errorf("failed to create linode client: missing Linode API key"),
+			expectedErr: fmt.Errorf("failed to create linode client: token cannot be empty"),
 			expects:     func(mock *mock.MockK8sClient) {},
 		},
 	}
@@ -215,7 +215,7 @@ func TestNewObjectStorageKeyScope(t *testing.T) {
 
 			testcase.args.params.Client = mockK8sClient
 
-			got, err := NewObjectStorageKeyScope(context.Background(), testcase.args.apiKey, testcase.args.params)
+			got, err := NewObjectStorageKeyScope(context.Background(), ClientConfig{Token: testcase.args.apiKey}, testcase.args.params)
 
 			if testcase.expectedErr != nil {
 				assert.ErrorContains(t, err, testcase.expectedErr.Error())
@@ -276,7 +276,7 @@ func TestObjectStrorageKeyAddFinalizer(t *testing.T) {
 
 			keyScope, err := NewObjectStorageKeyScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				ObjectStorageKeyScopeParams{
 					Client: mockK8sClient,
 					Key:    testcase.Key,

--- a/cloud/scope/placement_group.go
+++ b/cloud/scope/placement_group.go
@@ -96,7 +96,7 @@ func (s *PlacementGroupScope) RemoveCredentialsRefFinalizer(ctx context.Context)
 // This is meant to be called for each reconcile iteration.
 //
 //nolint:dupl // This is pretty much the same as VPC, maybe a candidate to use generics later.
-func NewPlacementGroupScope(ctx context.Context, apiKey string, params PlacementGroupScopeParams) (*PlacementGroupScope, error) {
+func NewPlacementGroupScope(ctx context.Context, linodeClientConfig ClientConfig, params PlacementGroupScopeParams) (*PlacementGroupScope, error) {
 	if err := validatePlacementGroupScope(params); err != nil {
 		return nil, err
 	}
@@ -108,9 +108,10 @@ func NewPlacementGroupScope(ctx context.Context, apiKey string, params Placement
 		if err != nil {
 			return nil, fmt.Errorf("credentials from secret ref: %w", err)
 		}
-		apiKey = string(apiToken)
+		linodeClientConfig.Token = string(apiToken)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout,
+	linodeClient, err := CreateLinodeClient(
+		linodeClientConfig,
 		WithRetryCount(0),
 	)
 	if err != nil {

--- a/cloud/scope/placement_group_test.go
+++ b/cloud/scope/placement_group_test.go
@@ -165,7 +165,7 @@ func TestNewPlacementGroupScope(t *testing.T) {
 				},
 			},
 			expects:       func(mock *mock.MockK8sClient) {},
-			expectedError: fmt.Errorf("failed to create linode client: missing Linode API key"),
+			expectedError: fmt.Errorf("failed to create linode client: token cannot be empty"),
 		},
 		{
 			name: "Error - Pass in valid args but get an error when creating a new patch helper",
@@ -194,7 +194,7 @@ func TestNewPlacementGroupScope(t *testing.T) {
 
 			testcase.args.params.Client = mockK8sClient
 
-			got, err := NewPlacementGroupScope(context.Background(), testcase.args.apiKey, testcase.args.params)
+			got, err := NewPlacementGroupScope(context.Background(), ClientConfig{Token: testcase.args.apiKey}, testcase.args.params)
 
 			if testcase.expectedError != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())
@@ -259,7 +259,7 @@ func TestPlacementGroupScopeMethods(t *testing.T) {
 
 			pgScope, err := NewPlacementGroupScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				PlacementGroupScopeParams{
 					Client:               mockK8sClient,
 					LinodePlacementGroup: testcase.LinodePlacementGroup,
@@ -353,7 +353,7 @@ func TestPlacementGroupAddCredentialsRefFinalizer(t *testing.T) {
 
 			pgScope, err := NewPlacementGroupScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				PlacementGroupScopeParams{
 					Client:               mockK8sClient,
 					LinodePlacementGroup: testcase.LinodePlacementGroup,
@@ -443,7 +443,7 @@ func TestPlacementGroupRemoveCredentialsRefFinalizer(t *testing.T) {
 
 			pgScope, err := NewPlacementGroupScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				PlacementGroupScopeParams{
 					Client:               mockK8sClient,
 					LinodePlacementGroup: testcase.LinodePlacementGroup,

--- a/cloud/scope/vpc.go
+++ b/cloud/scope/vpc.go
@@ -56,7 +56,7 @@ func validateVPCScopeParams(params VPCScopeParams) error {
 // This is meant to be called for each reconcile iteration.
 //
 //nolint:dupl // this is the same as PlacementGroups - worth making into generics later.
-func NewVPCScope(ctx context.Context, apiKey string, params VPCScopeParams) (*VPCScope, error) {
+func NewVPCScope(ctx context.Context, linodeClientConfig ClientConfig, params VPCScopeParams) (*VPCScope, error) {
 	if err := validateVPCScopeParams(params); err != nil {
 		return nil, err
 	}
@@ -68,9 +68,9 @@ func NewVPCScope(ctx context.Context, apiKey string, params VPCScopeParams) (*VP
 		if err != nil {
 			return nil, fmt.Errorf("credentials from secret ref: %w", err)
 		}
-		apiKey = string(apiToken)
+		linodeClientConfig.Token = string(apiToken)
 	}
-	linodeClient, err := CreateLinodeClient(apiKey, defaultClientTimeout,
+	linodeClient, err := CreateLinodeClient(linodeClientConfig,
 		WithRetryCount(0),
 	)
 	if err != nil {

--- a/cloud/scope/vpc_test.go
+++ b/cloud/scope/vpc_test.go
@@ -165,7 +165,7 @@ func TestNewVPCScope(t *testing.T) {
 				},
 			},
 			expects:       func(mock *mock.MockK8sClient) {},
-			expectedError: fmt.Errorf("failed to create linode client: missing Linode API key"),
+			expectedError: fmt.Errorf("failed to create linode client: token cannot be empty"),
 		},
 		{
 			name: "Error - Pass in valid args but get an error when creating a new patch helper",
@@ -194,7 +194,7 @@ func TestNewVPCScope(t *testing.T) {
 
 			testcase.args.params.Client = mockK8sClient
 
-			got, err := NewVPCScope(context.Background(), testcase.args.apiKey, testcase.args.params)
+			got, err := NewVPCScope(context.Background(), ClientConfig{Token: testcase.args.apiKey}, testcase.args.params)
 
 			if testcase.expectedError != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())
@@ -259,7 +259,7 @@ func TestVPCScopeMethods(t *testing.T) {
 
 			vScope, err := NewVPCScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				VPCScopeParams{
 					Client:    mockK8sClient,
 					LinodeVPC: testcase.LinodeVPC,
@@ -353,7 +353,7 @@ func TestVPCAddCredentialsRefFinalizer(t *testing.T) {
 
 			vScope, err := NewVPCScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				VPCScopeParams{
 					Client:    mockK8sClient,
 					LinodeVPC: testcase.LinodeVPC,
@@ -443,7 +443,7 @@ func TestVPCRemoveCredentialsRefFinalizer(t *testing.T) {
 
 			vScope, err := NewVPCScope(
 				context.Background(),
-				"test-key",
+				ClientConfig{Token: "test-key"},
 				VPCScopeParams{
 					Client:    mockK8sClient,
 					LinodeVPC: testcase.LinodeVPC,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,7 @@ func main() {
 		os.Exit(1)
 	}
 	if linodeDNSToken == "" {
+		setupLog.Info("LINODE_DNS_TOKEN not provided, defaulting to the value of LINODE_TOKEN")
 		linodeDNSToken = linodeToken
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,8 @@ func main() {
 		// Environment variables
 		linodeToken    = os.Getenv("LINODE_TOKEN")
 		linodeDNSToken = os.Getenv("LINODE_DNS_TOKEN")
+		linodeDNSURL   = os.Getenv("LINODE_DNS_URL")
+		linodeDNSCA    = os.Getenv("LINODE_DNS_CA")
 
 		machineWatchFilter             string
 		clusterWatchFilter             string
@@ -180,6 +182,8 @@ func main() {
 		WatchFilterValue: machineWatchFilter,
 		LinodeApiKey:     linodeToken,
 		LinodeDNSAPIKey:  linodeDNSToken,
+		LinodeDNSURL:     linodeDNSURL,
+		LinodeDNSCA:      linodeDNSCA,
 	}).SetupWithManager(mgr, crcontroller.Options{MaxConcurrentReconciles: linodeMachineConcurrency}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LinodeMachine")
 		os.Exit(1)

--- a/controller/linodecluster_controller.go
+++ b/controller/linodecluster_controller.go
@@ -52,10 +52,10 @@ import (
 // LinodeClusterReconciler reconciles a LinodeCluster object
 type LinodeClusterReconciler struct {
 	client.Client
-	Recorder         record.EventRecorder
-	LinodeApiKey     string
-	WatchFilterValue string
-	ReconcileTimeout time.Duration
+	Recorder           record.EventRecorder
+	LinodeClientConfig scope.ClientConfig
+	WatchFilterValue   string
+	ReconcileTimeout   time.Duration
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodeclusters,verbs=get;list;watch;create;update;patch;delete
@@ -91,7 +91,7 @@ func (r *LinodeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Create the cluster scope.
 	clusterScope, err := scope.NewClusterScope(
 		ctx,
-		r.LinodeApiKey,
+		r.LinodeClientConfig,
 		scope.ClusterScopeParams{
 			Client:        r.TracedClient(),
 			Cluster:       cluster,

--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -94,6 +94,8 @@ type LinodeMachineReconciler struct {
 	Recorder         record.EventRecorder
 	LinodeApiKey     string
 	LinodeDNSAPIKey  string
+	LinodeDNSURL     string
+	LinodeDNSCA      string
 	WatchFilterValue string
 	ReconcileTimeout time.Duration
 }
@@ -142,6 +144,8 @@ func (r *LinodeMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		ctx,
 		r.LinodeApiKey,
 		r.LinodeDNSAPIKey,
+		r.LinodeDNSURL,
+		r.LinodeDNSCA,
 		scope.MachineScopeParams{
 			Client:        r.TracedClient(),
 			Cluster:       cluster,

--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -91,13 +91,11 @@ var requeueInstanceStatuses = map[linodego.InstanceStatus]bool{
 // LinodeMachineReconciler reconciles a LinodeMachine object
 type LinodeMachineReconciler struct {
 	client.Client
-	Recorder         record.EventRecorder
-	LinodeApiKey     string
-	LinodeDNSAPIKey  string
-	LinodeDNSURL     string
-	LinodeDNSCA      string
-	WatchFilterValue string
-	ReconcileTimeout time.Duration
+	Recorder           record.EventRecorder
+	LinodeClientConfig scope.ClientConfig
+	DnsClientConfig    scope.ClientConfig
+	WatchFilterValue   string
+	ReconcileTimeout   time.Duration
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodemachines,verbs=get;list;watch;create;update;patch;delete
@@ -142,10 +140,8 @@ func (r *LinodeMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	machineScope, err := scope.NewMachineScope(
 		ctx,
-		r.LinodeApiKey,
-		r.LinodeDNSAPIKey,
-		r.LinodeDNSURL,
-		r.LinodeDNSCA,
+		r.LinodeClientConfig,
+		r.DnsClientConfig,
 		scope.MachineScopeParams{
 			Client:        r.TracedClient(),
 			Cluster:       cluster,

--- a/controller/linodeobjectstoragebucket_controller.go
+++ b/controller/linodeobjectstoragebucket_controller.go
@@ -53,11 +53,11 @@ import (
 // LinodeObjectStorageBucketReconciler reconciles a LinodeObjectStorageBucket object
 type LinodeObjectStorageBucketReconciler struct {
 	client.Client
-	Logger           logr.Logger
-	Recorder         record.EventRecorder
-	LinodeApiKey     string
-	WatchFilterValue string
-	ReconcileTimeout time.Duration
+	Logger             logr.Logger
+	Recorder           record.EventRecorder
+	LinodeClientConfig scope.ClientConfig
+	WatchFilterValue   string
+	ReconcileTimeout   time.Duration
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodeobjectstoragebuckets,verbs=get;list;watch;create;update;patch;delete
@@ -93,7 +93,7 @@ func (r *LinodeObjectStorageBucketReconciler) Reconcile(ctx context.Context, req
 
 	bScope, err := scope.NewObjectStorageBucketScope(
 		ctx,
-		r.LinodeApiKey,
+		r.LinodeClientConfig,
 		scope.ObjectStorageBucketScopeParams{
 			Client: r.TracedClient(),
 			Bucket: objectStorageBucket,

--- a/controller/linodeobjectstoragekey_controller.go
+++ b/controller/linodeobjectstoragekey_controller.go
@@ -54,12 +54,12 @@ import (
 // LinodeObjectStorageKeyReconciler reconciles a LinodeObjectStorageKey object
 type LinodeObjectStorageKeyReconciler struct {
 	client.Client
-	Logger           logr.Logger
-	Recorder         record.EventRecorder
-	LinodeApiKey     string
-	WatchFilterValue string
-	Scheme           *runtime.Scheme
-	ReconcileTimeout time.Duration
+	Logger             logr.Logger
+	Recorder           record.EventRecorder
+	LinodeClientConfig scope.ClientConfig
+	WatchFilterValue   string
+	Scheme             *runtime.Scheme
+	ReconcileTimeout   time.Duration
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodeobjectstoragekeys,verbs=get;list;watch;create;update;patch;delete
@@ -97,7 +97,7 @@ func (r *LinodeObjectStorageKeyReconciler) Reconcile(ctx context.Context, req ct
 
 	keyScope, err := scope.NewObjectStorageKeyScope(
 		ctx,
-		r.LinodeApiKey,
+		r.LinodeClientConfig,
 		scope.ObjectStorageKeyScopeParams{
 			Client: tracedClient,
 			Key:    objectStorageKey,

--- a/controller/linodeplacementgroup_controller.go
+++ b/controller/linodeplacementgroup_controller.go
@@ -54,11 +54,11 @@ import (
 // LinodePlacementGroupReconciler reconciles a LinodePlacementGroup object
 type LinodePlacementGroupReconciler struct {
 	client.Client
-	Recorder         record.EventRecorder
-	LinodeApiKey     string
-	WatchFilterValue string
-	Scheme           *runtime.Scheme
-	ReconcileTimeout time.Duration
+	Recorder           record.EventRecorder
+	LinodeClientConfig scope.ClientConfig
+	WatchFilterValue   string
+	Scheme             *runtime.Scheme
+	ReconcileTimeout   time.Duration
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodeplacementgroups,verbs=get;list;watch;create;update;patch;delete
@@ -88,7 +88,7 @@ func (r *LinodePlacementGroupReconciler) Reconcile(ctx context.Context, req ctrl
 
 	pgScope, err := scope.NewPlacementGroupScope(
 		ctx,
-		r.LinodeApiKey,
+		r.LinodeClientConfig,
 		scope.PlacementGroupScopeParams{
 			Client:               r.TracedClient(),
 			LinodePlacementGroup: linodeplacementgroup,

--- a/controller/linodevpc_controller.go
+++ b/controller/linodevpc_controller.go
@@ -53,11 +53,11 @@ import (
 // LinodeVPCReconciler reconciles a LinodeVPC object
 type LinodeVPCReconciler struct {
 	client.Client
-	Recorder         record.EventRecorder
-	LinodeApiKey     string
-	WatchFilterValue string
-	Scheme           *runtime.Scheme
-	ReconcileTimeout time.Duration
+	Recorder           record.EventRecorder
+	LinodeClientConfig scope.ClientConfig
+	WatchFilterValue   string
+	Scheme             *runtime.Scheme
+	ReconcileTimeout   time.Duration
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodevpcs,verbs=get;list;watch;create;update;patch;delete
@@ -94,7 +94,7 @@ func (r *LinodeVPCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	vpcScope, err := scope.NewVPCScope(
 		ctx,
-		r.LinodeApiKey,
+		r.LinodeClientConfig,
 		scope.VPCScopeParams{
 			Client:    r.TracedClient(),
 			LinodeVPC: linodeVPC,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
       - [rke2](./topics/flavors/rke2.md)
       - [vpcless](./topics/flavors/vpcless.md)
       - [konnectivity (kubeadm)](./topics/flavors/konnectivity.md)
+      - [DNS based apiserver Load Balancing](./topics/flavors/dns-loadbalancing.md)
     - [Etcd](./topics/etcd.md)
     - [Backups](./topics/backups.md)
     - [Multi-Tenancy](./topics/multi-tenancy.md)

--- a/docs/src/topics/flavors/dns-loadbalancing.md
+++ b/docs/src/topics/flavors/dns-loadbalancing.md
@@ -26,7 +26,18 @@ With these changes, the controlPlaneEndpoint is set to `<domain-name>-<uniqueid>
 The controller will create A/AAAA and TXT records under [the Domains tab in the Linode Cloud Manager.](https://cloud.linode.com/domains) or Akamai Edge DNS depending on the provider.
 
  ### Linode Domains:
-Using the `LINODE_DNS_TOKEN` env var, you can pass the [API token of a different account](https://cloud.linode.com/profile/tokens) if the Domain has been created in another acount under Linode CM
+Using the `LINODE_DNS_TOKEN` env var, you can pass the [API token of a different account](https://cloud.linode.com/profile/tokens) if the Domain has been created in another acount under Linode CM:
+
+```bash
+export LINODE_DNS_TOKEN=<your Linode PAT>
+```
+
+Optionally, provide an alternative Linode API URL and root CA certificate.
+
+```bash
+export LINODE_DNS_URL=custom.api.linode.com
+export LINODE_DNS_CA=/path/to/cacert.pem
+```
 
 ### Akamai Domains:
 For the controller to authenticate with the Edge DNS API, you'll need to set the following env vars when creating the mgmt cluster.

--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -28,6 +28,20 @@ export LINODE_TOKEN=<your linode PAT>
 export LINODE_CONTROL_PLANE_MACHINE_TYPE=g6-standard-2
 export LINODE_MACHINE_TYPE=g6-standard-2
 ```
+
+Optionally, provide an alternative Linode API client configuration for provisioning domain resources.
+If not provided, the above-mentioned configuration will be used.
+```bash
+export LINODE_DNS_URL=custom.api.linode.com
+export LINODE_DNS_CA=/path/to/cacert.pem
+export LINODE_DNS_TOKEN=<your Linode PAT for the API instance at LINODE_DNS_URL>
+```
+
+```admonish info
+This project uses [linodego](https://github.com/linode/linodego) for Linode API interaction. 
+Please refer to it for more details on environment variables used for client configuration.
+```
+
 ```admonish warning
 For Regions and Images that do not yet support Akamai's cloud-init datasource CAPL will automatically use a stackscript shim
 to provision the node. If you are using a custom image ensure the [cloud_init](https://www.linode.com/docs/api/images/#image-create) flag is set correctly on it

--- a/docs/src/topics/getting-started.md
+++ b/docs/src/topics/getting-started.md
@@ -29,14 +29,6 @@ export LINODE_CONTROL_PLANE_MACHINE_TYPE=g6-standard-2
 export LINODE_MACHINE_TYPE=g6-standard-2
 ```
 
-Optionally, provide an alternative Linode API client configuration for provisioning domain resources.
-If not provided, the above-mentioned configuration will be used.
-```bash
-export LINODE_DNS_URL=custom.api.linode.com
-export LINODE_DNS_CA=/path/to/cacert.pem
-export LINODE_DNS_TOKEN=<your Linode PAT for the API instance at LINODE_DNS_URL>
-```
-
 ```admonish info
 This project uses [linodego](https://github.com/linode/linodego) for Linode API interaction. 
 Please refer to it for more details on environment variables used for client configuration.

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.19.0
-	golang.org/x/oauth2 v0.21.0
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
@@ -95,6 +94,7 @@ require (
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/net v0.27.0 // indirect
+	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/mock/mocktest/suite_test.go
+++ b/mock/mocktest/suite_test.go
@@ -130,7 +130,6 @@ var _ = Describe("controller suite with events/logs", Label("suite"), func() {
 			mck.Logger().Info("+")
 
 			Expect(strings.Count(mck.Events(), "+")).To(Equal(2))
-			Expect(strings.Count(mck.Logs(), "+")).To(Equal(2))
 		}),
 	)
 })


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
- Currently, CAPL does not allow targeting different Linode API instances for the domain client, and the client for the remaining resources. This use case is required by an internal project.
- Also, using custom CA certs is broken, due to the way CAPL initializes the linodego client (see below).

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**:
- Exposes new environment variables DNS Linode client configuration:
    - `LINODE_DNS_URL` - equivalent of the `LINODE_URL`, but applies _only_ to the DNS client.
    - `LINODE_DNS_CA` - equivalent of the `LINODE_CA`, but applies _only_ to the DNS client. If we target a different API instance than `LINODE_URL`, we might also need to provide different root CA certs.
    - If the above are not provided, default linodego logic applies (same as before).
- Implements a struct for Linode client configuration (`ClientConfig`), to keep things from becoming messy with the new parameters. Used as a DTO right after startup.
- Adds an `info` level log informing about the fallback of `LINODE_DNS_TOKEN` to `LINODE_TOKEN` happening. I've noticed this happens silently, and it would be nice to know.
- Drops the usage of the `oauth2.Transport`. This caused the custom TLS configuration to be silently discarded, due to an unexpected interaction with [resty](https://github.com/go-resty/resty). The flow would go like this:
    - Set the `LINODE_CA` env var to a valid `*.pem` path.
    - Start CAPL
    - Eventually, `CreateLinodeClient` gets called, [passing an `oauth2.Transport` (encapsulated in an `oauth2.client`)](https://github.com/linode/cluster-api-provider-linode/blob/31190452f450d8a1dd7cadb85be2128f51bff91b/cloud/scope/common.go#L52-L60) to [`linodego.NewClient`](https://github.com/linode/linodego/blob/v1.38.0/client.go#L434).
    - During linodego client init, [CA certs get initialized](https://github.com/linode/linodego/blob/v1.38.0/client.go#L462-L468) (if provided and valid). 
    - The set the CA certs, linodego calls [resty client SetRootCertificate](https://github.com/linode/linodego/blob/v1.38.0/client.go#L233). This in turn fails on casting the provided `oauth2.Transport` as an `http.Transport` and silently discards the TLS config.
        - [resty SetRootCertificate](https://github.com/go-resty/resty/blob/v2.13.1/client.go#L877-L887) attempts to [load the TLS config into the `Transport`](https://github.com/go-resty/resty/blob/v2.13.1/client.go#L1255-L1259). 
        - [tlsConfig](https://github.com/go-resty/resty/blob/v2.13.1/client.go#L1255-L1259) [casts the client's `Transport` to `http.Transport`](https://github.com/go-resty/resty/blob/v2.13.1/client.go#L1270-L1274), but fails to do so (we provide an `oauth2.Transport`), and the flow errors out, [yielding and unchanged client](https://github.com/go-resty/resty/blob/v2.13.1/client.go#L887).
- [Removes emitted log line counting](https://github.com/linode/cluster-api-provider-linode/blob/1b4a2b957a8259535a87af55d3c66aa7826c8786/mock/mocktest/suite_test.go#L133) in for `controller test suite with events/logs`. We've agreed with @eljohnson92 this does not bring much value, while being troublesome to maintain and debug.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits - I'd prefer to squash on merge. The separate commits add valuable context.
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


