### PR TITLE
[improvement] : simplify rate limits as we now have only one limit for POST calls

### DIFF
--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -705,11 +705,11 @@ func createInstance(ctx context.Context, logger logr.Logger, machineScope *scope
 	defer ctr.Mu.Unlock()
 
 	if ctr.IsPOSTLimitReached() {
-		logger.Info(fmt.Sprintf("Cannot make more POST requests as rate-limit is reached (%d per %v seconds). Waiting and retrying after %v seconds", reconciler.SecondaryPOSTRequestLimit, reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay, reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay))
+		logger.Info(fmt.Sprintf("Cannot make more POST requests as rate-limit is reached (%d per %v seconds). Waiting and retrying after %v seconds", reconciler.DefaultPOSTRequestLimit, reconciler.DefaultLinodeTooManyPOSTRequestsErrorRetryDelay, ctr.RetryAfter()))
 		return nil, ctr.RetryAfter(), util.ErrRateLimit
 	}
 
 	machineScope.LinodeClient.OnAfterResponse(ctr.ApiResponseRatelimitCounter)
 	inst, err := machineScope.LinodeClient.CreateInstance(ctx, *createOpts)
-	return inst, time.Duration(reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay.Seconds()), err
+	return inst, time.Duration(reconciler.DefaultLinodeTooManyPOSTRequestsErrorRetryDelay.Seconds()), err
 }

--- a/util/ratelimits.go
+++ b/util/ratelimits.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
-
-	"github.com/linode/cluster-api-provider-linode/util/reconciler"
 )
 
 // PostRequestCounter keeps track of rate limits for POST to /linode/instances
@@ -84,7 +82,9 @@ func GetPostReqCounter(tokenHash string) *PostRequestCounter {
 	ctr, exists := postRequestCounters[tokenHash]
 	if !exists {
 		ctr = &PostRequestCounter{
-			ReqRemaining: reconciler.DefaultPOSTRequestLimit,
+			// Set remaining requests to a number greater than 0.
+			// It gets updated to correct value once first POST request is made using the token.
+			ReqRemaining: 1,
 			RefreshTime:  time.Time{},
 		}
 		postRequestCounters[tokenHash] = ctr

--- a/util/ratelimits.go
+++ b/util/ratelimits.go
@@ -59,22 +59,12 @@ func (c *PostRequestCounter) ApiResponseRatelimitCounter(resp *resty.Response) e
 		return err
 	}
 	c.RefreshTime = time.Unix(epochTime, 0)
-	// We Add a negative number as secondary refresh time is smaller than refresh time
-	secondaryRefreshTime := time.Unix(epochTime, 0).Add(reconciler.SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay * -1)
-
-	// TODO: remove when rate-limits are simplified
-	currTime := time.Now()
-	if c.ReqRemaining >= reconciler.SecondaryPOSTRequestLimit && currTime.Before(secondaryRefreshTime) {
-		c.RefreshTime = secondaryRefreshTime
-	}
 	return nil
 }
 
 // IsPOSTLimitReached checks whether POST limits have been reached.
 func (c *PostRequestCounter) IsPOSTLimitReached() bool {
-	// TODO: Once linode API adjusts rate-limits, remove secondary rate limit and simplify accordingly
-	// if we have made 5 requests (5 remaining) or 10 requests (0 remaining), then we want to wait until refresh time has passed for that window
-	return time.Now().Before(c.RefreshTime) && (c.ReqRemaining == 0 || c.ReqRemaining == reconciler.SecondaryPOSTRequestLimit)
+	return time.Now().Before(c.RefreshTime) && c.ReqRemaining == 0
 }
 
 // RetryAfter returns how long to wait in seconds for rate-limit to reset

--- a/util/ratelimits_test.go
+++ b/util/ratelimits_test.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
-
-	"github.com/linode/cluster-api-provider-linode/util/reconciler"
 )
 
 func TestGetPostReqCounter(t *testing.T) {
@@ -48,7 +46,7 @@ func TestGetPostReqCounter(t *testing.T) {
 			name:      "provide hash which doesn't exist",
 			tokenHash: "uvwxyz",
 			want: &PostRequestCounter{
-				ReqRemaining: reconciler.DefaultPOSTRequestLimit,
+				ReqRemaining: 1,
 				RefreshTime:  time.Time{},
 			},
 		},

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -65,11 +65,6 @@ const (
 
 	// DefaultDNSTTLSec is the default TTL used for DNS entries for api server loadbalancing
 	DefaultDNSTTLSec = 30
-
-	// DefaultLinodeTooManyPOSTRequestsErrorRetryDelay is the default requeue delay if there is Linode API error for POST request
-	DefaultLinodeTooManyPOSTRequestsErrorRetryDelay = 15 * time.Second
-	// DefaultPOSTRequestLimit is the default limit of how many POST requests can be made to /linode/instances endpoint in 15 seconds before rate-limit reset.
-	DefaultPOSTRequestLimit = 5
 )
 
 // DefaultedLoopTimeout will default the timeout if it is zero-valued.

--- a/util/reconciler/defaults.go
+++ b/util/reconciler/defaults.go
@@ -66,14 +66,10 @@ const (
 	// DefaultDNSTTLSec is the default TTL used for DNS entries for api server loadbalancing
 	DefaultDNSTTLSec = 30
 
-	// DefaultLinodeTooManyPOSTRequestsErrorRetryDelay is the default requeue delay if there is Linode API error for POST request. Currently, it is set to 10 requests per 30 seconds
-	DefaultLinodeTooManyPOSTRequestsErrorRetryDelay = 30 * time.Second
-	// SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay is the secondary requeue delay if there is Linode API error for POST request. Currently, it is set to 5 requests per 15 seconds
-	SecondaryLinodeTooManyPOSTRequestsErrorRetryDelay = 15 * time.Second
-	// DefaultPOSTRequestLimit is the default limit of how many POST requests can be made to /linode/instances endpoint in 30 seconds before rate-limit reset.
-	DefaultPOSTRequestLimit = 10
-	// SecondaryPOSTRequestLimit is the secondary limit of how many POST requests can be made to /linode/instances endpoint in 15 seconds before rate-limit kicks in.
-	SecondaryPOSTRequestLimit = 5
+	// DefaultLinodeTooManyPOSTRequestsErrorRetryDelay is the default requeue delay if there is Linode API error for POST request
+	DefaultLinodeTooManyPOSTRequestsErrorRetryDelay = 15 * time.Second
+	// DefaultPOSTRequestLimit is the default limit of how many POST requests can be made to /linode/instances endpoint in 15 seconds before rate-limit reset.
+	DefaultPOSTRequestLimit = 5
 )
 
 // DefaultedLoopTimeout will default the timeout if it is zero-valued.


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Since the rate limits are now simplified to 5 req/15 secs, this PR updates CAPL to use that. Logs from a deployed cluster when worker nodes are scaled up from 0 to 100 nodes
```
cat logs/14oct/100nodes1.txt | grep "POST  /v4beta/linode/instances " | wc -l
100

cat logs/14oct/100nodes1.txt | grep "POST  /v4beta/linode/instances " | awk -F':' '{print $2}'  | sort -n | uniq -c | awk '{print $2 " - " $1}'
21 - 2
22 - 18
23 - 20
24 - 17
25 - 18
26 - 19
27 - 6
```

Time it took to bring up 100 nodes: 5 min 40 secs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


