### PR TITLE
[fix] handle nil firewall ID if there is an error creating the Firewall referenced

### DIFF
--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -312,15 +312,20 @@ func getFirewallID(ctx context.Context, machineScope *scope.MachineScope, logger
 
 	logger = logger.WithValues("firewallName", name, "firewallNamespace", namespace)
 
-	linodeFirewall := infrav1alpha2.LinodeFirewall{
+	linodeFirewall := &infrav1alpha2.LinodeFirewall{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 		},
 	}
-	objectKey := client.ObjectKeyFromObject(&linodeFirewall)
-	err := machineScope.Client.Get(ctx, objectKey, &linodeFirewall)
+	objectKey := client.ObjectKeyFromObject(linodeFirewall)
+	err := machineScope.Client.Get(ctx, objectKey, linodeFirewall)
 	if err != nil {
+		logger.Error(err, "Failed to fetch LinodeFirewall")
+		return -1, err
+	}
+	if linodeFirewall.Spec.FirewallID == nil {
+		err = errors.New("nil firewallID")
 		logger.Error(err, "Failed to fetch LinodeFirewall")
 		return -1, err
 	}


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: If a Firewall already exists with the same label, Firewall creation will fail and the resulting ID will be nil. This addresses that edge case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


