### PR TITLE
[test] bump Flatcar tested version to Stable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -275,7 +275,7 @@ func setupControllers(mgr manager.Manager, flags flagVars, linodeClientConfig, d
 
 	useGzip, err := strconv.ParseBool(os.Getenv("GZIP_COMPRESSION_ENABLED"))
 	if err != nil {
-		setupLog.Error(err, "proceeding without gzip compression for cloud-init data")
+		setupLog.Error(err, "proceeding without gzip compression for user-data")
 	}
 
 	// LinodeMachine Controller

--- a/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
@@ -37,14 +37,13 @@ spec:
                 value: (env('LINODE_REGION'))
             content: |
               set -e
-              # Get the latest version on Beta channel.
-              # NOTE: This can be changed to Stable when Akamai support will come on these channels.
+              # Get the latest version on Stable channel.
               curl -fsSL --remote-name \
-                https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_akamai_image.bin.gz
+                https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_akamai_image.bin.gz
 
               res=$(curl -s --request POST \
                 --url "https://${TARGET_API}/${TARGET_API_VERSION}/${URI}" \
-                --data '{"region":"'${LINODE_REGION}'","cloud_init":true,"label":"flatcar-beta"}' \
+                --data '{"region":"'${LINODE_REGION}'","cloud_init":true,"label":"flatcar-stable"}' \
                 --header "Authorization: Bearer ${LINODE_TOKEN}" \
                 --header "accept: application/json" \
                 --header "content-type: application/json")


### PR DESCRIPTION
**What this PR does / why we need it**: In this PR, we bump Flatcar channel to Stable. Akamai support (with GZIP compression support for user-data) is now available on Stable since the latest release.

**Special notes for your reviewer**: This is not tested yet

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests


