### PR TITLE
[fix] delete all stale entries for the domain

### DIFF
--- a/cloud/services/domains_test.go
+++ b/cloud/services/domains_test.go
@@ -615,6 +615,7 @@ func TestAddIPToDNS(t *testing.T) {
 						TTLSec: 30,
 					},
 				}, nil).AnyTimes()
+				mockClient.EXPECT().DeleteDomainRecord(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
@@ -739,6 +740,7 @@ func TestAddIPToDNS(t *testing.T) {
 						TTLSec: 30,
 					},
 				}, nil).AnyTimes()
+				mockClient.EXPECT().DeleteDomainRecord(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {

--- a/cloud/services/loadbalancers.go
+++ b/cloud/services/loadbalancers.go
@@ -114,7 +114,7 @@ func EnsureNodeBalancerConfigs(
 }
 
 // AddNodesToNB adds backend Nodes on the Node Balancer configuration
-func AddNodesToNB(ctx context.Context, logger logr.Logger, clusterScope *scope.ClusterScope, eachMachine v1alpha2.LinodeMachine) error {
+func AddNodesToNB(ctx context.Context, logger logr.Logger, clusterScope *scope.ClusterScope, eachMachine v1alpha2.LinodeMachine, nodeBalancerNodes []linodego.NodeBalancerNode) error {
 	apiserverLBPort := DefaultApiserverLBPort
 	if clusterScope.LinodeCluster.Spec.Network.ApiserverLoadBalancerPort != 0 {
 		apiserverLBPort = clusterScope.LinodeCluster.Spec.Network.ApiserverLoadBalancerPort
@@ -124,15 +124,6 @@ func AddNodesToNB(ctx context.Context, logger logr.Logger, clusterScope *scope.C
 		return errors.New("nil NodeBalancer Config ID")
 	}
 
-	nodeBalancerNodes, err := clusterScope.LinodeClient.ListNodeBalancerNodes(
-		ctx,
-		*clusterScope.LinodeCluster.Spec.Network.NodeBalancerID,
-		*clusterScope.LinodeCluster.Spec.Network.ApiserverNodeBalancerConfigID,
-		&linodego.ListOptions{},
-	)
-	if err != nil {
-		return err
-	}
 	internalIPFound := false
 	for _, IPs := range eachMachine.Status.Addresses {
 		if IPs.Type != v1beta1.MachineInternalIP || !strings.Contains(IPs.Address, "192.168") {

--- a/cloud/services/loadbalancers_test.go
+++ b/cloud/services/loadbalancers_test.go
@@ -489,7 +489,7 @@ func TestAddNodeToNBConditions(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("no private IP address"),
 			expects: func(mockClient *mock.MockLinodeClient) {
-				mockClient.EXPECT().ListNodeBalancerNodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]linodego.NodeBalancerNode{}, nil)
+				mockClient.EXPECT().ListNodeBalancerNodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]linodego.NodeBalancerNode{}, nil).AnyTimes()
 			},
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
 				mockK8sClient.EXPECT().Scheme().Return(nil).AnyTimes()
@@ -512,7 +512,7 @@ func TestAddNodeToNBConditions(t *testing.T) {
 			testcase.expectK8sClient(MockK8sClient)
 
 			for _, eachMachine := range testcase.clusterScope.LinodeMachines.Items {
-				err := AddNodesToNB(context.Background(), logr.Discard(), testcase.clusterScope, eachMachine)
+				err := AddNodesToNB(context.Background(), logr.Discard(), testcase.clusterScope, eachMachine, []linodego.NodeBalancerNode{})
 				if testcase.expectedError != nil {
 					assert.ErrorContains(t, err, testcase.expectedError.Error())
 				}
@@ -574,7 +574,7 @@ func TestAddNodeToNBFullWorkflow(t *testing.T) {
 				},
 			},
 			expects: func(mockClient *mock.MockLinodeClient) {
-				mockClient.EXPECT().ListNodeBalancerNodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]linodego.NodeBalancerNode{}, nil)
+				mockClient.EXPECT().ListNodeBalancerNodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]linodego.NodeBalancerNode{}, nil).AnyTimes()
 				mockClient.EXPECT().CreateNodeBalancerNode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&linodego.NodeBalancerNode{}, nil)
 			},
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
@@ -627,7 +627,7 @@ func TestAddNodeToNBFullWorkflow(t *testing.T) {
 			},
 			expectedError: nil,
 			expects: func(mockClient *mock.MockLinodeClient) {
-				mockClient.EXPECT().ListNodeBalancerNodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]linodego.NodeBalancerNode{}, nil)
+				mockClient.EXPECT().ListNodeBalancerNodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]linodego.NodeBalancerNode{}, nil).AnyTimes()
 				mockClient.EXPECT().CreateNodeBalancerNode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			},
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
@@ -651,7 +651,7 @@ func TestAddNodeToNBFullWorkflow(t *testing.T) {
 			testcase.expectK8sClient(MockK8sClient)
 
 			for _, eachMachine := range testcase.clusterScope.LinodeMachines.Items {
-				err := AddNodesToNB(context.Background(), logr.Discard(), testcase.clusterScope, eachMachine)
+				err := AddNodesToNB(context.Background(), logr.Discard(), testcase.clusterScope, eachMachine, []linodego.NodeBalancerNode{})
 				if testcase.expectedError != nil {
 					assert.ErrorContains(t, err, testcase.expectedError.Error())
 				}

--- a/controller/linodecluster_controller_helpers.go
+++ b/controller/linodecluster_controller_helpers.go
@@ -2,8 +2,13 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/linode/linodego"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	"github.com/linode/cluster-api-provider-linode/cloud/services"
@@ -11,15 +16,33 @@ import (
 
 func (r *LinodeClusterReconciler) addMachineToLB(ctx context.Context, clusterScope *scope.ClusterScope) error {
 	logger := logr.FromContextOrDiscard(ctx)
-	if clusterScope.LinodeCluster.Spec.Network.LoadBalancerType != "dns" {
-		for _, eachMachine := range clusterScope.LinodeMachines.Items {
-			if err := services.AddNodesToNB(ctx, logger, clusterScope, eachMachine); err != nil {
-				return err
-			}
-		}
-	} else {
+	if clusterScope.LinodeCluster.Spec.Network.LoadBalancerType == "dns" {
 		if err := services.EnsureDNSEntries(ctx, clusterScope, "create"); err != nil {
 			return err
+		}
+		return nil
+	}
+	nodeBalancerNodes, err := clusterScope.LinodeClient.ListNodeBalancerNodes(
+		ctx,
+		*clusterScope.LinodeCluster.Spec.Network.NodeBalancerID,
+		*clusterScope.LinodeCluster.Spec.Network.ApiserverNodeBalancerConfigID,
+		&linodego.ListOptions{},
+	)
+	if err != nil {
+		return err
+	}
+	for _, eachMachine := range clusterScope.LinodeMachines.Items {
+		err = services.AddNodesToNB(ctx, logger, clusterScope, eachMachine, nodeBalancerNodes)
+		if err != nil {
+			return err
+		}
+	}
+	ipPortCombo := getIPPortCombo(clusterScope)
+	for _, node := range nodeBalancerNodes {
+		if !slices.Contains(ipPortCombo, node.Address) {
+			if err := clusterScope.LinodeClient.DeleteNodeBalancerNode(ctx, node.NodeBalancerID, node.ConfigID, node.ID); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -39,4 +62,23 @@ func (r *LinodeClusterReconciler) removeMachineFromLB(ctx context.Context, logge
 		}
 	}
 	return nil
+}
+
+func getIPPortCombo(cscope *scope.ClusterScope) (ipPortComboList []string) {
+	apiserverLBPort := services.DefaultApiserverLBPort
+	if cscope.LinodeCluster.Spec.Network.ApiserverLoadBalancerPort != 0 {
+		apiserverLBPort = cscope.LinodeCluster.Spec.Network.ApiserverLoadBalancerPort
+	}
+	for _, eachMachine := range cscope.LinodeMachines.Items {
+		for _, IPs := range eachMachine.Status.Addresses {
+			if IPs.Type != v1beta1.MachineInternalIP || !strings.Contains(IPs.Address, "192.168") {
+				continue
+			}
+			ipPortComboList = append(ipPortComboList, fmt.Sprintf("%s:%d", IPs.Address, apiserverLBPort))
+			for _, portConfig := range cscope.LinodeCluster.Spec.Network.AdditionalPorts {
+				ipPortComboList = append(ipPortComboList, fmt.Sprintf("%s:%d", IPs.Address, portConfig.Port))
+			}
+		}
+	}
+	return ipPortComboList
 }

--- a/controller/linodecluster_controller_helpers.go
+++ b/controller/linodecluster_controller_helpers.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -21,6 +22,12 @@ func (r *LinodeClusterReconciler) addMachineToLB(ctx context.Context, clusterSco
 			return err
 		}
 		return nil
+	}
+	if clusterScope.LinodeCluster.Spec.Network.NodeBalancerID == nil {
+		return errors.New("nil NodeBalancer Config ID")
+	}
+	if clusterScope.LinodeCluster.Spec.Network.ApiserverNodeBalancerConfigID == nil {
+		return errors.New("nil NodeBalancer Config ID")
 	}
 	nodeBalancerNodes, err := clusterScope.LinodeClient.ListNodeBalancerNodes(
 		ctx,

--- a/controller/linodecluster_controller_test.go
+++ b/controller/linodecluster_controller_test.go
@@ -353,6 +353,7 @@ var _ = Describe("cluster-lifecycle-dns", Ordered, Label("cluster", "cluster-lif
 							TTLSec: 30,
 						},
 					}, nil).AnyTimes()
+					mck.LinodeClient.EXPECT().DeleteDomainRecord(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				}),
 				Result("cluster created", func(ctx context.Context, mck Mock) {
 					reconciler.Client = k8sClient
@@ -558,6 +559,7 @@ var _ = Describe("dns-override-endpoint", Ordered, Label("cluster", "dns-overrid
 							TTLSec: 30,
 						},
 					}, nil).AnyTimes()
+					mck.LinodeClient.EXPECT().DeleteDomainRecord(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 				}),
 				Result("cluster created", func(ctx context.Context, mck Mock) {
 					reconciler.Client = k8sClient


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Currently, if an individual node is deleted and a new one comes up, a DNS entry is appropriately created, but, the entry of the deleted node remains. This PR fixes the issue