### PR TITLE
[improvement] update default firewall to restrict API server access and fix nodeport range

### DIFF
--- a/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
@@ -63,7 +63,7 @@ patches:
             ports: "${APISERVER_PORT:=6443}"
             protocol: TCP
             label: inbound-api-server
-            description: accept all api server and konnectivity related traffic from nodebalancers
+            description: accept all api server related traffic from nodebalancers
           - action: ACCEPT
             addresses:
               ipv4:

--- a/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
@@ -20,3 +20,55 @@ patches:
           dnsUniqueIdentifier: ${DNS_UNIQUE_ID}
           dnsProvider: ${DNS_PROVIDER:-"linode"}
           dnsSubDomainOverride: ${DNS_SUBDOMAIN_OVERRIDE:-""}
+  - target:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1alpha2
+      kind: LinodeFirewall
+    patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeFirewall
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        inboundRules:
+          - action: ACCEPT
+            label: intra-cluster-tcp
+            ports: "1-65535"
+            protocol: "TCP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all tcp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-udp
+            ports: "1-65535"
+            protocol: "UDP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all udp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-icmp
+            protocol: "ICMP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all icmp traffic within the vpc
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 0.0.0.0/0
+              ipv6:
+                - ::/0
+            ports: "${APISERVER_PORT:=6443}"
+            protocol: TCP
+            label: inbound-api-server
+            description: accept all api server and konnectivity related traffic from nodebalancers
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 192.168.255.0/24
+            ports: 30000-32767
+            protocol: TCP
+            label: accept-NodeBalancer
+            description: accept traffic from the entire NodeBalancer CIDR to the NodePort service range

--- a/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
@@ -20,3 +20,55 @@ patches:
           dnsUniqueIdentifier: ${DNS_UNIQUE_ID}
           dnsProvider: ${DNS_PROVIDER:-"linode"}
           dnsSubDomainOverride: ${DNS_SUBDOMAIN_OVERRIDE:-""}
+  - target:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1alpha2
+      kind: LinodeFirewall
+    patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeFirewall
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        inboundRules:
+          - action: ACCEPT
+            label: intra-cluster-tcp
+            ports: "1-65535"
+            protocol: "TCP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all tcp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-udp
+            ports: "1-65535"
+            protocol: "UDP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all udp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-icmp
+            protocol: "ICMP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all icmp traffic within the vpc
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 0.0.0.0/0
+              ipv6:
+                - ::/0
+            ports: "${APISERVER_PORT:=6443}}"
+            protocol: TCP
+            label: inbound-api-server
+            description: accept all api server and konnectivity related traffic from nodebalancers
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 192.168.255.0/24
+            ports: 30000-32767
+            protocol: TCP
+            label: accept-NodeBalancer
+            description: accept traffic from the entire NodeBalancer CIDR to the NodePort service range

--- a/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
@@ -60,10 +60,10 @@ patches:
                 - 0.0.0.0/0
               ipv6:
                 - ::/0
-            ports: "${APISERVER_PORT:=6443}}"
+            ports: "${APISERVER_PORT:=6443}"
             protocol: TCP
             label: inbound-api-server
-            description: accept all api server and konnectivity related traffic from nodebalancers
+            description: accept all api server related traffic from nodebalancers
           - action: ACCEPT
             addresses:
               ipv4:

--- a/templates/flavors/kubeadm/konnectivity/kustomization.yaml
+++ b/templates/flavors/kubeadm/konnectivity/kustomization.yaml
@@ -115,3 +115,53 @@ patches:
                 toPorts:
                   - ports:
                       - port: "${KONNECTIVITY_PORT:=8132}"
+  - target:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1alpha2
+      kind: LinodeFirewall
+    patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeFirewall
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        inboundRules:
+          - action: ACCEPT
+            label: intra-cluster-tcp
+            ports: "1-65535"
+            protocol: "TCP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all tcp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-udp
+            ports: "1-65535"
+            protocol: "UDP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all udp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-icmp
+            protocol: "ICMP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all icmp traffic within the vpc
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 192.168.255.0/24
+            ports: "${APISERVER_PORT:=6443}, ${KONNECTIVITY_PORT:=8132}"
+            protocol: TCP
+            label: inbound-api-server
+            description: accept all api server and konnectivity related traffic from nodebalancers
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 192.168.255.0/24
+            ports: 30000-32767
+            protocol: TCP
+            label: accept-NodeBalancer
+            description: accept traffic from the entire NodeBalancer CIDR to the NodePort service range

