### PR TITLE
[fix] respect vlan interface if defined in linodemachine

### DIFF
--- a/controller/linodemachine_controller_test.go
+++ b/controller/linodemachine_controller_test.go
@@ -2152,6 +2152,14 @@ var _ = Describe("machine in vlan", Label("machine", "vlan"), Ordered, func() {
 				Type:           "g6-nanode-1",
 				Image:          rutil.DefaultMachineControllerLinodeImage,
 				DiskEncryption: string(linodego.InstanceDiskEncryptionEnabled),
+				Interfaces: []infrav1alpha2.InstanceConfigInterfaceCreateOptions{
+					{
+						Purpose: linodego.InterfacePurposePublic,
+					},
+					{
+						Purpose: linodego.InterfacePurposeVLAN,
+					},
+				},
 			},
 		}
 
@@ -2221,6 +2229,9 @@ var _ = Describe("machine in vlan", Label("machine", "vlan"), Ordered, func() {
 			After(getAddrs).
 			Return([]linodego.InstanceConfig{{
 				Interfaces: []linodego.InstanceConfigInterface{
+					{
+						Purpose: linodego.InterfacePurposePublic,
+					},
 					{
 						Purpose:     linodego.InterfacePurposeVLAN,
 						IPAMAddress: "10.0.0.2/11",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: Currently we can't define the VLAN interface to be on something other than eth0. This respects what VLAN interface is defined in the LinodeMachine if any.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


