### PR TITLE
[fix] - add check for stackscript size limit when falling back to stackscripts, only check metadata for cloud-init size limit when actually using cloud-init to bootstrap

### DIFF
--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -474,10 +474,12 @@ func setUserData(ctx context.Context, machineScope *scope.MachineScope, createCo
 	}
 
 	if machineScope.LinodeMachine.Status.CloudinitMetadataSupport {
-		if len(bootstrapData) > maxBootstrapDataBytesCloudInit {
+		bootstrapSize := len(bootstrapData)
+		if bootstrapSize > maxBootstrapDataBytesCloudInit {
 			err = errors.New("bootstrap data too large")
 			logger.Error(err, "decoded bootstrap data exceeds size limit",
 				"limit", maxBootstrapDataBytesCloudInit,
+				"size", bootstrapSize,
 			)
 
 			return err
@@ -487,10 +489,12 @@ func setUserData(ctx context.Context, machineScope *scope.MachineScope, createCo
 		}
 	} else {
 		logger.Info("using StackScripts for bootstrapping")
-		if len(bootstrapData) > maxBootstrapDataBytesStackscript {
+		bootstrapSize := len(bootstrapData)
+		if bootstrapSize > maxBootstrapDataBytesStackscript {
 			err = errors.New("bootstrap data too large")
 			logger.Error(err, "decoded bootstrap data exceeds size limit",
 				"limit", maxBootstrapDataBytesStackscript,
+				"size", bootstrapSize,
 			)
 
 			return err


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: We were checking the bootstrap data doesn't exceed the cloud-init size limit even when using stackscripts which have a higher limit (which wasn't checked). This PR addresses that. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