--- a/templates/flavors/rke2/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/rke2/dns-loadbalancing/kustomization.yaml
@@ -63,7 +63,7 @@ patches:
             ports: "${APISERVER_PORT:=6443}"
             protocol: TCP
             label: inbound-api-server
-            description: accept all api server and konnectivity related traffic from nodebalancers
+            description: accept all api server related traffic from nodebalancers
           - action: ACCEPT
             addresses:
               ipv4:

--- a/templates/flavors/rke2/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/rke2/dns-loadbalancing/kustomization.yaml
@@ -20,3 +20,55 @@ patches:
           dnsUniqueIdentifier: ${DNS_UNIQUE_ID}
           dnsProvider: ${DNS_PROVIDER:-"linode"}
           dnsSubDomainOverride: ${DNS_SUBDOMAIN_OVERRIDE:-""}
+  - target:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1alpha2
+      kind: LinodeFirewall
+    patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeFirewall
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        inboundRules:
+          - action: ACCEPT
+            label: intra-cluster-tcp
+            ports: "1-65535"
+            protocol: "TCP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all tcp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-udp
+            ports: "1-65535"
+            protocol: "UDP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all udp traffic within the vpc
+          - action: ACCEPT
+            label: intra-cluster-icmp
+            protocol: "ICMP"
+            addresses:
+              ipv4:
+                - "10.0.0.0/8"
+            description: accept all icmp traffic within the vpc
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 0.0.0.0/0
+              ipv6:
+                - ::/0
+            ports: "${APISERVER_PORT:=6443}"
+            protocol: TCP
+            label: inbound-api-server
+            description: accept all api server and konnectivity related traffic from nodebalancers
+          - action: ACCEPT
+            addresses:
+              ipv4:
+                - 192.168.255.0/24
+            ports: 30000-32767
+            protocol: TCP
+            label: accept-NodeBalancer
+            description: accept traffic from the entire NodeBalancer CIDR to the NodePort service range

--- a/templates/infra/linodeFirewall.yaml
+++ b/templates/infra/linodeFirewall.yaml
@@ -37,18 +37,16 @@ spec:
     - action: ACCEPT
       addresses:
         ipv4:
-          - 0.0.0.0/0
-        ipv6:
-          - ::/0
-      ports: 6443, 8132
+          - 192.168.255.0/24
+      ports: "6443"
       protocol: TCP
       label: inbound-api-server
-      description: accept all api server and Konnectivity related traffic
+      description: accept all api server related traffic from nodebalancers
     - action: ACCEPT
       addresses:
         ipv4:
           - 192.168.255.0/24
-      ports: 30000-30100
+      ports: 30000-32767
       protocol: TCP
       label: accept-NodeBalancer
       description: accept traffic from the entire NodeBalancer CIDR to the NodePort service range

--- a/templates/infra/linodeFirewall.yaml
+++ b/templates/infra/linodeFirewall.yaml
@@ -38,7 +38,7 @@ spec:
       addresses:
         ipv4:
           - 192.168.255.0/24
-      ports: "6443"
+      ports: "${APISERVER_PORT:=6443}"
       protocol: TCP
       label: inbound-api-server
       description: accept all api server related traffic from nodebalancers


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR tweaks firewall rules to be more accurate restrictive in the following ways:
- [x] by default the API server port is restricted only to the nodebalancer range since it isn't needed to talk be talked to directly
- [x] the nodeport range is expanded from 30000-30100 to the nodeport default range of 30000-32767
- [x] konnectivity port rules are only enabled in the konnectivity flavor
- [x] dns based loadbalancing flavors have specific API server rules to allow direct connection to the API server

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


