### PR TITLE
[fix] fix etcd-backup-restore based flavors

### DIFF
--- a/cloud/scope/object_storage_key.go
+++ b/cloud/scope/object_storage_key.go
@@ -107,6 +107,7 @@ const (
 apiVersion: v1
 metadata:
   name: %s
+  namespace: kube-system
 stringData:
   bucket_name: %s
   bucket_region: %s

--- a/docs/src/topics/backups.md
+++ b/docs/src/topics/backups.md
@@ -55,7 +55,7 @@ CAPL will also create `read_write` and `read_only` access keys for the bucket an
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <unique-bucket-label>-bucket-details
+  name: <unique-bucket-label>-obj-key
   namespace: <same-namespace-as-object-storage-bucket>
   ownerReferences:
     - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
@@ -67,13 +67,11 @@ data:
   bucket_name: <unique-bucket-label>
   bucket_region: <linode-obj-bucket-region>
   bucket_endpoint: <hostname-to-access-bucket>
-  access_key_rw: <base64-encoded-access-key>
-  secret_key_rw: <base64-encoded-secret-key>
-  access_key_ro: <base64-encoded-access-key>
-  secret_key_ro: <base64-encoded-secret-key>
+  access_key: <base64-encoded-access-key>
+  secret_key: <base64-encoded-secret-key>
 ```
 
-The bucket-details secret is owned and managed by CAPL during the life of the `LinodeObjectStorageBucket`.
+The<unique-bucket-label>-obj-key secret is owned and managed by CAPL during the life of the `LinodeObjectStorageBucket`.
 
 ### Access Keys Rotation
 

--- a/templates/addons/etcd-backup-restore/etcd-backup-restore.yaml
+++ b/templates/addons/etcd-backup-restore/etcd-backup-restore.yaml
@@ -62,12 +62,12 @@ data:
               valueFrom:
                 secretKeyRef:
                   name: ${CLUSTER_NAME}-etcd-backup-obj-key
-                  key: "access_key_rw"
+                  key: "access_key"
             - name: "AWS_SECRET_ACCESS_KEY"
               valueFrom:
                 secretKeyRef:
                   name: ${CLUSTER_NAME}-etcd-backup-obj-key
-                  key: "secret_key_rw"
+                  key: "secret_key"
             - name: "AWS_SSE_CUSTOMER_KEY"
               valueFrom:
                 secretKeyRef:
@@ -94,7 +94,7 @@ data:
             - --cacert=${CERTPATH}/etcd/${CACERTFILE}
             - --cert=${CERTPATH}/etcd/${CERTFILE}
             - --key=${CERTPATH}/etcd/${KEYFILE}
-            image: ${ETCDBR_IMAGE:-europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl:v0.28.0}
+            image: ${ETCDBR_IMAGE:-europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl:v0.29.0}
             securityContext:
               allowPrivilegeEscalation: false
               runAsUser: 0


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
CAPL clusterrs with etcd-backup-restore and related flavors fail to created. This is down to some recent OBJ changes for key names and namespaces within the secrets.
