### PR TITLE
[improvement] : simplify addr calculation and fetch instance config only for vlans

### DIFF
--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -193,11 +193,13 @@ func buildInstanceAddrs(ctx context.Context, machineScope *scope.MachineScope, i
 	})
 
 	// check if a node has vpc specific ip and store it
-	if len(addresses.IPv4.VPC) != 0 {
-		ips = append(ips, clusterv1.MachineAddress{
-			Address: *addresses.IPv4.VPC[0].Address,
-			Type:    clusterv1.MachineInternalIP,
-		})
+	for _, vpcIP := range addresses.IPv4.VPC {
+		if *vpcIP.Address != "" {
+			ips = append(ips, clusterv1.MachineAddress{
+				Address: *vpcIP.Address,
+				Type:    clusterv1.MachineInternalIP,
+			})
+		}
 	}
 
 	if machineScope.LinodeCluster.Spec.Network.UseVlan {

--- a/controller/linodemachine_controller_helpers.go
+++ b/controller/linodemachine_controller_helpers.go
@@ -170,12 +170,6 @@ func buildInstanceAddrs(ctx context.Context, machineScope *scope.MachineScope, i
 		return nil, fmt.Errorf("get instance ips: %w", err)
 	}
 
-	// get the default instance config
-	configs, err := machineScope.LinodeClient.ListInstanceConfigs(ctx, instanceID, &linodego.ListOptions{})
-	if err != nil || len(configs) == 0 {
-		return nil, fmt.Errorf("list instance configs: %w", err)
-	}
-
 	ips := []clusterv1.MachineAddress{}
 	// check if a node has public ipv4 ip and store it
 	if len(addresses.IPv4.Public) == 0 {
@@ -198,21 +192,30 @@ func buildInstanceAddrs(ctx context.Context, machineScope *scope.MachineScope, i
 		Type:    clusterv1.MachineExternalIP,
 	})
 
-	// Iterate over interfaces in config and find VPC or VLAN specific ips
-	for _, iface := range configs[0].Interfaces {
-		if iface.VPCID != nil && iface.IPv4.VPC != "" {
-			ips = append(ips, clusterv1.MachineAddress{
-				Address: iface.IPv4.VPC,
-				Type:    clusterv1.MachineInternalIP,
-			})
+	// check if a node has vpc specific ip and store it
+	if len(addresses.IPv4.VPC) != 0 {
+		ips = append(ips, clusterv1.MachineAddress{
+			Address: *addresses.IPv4.VPC[0].Address,
+			Type:    clusterv1.MachineInternalIP,
+		})
+	}
+
+	if machineScope.LinodeCluster.Spec.Network.UseVlan {
+		// get the default instance config
+		configs, err := machineScope.LinodeClient.ListInstanceConfigs(ctx, instanceID, &linodego.ListOptions{})
+		if err != nil || len(configs) == 0 {
+			return nil, fmt.Errorf("list instance configs: %w", err)
 		}
 
-		if iface.Purpose == linodego.InterfacePurposeVLAN {
-			// vlan addresses have a /11 appended to them - we should strip it out.
-			ips = append(ips, clusterv1.MachineAddress{
-				Address: netip.MustParsePrefix(iface.IPAMAddress).Addr().String(),
-				Type:    clusterv1.MachineInternalIP,
-			})
+		// Iterate over interfaces in config and find VLAN specific ips
+		for _, iface := range configs[0].Interfaces {
+			if iface.Purpose == linodego.InterfacePurposeVLAN {
+				// vlan addresses have a /11 appended to them - we should strip it out.
+				ips = append(ips, clusterv1.MachineAddress{
+					Address: netip.MustParsePrefix(iface.IPAMAddress).Addr().String(),
+					Type:    clusterv1.MachineInternalIP,
+				})
+			}
 		}
 	}
 

--- a/controller/linodemachine_controller_test.go
+++ b/controller/linodemachine_controller_test.go
@@ -229,7 +229,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				BootInstance(ctx, 123, 0).
 				After(createInst).
 				Return(nil)
-			getAddrs := mockLinodeClient.EXPECT().
+			mockLinodeClient.EXPECT().
 				GetInstanceIPAddresses(ctx, 123).
 				After(bootInst).
 				Return(&linodego.InstanceIPAddressResponse{
@@ -243,14 +243,6 @@ var _ = Describe("create", Label("machine", "create"), func() {
 						},
 					},
 				}, nil)
-			mockLinodeClient.EXPECT().
-				ListInstanceConfigs(ctx, 123, gomock.Any()).
-				After(getAddrs).
-				Return([]linodego.InstanceConfig{{
-					Devices: &linodego.InstanceConfigDeviceMap{
-						SDA: &linodego.InstanceConfigDevice{DiskID: 100},
-					},
-				}}, nil)
 			linodeMachine.Spec.FirewallRef = &corev1.ObjectReference{Name: "fw2", Namespace: defaultNamespace, Kind: "LinodeFirewall", APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2"}
 			mScope := scope.MachineScope{
 				Client:        k8sClient,
@@ -295,7 +287,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 			BootInstance(ctx, 123, 0).
 			After(createInst).
 			Return(nil)
-		getAddrs := mockLinodeClient.EXPECT().
+		mockLinodeClient.EXPECT().
 			GetInstanceIPAddresses(ctx, 123).
 			After(bootInst).
 			Return(&linodego.InstanceIPAddressResponse{
@@ -309,14 +301,6 @@ var _ = Describe("create", Label("machine", "create"), func() {
 					},
 				},
 			}, nil)
-		mockLinodeClient.EXPECT().
-			ListInstanceConfigs(ctx, 123, gomock.Any()).
-			After(getAddrs).
-			Return([]linodego.InstanceConfig{{
-				Devices: &linodego.InstanceConfigDeviceMap{
-					SDA: &linodego.InstanceConfigDevice{DiskID: 100},
-				},
-			}}, nil)
 
 		mScope := scope.MachineScope{
 			Client:        k8sClient,
@@ -536,7 +520,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				}).
 				After(getAddrs).MaxTimes(2).
 				Return(nil, nil)
-			getAddrs = mockLinodeClient.EXPECT().
+			mockLinodeClient.EXPECT().
 				GetInstanceIPAddresses(ctx, 123).
 				After(createNB).
 				Return(&linodego.InstanceIPAddressResponse{
@@ -550,14 +534,6 @@ var _ = Describe("create", Label("machine", "create"), func() {
 						},
 					},
 				}, nil).MaxTimes(2)
-			mockLinodeClient.EXPECT().
-				ListInstanceConfigs(ctx, 123, gomock.Any()).
-				After(getAddrs).
-				Return([]linodego.InstanceConfig{{
-					Devices: &linodego.InstanceConfigDeviceMap{
-						SDA: &linodego.InstanceConfigDevice{DiskID: 100},
-					},
-				}}, nil)
 
 			mScope := scope.MachineScope{
 				Client:        k8sClient,
@@ -716,6 +692,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 					IPv4: &linodego.InstanceIPv4Response{
 						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
 						Public:  []*linodego.InstanceIP{{Address: "172.0.0.2"}},
+						VPC:     []*linodego.VPCIP{{Address: ptr.To("10.0.0.2")}},
 					},
 					IPv6: &linodego.InstanceIPv6Response{
 						SLAAC: &linodego.InstanceIP{
@@ -731,13 +708,14 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				}).
 				After(getAddrs).
 				Return(nil, nil).MaxTimes(2)
-			getAddrs = mockLinodeClient.EXPECT().
+			mockLinodeClient.EXPECT().
 				GetInstanceIPAddresses(ctx, 123).
 				After(createNB).
 				Return(&linodego.InstanceIPAddressResponse{
 					IPv4: &linodego.InstanceIPv4Response{
 						Private: []*linodego.InstanceIP{{Address: "192.168.0.2"}},
 						Public:  []*linodego.InstanceIP{{Address: "172.0.0.2"}},
+						VPC:     []*linodego.VPCIP{{Address: ptr.To("10.0.0.2")}},
 					},
 					IPv6: &linodego.InstanceIPv6Response{
 						SLAAC: &linodego.InstanceIP{
@@ -745,18 +723,6 @@ var _ = Describe("create", Label("machine", "create"), func() {
 						},
 					},
 				}, nil).MaxTimes(2)
-			mockLinodeClient.EXPECT().
-				ListInstanceConfigs(ctx, 123, gomock.Any()).
-				After(getAddrs).
-				Return([]linodego.InstanceConfig{{
-					Devices: &linodego.InstanceConfigDeviceMap{
-						SDA: &linodego.InstanceConfigDevice{DiskID: 100},
-					},
-					Interfaces: []linodego.InstanceConfigInterface{{
-						VPCID: ptr.To(1),
-						IPv4:  &linodego.VPCIPv4{VPC: "10.0.0.2"},
-					}},
-				}}, nil)
 
 			_, err = reconciler.reconcileCreate(ctx, logger, &mScope)
 			Expect(err).NotTo(HaveOccurred())
@@ -889,7 +855,7 @@ var _ = Describe("createDNS", Label("machine", "createDNS"), func() {
 			BootInstance(ctx, 123, 0).
 			After(createInst).
 			Return(nil)
-		getAddrs := mockLinodeClient.EXPECT().
+		mockLinodeClient.EXPECT().
 			GetInstanceIPAddresses(ctx, 123).
 			After(bootInst).
 			Return(&linodego.InstanceIPAddressResponse{
@@ -903,14 +869,6 @@ var _ = Describe("createDNS", Label("machine", "createDNS"), func() {
 					},
 				},
 			}, nil)
-		mockLinodeClient.EXPECT().
-			ListInstanceConfigs(ctx, 123, gomock.Any()).
-			After(getAddrs).
-			Return([]linodego.InstanceConfig{{
-				Devices: &linodego.InstanceConfigDeviceMap{
-					SDA: &linodego.InstanceConfigDevice{DiskID: 100},
-				},
-			}}, nil)
 
 		mScope := scope.MachineScope{
 			Client:        k8sClient,


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR simplifies buildInstanceAddrs function and makes getInstanceConfigs call only when required(in case of vlan). Otherwise, it relies on the output of `/v4/linode/instances/<id>/ips` to get all ips associated with the instance.

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


