### PR TITLE
Update IgnoreLinodeAPIError to accept multiple codes

### DIFF
--- a/util/helpers.go
+++ b/util/helpers.go
@@ -17,10 +17,12 @@ func Pointer[T any](t T) *T {
 }
 
 // IgnoreLinodeAPIError returns the error except matches to status code
-func IgnoreLinodeAPIError(err error, code int) error {
-	apiErr := linodego.Error{Code: code}
-	if apiErr.Is(err) {
-		err = nil
+func IgnoreLinodeAPIError(err error, codes ...int) error {
+	for _, code := range codes {
+		apiErr := linodego.Error{Code: code}
+		if apiErr.Is(err) {
+			return nil
+		}
 	}
 
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the utility func which helps you ignore https status codes to accept multiple inputs of codes so you can ignore 2+ codes in the same check.

**Which issue(sa) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


