### PR TITLE
[improvement] Add env var toggle for gzip compression of cloud-init user data

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -271,12 +271,18 @@ func setupControllers(mgr manager.Manager, flags flagVars, linodeClientConfig, d
 		os.Exit(1)
 	}
 
+	useGzip, err := strconv.ParseBool(os.Getenv("GZIP_COMPRESSION_ENABLED"))
+	if err != nil {
+		setupLog.Error(err, "proceeding without gzip compression for cloud-init data")
+	}
+
 	// LinodeMachine Controller
 	if err := (&controller.LinodeMachineReconciler{
-		Client:             mgr.GetClient(),
-		Recorder:           mgr.GetEventRecorderFor("LinodeMachineReconciler"),
-		WatchFilterValue:   flags.machineWatchFilter,
-		LinodeClientConfig: linodeClientConfig,
+		Client:                 mgr.GetClient(),
+		Recorder:               mgr.GetEventRecorderFor("LinodeMachineReconciler"),
+		WatchFilterValue:       flags.machineWatchFilter,
+		LinodeClientConfig:     linodeClientConfig,
+		GzipCompressionEnabled: useGzip,
 	}).SetupWithManager(mgr, crcontroller.Options{MaxConcurrentReconciles: flags.linodeMachineConcurrency}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LinodeMachine")
 		os.Exit(1)

--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -95,6 +95,8 @@ type LinodeMachineReconciler struct {
 	LinodeClientConfig scope.ClientConfig
 	WatchFilterValue   string
 	ReconcileTimeout   time.Duration
+	// Feature flags
+	GzipCompressionEnabled bool
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodemachines,verbs=get;list;watch;create;update;patch;delete
@@ -400,7 +402,7 @@ func (r *LinodeMachineReconciler) reconcilePreflightMetadataSupportConfigure(ctx
 
 func (r *LinodeMachineReconciler) reconcilePreflightCreate(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope) (ctrl.Result, error) {
 	// get the bootstrap data for the Linode instance and set it for create config
-	createOpts, err := newCreateConfig(ctx, machineScope, logger)
+	createOpts, err := newCreateConfig(ctx, machineScope, r.GzipCompressionEnabled, logger)
 	if err != nil {
 		logger.Error(err, "Failed to create Linode machine InstanceCreateOptions")
 		return retryIfTransient(err)

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	b64 "encoding/base64"
 	"errors"
@@ -95,7 +97,7 @@ func fillCreateConfig(createConfig *linodego.InstanceCreateOptions, machineScope
 	}
 }
 
-func newCreateConfig(ctx context.Context, machineScope *scope.MachineScope, logger logr.Logger) (*linodego.InstanceCreateOptions, error) {
+func newCreateConfig(ctx context.Context, machineScope *scope.MachineScope, gzipCompressionEnabled bool, logger logr.Logger) (*linodego.InstanceCreateOptions, error) {
 	var err error
 
 	createConfig := linodeMachineSpecToInstanceCreateConfig(machineScope.LinodeMachine.Spec)
@@ -108,7 +110,7 @@ func newCreateConfig(ctx context.Context, machineScope *scope.MachineScope, logg
 	}
 
 	createConfig.Booted = util.Pointer(false)
-	if err := setUserData(ctx, machineScope, createConfig, logger); err != nil {
+	if err := setUserData(ctx, machineScope, createConfig, gzipCompressionEnabled, logger); err != nil {
 		return nil, err
 	}
 
@@ -476,7 +478,21 @@ func linodeMachineSpecToInstanceCreateConfig(machineSpec infrav1alpha2.LinodeMac
 	}
 }
 
-func setUserData(ctx context.Context, machineScope *scope.MachineScope, createConfig *linodego.InstanceCreateOptions, logger logr.Logger) error {
+func compressUserData(bootstrapData []byte) ([]byte, error) {
+	var userDataBuff bytes.Buffer
+	var err error
+	gz := gzip.NewWriter(&userDataBuff)
+	defer func(gz *gzip.Writer) {
+		err = gz.Close()
+	}(gz)
+	if _, err := gz.Write(bootstrapData); err != nil {
+		return nil, err
+	}
+	err = gz.Close()
+	return userDataBuff.Bytes(), err
+}
+
+func setUserData(ctx context.Context, machineScope *scope.MachineScope, createConfig *linodego.InstanceCreateOptions, gzipCompressionEnabled bool, logger logr.Logger) error {
 	bootstrapData, err := machineScope.GetBootstrapData(ctx)
 	if err != nil {
 		logger.Error(err, "Failed to get bootstrap data")
@@ -484,8 +500,18 @@ func setUserData(ctx context.Context, machineScope *scope.MachineScope, createCo
 		return err
 	}
 
+	userData := bootstrapData
+	//nolint:nestif // this is a temp flag until cloud-init is updated in cloud-init compatible images
 	if machineScope.LinodeMachine.Status.CloudinitMetadataSupport {
-		bootstrapSize := len(bootstrapData)
+		if gzipCompressionEnabled {
+			userData, err = compressUserData(bootstrapData)
+			if err != nil {
+				logger.Error(err, "failed to compress bootstrap data")
+
+				return err
+			}
+		}
+		bootstrapSize := len(userData)
 		if bootstrapSize > maxBootstrapDataBytesCloudInit {
 			err = errors.New("bootstrap data too large")
 			logger.Error(err, "decoded bootstrap data exceeds size limit",
@@ -496,7 +522,7 @@ func setUserData(ctx context.Context, machineScope *scope.MachineScope, createCo
 			return err
 		}
 		createConfig.Metadata = &linodego.InstanceMetadataOptions{
-			UserData: b64.StdEncoding.EncodeToString(bootstrapData),
+			UserData: b64.StdEncoding.EncodeToString(userData),
 		}
 	} else {
 		logger.Info("using StackScripts for bootstrapping")

--- a/controller/linodemachine_controller_test.go
+++ b/controller/linodemachine_controller_test.go
@@ -49,7 +49,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const defaultNamespace = "default"
+const (
+	defaultNamespace    = "default"
+	gzipCompressionFlag = false
+)
 
 var _ = Describe("create", Label("machine", "create"), func() {
 	var machine clusterv1.Machine
@@ -1820,7 +1823,7 @@ var _ = Describe("machine in PlacementGroup", Label("machine", "placementGroup")
 		Expect(err).NotTo(HaveOccurred())
 		mScope.PatchHelper = patchHelper
 
-		createOpts, err := newCreateConfig(ctx, &mScope, logger)
+		createOpts, err := newCreateConfig(ctx, &mScope, gzipCompressionFlag, logger)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createOpts).NotTo(BeNil())
 		Expect(createOpts.PlacementGroup.ID).To(Equal(1))
@@ -1997,7 +2000,7 @@ var _ = Describe("machine in VPC", Label("machine", "VPC"), Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		mScope.PatchHelper = patchHelper
 
-		createOpts, err := newCreateConfig(ctx, &mScope, logger)
+		createOpts, err := newCreateConfig(ctx, &mScope, gzipCompressionFlag, logger)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createOpts).NotTo(BeNil())
 		Expect(createOpts.Interfaces).To(Equal([]linodego.InstanceConfigInterfaceCreateOptions{
@@ -2073,7 +2076,7 @@ var _ = Describe("machine in VPC", Label("machine", "VPC"), Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		mScope.PatchHelper = patchHelper
 
-		createOpts, err := newCreateConfig(ctx, &mScope, logger)
+		createOpts, err := newCreateConfig(ctx, &mScope, gzipCompressionFlag, logger)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createOpts).NotTo(BeNil())
 		Expect(createOpts.Interfaces).To(Equal([]linodego.InstanceConfigInterfaceCreateOptions{


### PR DESCRIPTION
### NOTE: Using this toggle requires using OS images with an [updated cloud-init](https://github.com/canonical/cloud-init/commit/ce80781478f8e48d8edd13f69b8c1bc006114bde) version (>24.3.1)

**What this PR does / why we need it**: This adds support for gzipping the userData before base64 encoding it so we can fit more configuration into cloud-init.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


