### PR TITLE
[fix] use protocol set by the firewall rule, add protocol validation

### DIFF
--- a/api/v1alpha2/linodefirewall_types.go
+++ b/api/v1alpha2/linodefirewall_types.go
@@ -63,12 +63,13 @@ type LinodeFirewallSpec struct {
 }
 
 type FirewallRule struct {
-	Action      string                   `json:"action"`
-	Label       string                   `json:"label"`
-	Description string                   `json:"description,omitempty"`
-	Ports       string                   `json:"ports,omitempty"`
-	Protocol    linodego.NetworkProtocol `json:"protocol"`
-	Addresses   *NetworkAddresses        `json:"addresses"`
+	Action      string `json:"action"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Ports       string `json:"ports,omitempty"`
+	// +kubebuilder:validation:Enum=TCP;UDP;ICMP;IPENCAP
+	Protocol  linodego.NetworkProtocol `json:"protocol"`
+	Addresses *NetworkAddresses        `json:"addresses"`
 }
 
 // NetworkAddresses holds a list of IPv4 and IPv6 addresses

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodefirewalls.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodefirewalls.yaml
@@ -106,6 +106,11 @@ spec:
                       type: string
                     protocol:
                       description: NetworkProtocol enum type
+                      enum:
+                      - TCP
+                      - UDP
+                      - ICMP
+                      - IPENCAP
                       type: string
                   required:
                   - action
@@ -150,6 +155,11 @@ spec:
                       type: string
                     protocol:
                       description: NetworkProtocol enum type
+                      enum:
+                      - TCP
+                      - UDP
+                      - ICMP
+                      - IPENCAP
                       type: string
                   required:
                   - action

--- a/controller/linodefirewall_controller_helpers.go
+++ b/controller/linodefirewall_controller_helpers.go
@@ -178,7 +178,7 @@ func processACL(firewall *infrav1alpha2.LinodeFirewall) (
 				Action:      rule.Action,
 				Label:       ruleLabel,
 				Description: fmt.Sprintf("Rule %d, Created by CAPL: %s", i, rule.Label),
-				Protocol:    linodego.TCP,
+				Protocol:    rule.Protocol,
 				Ports:       rule.Ports,
 				Addresses:   linodego.NetworkAddresses{IPv4: &v4chunk},
 			})
@@ -193,7 +193,7 @@ func processACL(firewall *infrav1alpha2.LinodeFirewall) (
 				Action:      rule.Action,
 				Label:       ruleLabel,
 				Description: fmt.Sprintf("Rule %d, Created by CAPL: %s", i, rule.Label),
-				Protocol:    linodego.TCP,
+				Protocol:    rule.Protocol,
 				Ports:       rule.Ports,
 				Addresses:   linodego.NetworkAddresses{IPv6: &v6chunk},
 			})
@@ -232,7 +232,7 @@ func processACL(firewall *infrav1alpha2.LinodeFirewall) (
 				Action:      rule.Action,
 				Label:       ruleLabel,
 				Description: fmt.Sprintf("Rule %d, Created by CAPL: %s", i, rule.Label),
-				Protocol:    linodego.TCP,
+				Protocol:    rule.Protocol,
 				Ports:       rule.Ports,
 				Addresses:   linodego.NetworkAddresses{IPv4: &v4chunk},
 			})
@@ -247,7 +247,7 @@ func processACL(firewall *infrav1alpha2.LinodeFirewall) (
 				Action:      rule.Action,
 				Label:       ruleLabel,
 				Description: fmt.Sprintf("Rule %d, Created by CAPL: %s", i, rule.Label),
-				Protocol:    linodego.TCP,
+				Protocol:    rule.Protocol,
 				Ports:       rule.Ports,
 				Addresses:   linodego.NetworkAddresses{IPv6: &v6chunk},
 			})


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: The protocol was previously hard-coded to TCP. This change is necessary for other protocols to work like UDP.

Sample FW:
```
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
kind: LinodeFirewall
metadata:
  name: sample-fw
spec:
  enabled: true
  inboundPolicy: DROP
  inboundRules:
    - action: ACCEPT
      label: DHCP
      ports: "68,546"
      protocol: "UDP"
      addresses:
        ipv4:
          - "0.0.0.0/0"
        ipv6:
          - "::/0"
      label: node_traffic
      ports: "1-65535"
      protocol: "TCP"
      addresses:
        ipv4:
          - 10.0.0.0/24
    - action: ACCEPT
      label: node_traffic
      ports: "1-65535"
      protocol: "UDP"
      addresses:
        ipv4:
          - 10.0.0.0/24
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


