### PR TITLE
[fix] : always cleanup child clusters

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -109,6 +109,10 @@ jobs:
           CLUSTERCTL_CONFIG: /home/runner/work/cluster-api-provider-linode/cluster-api-provider-linode/e2e/gha-clusterctl-config.yaml
         run: make e2etest
 
+      - name: cleanup stale clusters
+        if: ${{ always() }}
+        run: make clean-child-clusters
+
       - name: Copy logs
         if: ${{ always() }}
         run: docker cp tilt-control-plane:/var/log .logs

--- a/Makefile
+++ b/Makefile
@@ -265,13 +265,9 @@ clean-release: clean-release-git
 	rm -rf $(RELEASE_DIR)
 
 .PHONY: clean-child-clusters
-clean-child-clusters:
-	@for cluster in $$($(KUBECTL) get clusters -o name); do \
-		$(KUBECTL) delete $$cluster; \
-	done
-	@for vpc in $$($(KUBECTL) get linodevpc -o name); do \
-		$(KUBECTL) delete $$vpc; \
-	done
+clean-child-clusters: kubectl
+	$(KUBECTL) delete clusters -A --all --timeout=180s
+	$(KUBECTL) delete linodevpc -A --all --timeout=60s
 
 ## --------------------------------------
 ## Build Dependencies
@@ -325,6 +321,7 @@ GOWRAP         ?= $(CACHE_BIN)/gowrap
 KUSTOMIZE_VERSION        ?= v5.4.1
 CTLPTL_VERSION           ?= v0.8.29
 CLUSTERCTL_VERSION       ?= v1.7.2
+KUBECTL_VERSION          ?= v1.28.0
 KUBEBUILDER_VERSION      ?= v3.15.1
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 TILT_VERSION             ?= 0.33.10
@@ -337,7 +334,7 @@ MOCKGEN_VERSION          ?= v0.4.0
 GOWRAP_VERSION           ?= latest
 
 .PHONY: tools
-tools: $(KUSTOMIZE) $(CTLPTL) $(CLUSTERCTL) $(CONTROLLER_GEN) $(CONVERSION_GEN) $(TILT) $(KIND) $(CHAINSAW) $(ENVTEST) $(HUSKY) $(NILAWAY) $(GOVULNC) $(MOCKGEN) $(GOWRAP)
+tools: $(KUSTOMIZE) $(CTLPTL) $(CLUSTERCTL) $(KUBECTL) $(CONTROLLER_GEN) $(CONVERSION_GEN) $(TILT) $(KIND) $(CHAINSAW) $(ENVTEST) $(HUSKY) $(NILAWAY) $(GOVULNC) $(MOCKGEN) $(GOWRAP)
 
 
 .PHONY: kustomize
@@ -355,6 +352,12 @@ clusterctl: $(CLUSTERCTL) ## Download clusterctl locally if necessary.
 $(CLUSTERCTL): $(LOCALBIN)
 	curl -fsSL https://github.com/kubernetes-sigs/cluster-api/releases/download/$(CLUSTERCTL_VERSION)/clusterctl-$(OS)-$(ARCH_SHORT) -o $(CLUSTERCTL)
 	chmod +x $(CLUSTERCTL)
+
+.PHONY: kubectl
+kubectl: $(KUBECTL) ## Download kubectl locally if necessary.
+$(KUBECTL): $(LOCALBIN)
+	curl -fsSL https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OS)/$(ARCH_SHORT)/kubectl -o $(KUBECTL)
+	chmod +x $(KUBECTL)
 
 .PHONY: kubebuilder
 kubebuilder: $(KUBEBUILDER) ## Download kubebuilder locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,15 @@ clean-release-git: ## Restores the git files usually modified during a release
 clean-release: clean-release-git
 	rm -rf $(RELEASE_DIR)
 
+.PHONY: clean-child-clusters
+clean-child-clusters:
+	@for cluster in $$($(KUBECTL) get clusters -o name); do \
+		$(KUBECTL) delete $$cluster; \
+	done
+	@for vpc in $$($(KUBECTL) get linodevpc -o name); do \
+		$(KUBECTL) delete $$vpc; \
+	done
+
 ## --------------------------------------
 ## Build Dependencies
 ## --------------------------------------


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR adds target in makefile to clean all child clusters. This will allow us to clean up resources when an e2e test run gets cancelled. We plan to always run the cleanup job to clean all child clusters when e2e test run finishes or gets cancelled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


