### PR TITLE
[fix] block credentials deletion until all dependent resources are cleaned up

### DIFF
--- a/controller/linodecluster_controller.go
+++ b/controller/linodecluster_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -219,6 +220,10 @@ func (r *LinodeClusterReconciler) reconcileDelete(ctx context.Context, logger lo
 	if clusterScope.LinodeCluster.Spec.Network.NodeBalancerID == nil && clusterScope.LinodeCluster.Spec.Network.LoadBalancerType != lbTypeDNS {
 		logger.Info("NodeBalancer ID is missing, nothing to do")
 
+		if len(clusterScope.LinodeMachines.Items) == 0 {
+			return errors.New("Waiting for associated LinodeMachine objects to be deleted")
+		}
+
 		if err := clusterScope.RemoveCredentialsRefFinalizer(ctx); err != nil {
 			logger.Error(err, "failed to remove credentials finalizer")
 			setFailureReason(clusterScope, cerrs.DeleteClusterError, err, r)
@@ -249,6 +254,10 @@ func (r *LinodeClusterReconciler) reconcileDelete(ctx context.Context, logger lo
 	clusterScope.LinodeCluster.Spec.Network.NodeBalancerID = nil
 	clusterScope.LinodeCluster.Spec.Network.ApiserverNodeBalancerConfigID = nil
 	clusterScope.LinodeCluster.Spec.Network.AdditionalPorts = []infrav1alpha2.LinodeNBPortConfig{}
+
+	if len(clusterScope.LinodeMachines.Items) == 0 {
+		return errors.New("Waiting for associated LinodeMachine objects to be deleted")
+	}
 
 	if err := clusterScope.RemoveCredentialsRefFinalizer(ctx); err != nil {
 		logger.Error(err, "failed to remove credentials finalizer")

--- a/controller/linodecluster_controller.go
+++ b/controller/linodecluster_controller.go
@@ -220,7 +220,7 @@ func (r *LinodeClusterReconciler) reconcileDelete(ctx context.Context, logger lo
 	if clusterScope.LinodeCluster.Spec.Network.NodeBalancerID == nil && clusterScope.LinodeCluster.Spec.Network.LoadBalancerType != lbTypeDNS {
 		logger.Info("NodeBalancer ID is missing, nothing to do")
 
-		if len(clusterScope.LinodeMachines.Items) == 0 {
+		if len(clusterScope.LinodeMachines.Items) > 0 {
 			return errors.New("Waiting for associated LinodeMachine objects to be deleted")
 		}
 
@@ -255,7 +255,7 @@ func (r *LinodeClusterReconciler) reconcileDelete(ctx context.Context, logger lo
 	clusterScope.LinodeCluster.Spec.Network.ApiserverNodeBalancerConfigID = nil
 	clusterScope.LinodeCluster.Spec.Network.AdditionalPorts = []infrav1alpha2.LinodeNBPortConfig{}
 
-	if len(clusterScope.LinodeMachines.Items) == 0 {
+	if len(clusterScope.LinodeMachines.Items) > 0 {
 		return errors.New("Waiting for associated LinodeMachine objects to be deleted")
 	}
 

--- a/templates/infra/linodeMachineTemplate.yaml
+++ b/templates/infra/linodeMachineTemplate.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     spec:
+      credentialsRef:
+        name: ${CLUSTER_NAME}-credentials
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_CONTROL_PLANE_MACHINE_TYPE}
       region: ${LINODE_REGION}
@@ -27,6 +29,8 @@ metadata:
 spec:
   template:
     spec:
+      credentialsRef:
+        name: ${CLUSTER_NAME}-credentials
       image: ${LINODE_OS:="linode/ubuntu22.04"}
       type: ${LINODE_MACHINE_TYPE}
       region: ${LINODE_REGION}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We are currently relying on the credentials secret to fetch token for the linodeclient. The machine and cluster controllers rely on this to be present.
We need to block the deletion of said secret until all resources that rely on this secret are deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


