### PR TITLE
[test]: bump Flatcar channel from Alpha to Beta

### DIFF
--- a/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
@@ -38,14 +38,14 @@ spec:
                 value: (env('LINODE_REGION'))
             content: |
               set -e
-              # Get the latest version on Alpha channel.
-              # NOTE: This can be changed to Beta or Stable when Akamai support will come on these channels.
+              # Get the latest version on Beta channel.
+              # NOTE: This can be changed to Stable when Akamai support will come on these channels.
               curl -fsSL --remote-name \
-                https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_akamai_image.bin.gz
+                https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_akamai_image.bin.gz
 
               res=$(curl -s --request POST \
                 --url "https://${TARGET_API}/${TARGET_API_VERSION}/${URI}" \
-                --data '{"region":"'${LINODE_REGION}'","cloud_init":true,"label":"flatcar-alpha"}' \
+                --data '{"region":"'${LINODE_REGION}'","cloud_init":true,"label":"flatcar-beta"}' \
                 --header "Authorization: Bearer ${LINODE_TOKEN}" \
                 --header "accept: application/json" \
                 --header "content-type: application/json")


### PR DESCRIPTION
**What this PR does / why we need it**: Akamai / Linode support has been promoted to Flatcar Beta channel. Let's use this version in the test to get closer of what CAPL users would actually run. (https://github.com/flatcar/Flatcar/issues/1509) 

**Special notes for your reviewer**: Locally tested with `make e2etest E2E_SELECTOR='flatcar' E2E_FLAGS='--assert-timeout 10m0s'`


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


