### PR TITLE
[improvement] : retry on ratelimit-reset than always waiting for 15 secs

### DIFF
--- a/controller/linodemachine_controller.go
+++ b/controller/linodemachine_controller.go
@@ -321,9 +321,9 @@ func (r *LinodeMachineReconciler) reconcilePreflightCreate(ctx context.Context, 
 		return retryIfTransient(err)
 	}
 
-	linodeInstance, err := createInstance(ctx, logger, machineScope, createOpts)
+	linodeInstance, retryAfter, err := createInstance(ctx, logger, machineScope, createOpts)
 	if errors.Is(err, util.ErrRateLimit) {
-		return ctrl.Result{RequeueAfter: reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: retryAfter}, nil
 	}
 
 	if err != nil {

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -695,7 +695,11 @@ func getDefaultInstanceConfig(ctx context.Context, machineScope *scope.MachineSc
 }
 
 // createInstance provisions linode instance after checking if the request will be within the rate-limits
-// Note: it takes a lock before checking for the rate limits and releases it after making request to linode API or when returning from function
+// Note:
+//  1. this method represents the critical section. It takes a lock before checking for the rate limits and releases it after making request to linode API or when returning from function
+//  2. returned time duration here is not always used.
+//     a) In case of an error, we calculate for how long to requeue in method which checks if its a transient error or not.
+//     b) If POST limit is reached, only then the returned time duration is used to retry after that time has elapsed.
 func createInstance(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, createOpts *linodego.InstanceCreateOptions) (*linodego.Instance, time.Duration, error) {
 	ctr := util.GetPostReqCounter(machineScope.TokenHash)
 	ctr.Mu.Lock()

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -27,6 +27,7 @@ import (
 	"net/netip"
 	"slices"
 	"sort"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -695,16 +696,17 @@ func getDefaultInstanceConfig(ctx context.Context, machineScope *scope.MachineSc
 
 // createInstance provisions linode instance after checking if the request will be within the rate-limits
 // Note: it takes a lock before checking for the rate limits and releases it after making request to linode API or when returning from function
-func createInstance(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, createOpts *linodego.InstanceCreateOptions) (*linodego.Instance, error) {
+func createInstance(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, createOpts *linodego.InstanceCreateOptions) (*linodego.Instance, time.Duration, error) {
 	ctr := util.GetPostReqCounter(machineScope.TokenHash)
 	ctr.Mu.Lock()
 	defer ctr.Mu.Unlock()
 
 	if ctr.IsPOSTLimitReached() {
 		logger.Info(fmt.Sprintf("Cannot make more POST requests as rate-limit is reached (%d per %v seconds). Waiting and retrying after %v seconds", reconciler.SecondaryPOSTRequestLimit, reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay, reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay))
-		return nil, util.ErrRateLimit
+		return nil, ctr.RetryAfter(), util.ErrRateLimit
 	}
 
 	machineScope.LinodeClient.OnAfterResponse(ctr.ApiResponseRatelimitCounter)
-	return machineScope.LinodeClient.CreateInstance(ctx, *createOpts)
+	inst, err := machineScope.LinodeClient.CreateInstance(ctx, *createOpts)
+	return inst, time.Duration(reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay.Seconds()), err
 }

--- a/util/ratelimits.go
+++ b/util/ratelimits.go
@@ -72,6 +72,7 @@ func (c *PostRequestCounter) ApiResponseRatelimitCounter(resp *resty.Response) e
 func (c *PostRequestCounter) IsPOSTLimitReached() bool {
 	// TODO: Once linode API adjusts rate-limits, remove secondary rate limit and simplify accordingly
 	currTime := time.Now().Unix()
+	// if we have made 5 requests (5 remaining) or 10 requests (0 remaining), then we want to wait until refresh time has passed for that window
 	return currTime <= int64(c.RefreshTime) && (c.ReqRemaining == 0 || c.ReqRemaining == reconciler.SecondaryPOSTRequestLimit)
 }
 

--- a/util/ratelimits.go
+++ b/util/ratelimits.go
@@ -54,12 +54,13 @@ func (c *PostRequestCounter) ApiResponseRatelimitCounter(resp *resty.Response) e
 		return err
 	}
 
-	epochTime, err := strconv.Atoi(resp.Header().Get("X-Ratelimit-Reset"))
+	epochTime, err := strconv.ParseInt(resp.Header().Get("X-Ratelimit-Reset"), 10, 64)
 	if err != nil {
 		return err
 	}
-	c.RefreshTime = time.Unix(int64(epochTime), 0)
-	secondaryRefreshTime := time.Unix(int64(epochTime)-int64(reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay.Seconds()), 0)
+	c.RefreshTime = time.Unix(epochTime, 0)
+	// We Add a negative number as secondary refresh time is smaller than refresh time
+	secondaryRefreshTime := time.Unix(epochTime, 0).Add(reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay * -1)
 
 	// TODO: remove when rate-limits are simplified
 	currTime := time.Now()


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
First 5 POST requests take close to 5 secs or so. If we requeue subsequent requests with duration of 15 secs, then they will be next picked up at 20th second or so. This results in first 5 seconds of 15 sec window to not do anything. Since we are sleeping extra 5 or 6 secs in every 15 sec window, we end up taking additional 60+ seconds doing nothing when provisioning big clusters (say 100 node cluster). Ideally, we should sleep for 15 - 5 secs, i.e. 10 secs in this case. This PR takes account of ratelimit-reset value and uses that when requeueing.

Logs from cluster with new changes (bringing up 100 worker nodes)
```
k logs deploy/capl-controller-manager -n capl-system -f --timestamps > out.txt

cat out.txt  | grep "POST  /v4beta/linode/instances " | awk -F':' '{print $2}'  | sort -n | uniq -c | awk '{print $2 " - " $1}'
31 - 5
32 - 20
33 - 17
34 - 18
35 - 20
36 - 20
37 - 8

// First and last requests:
cat out.txt | grep "POST  /v4beta/linode/instances "

2024-10-07T19:31:49.369582068Z POST  /v4beta/linode/instances  HTTP/1.1
...
...
2024-10-07T19:37:29.415749236Z POST  /v4beta/linode/instances  HTTP/1.1
```
From above logs, total time taken for 100 node cluster: 5 min 40 secs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


