### PR TITLE
[improvement] : use fixed retryAfter instead of exponential backoff

### DIFF
--- a/internal/controller/linodemachine_controller_helpers.go
+++ b/internal/controller/linodemachine_controller_helpers.go
@@ -72,7 +72,7 @@ func retryIfTransient(err error, logger logr.Logger) (ctrl.Result, error) {
 		return ctrl.Result{RequeueAfter: reconciler.DefaultMachineControllerRetryDelay}, nil
 	}
 	logger.Error(err, "unknown Linode API error")
-	return ctrl.Result{RequeueAfter: reconciler.DefaultMachineControllerRetryDelay}, err
+	return ctrl.Result{RequeueAfter: reconciler.DefaultMachineControllerRetryDelay}, nil
 }
 
 func fillCreateConfig(createConfig *linodego.InstanceCreateOptions, machineScope *scope.MachineScope) {

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -624,9 +624,8 @@ var _ = Describe("create", Label("machine", "create"), func() {
 			reconciler.ReconcileTimeout = time.Nanosecond
 
 			res, err := reconciler.reconcileCreate(ctx, logger, &mScope)
-			Expect(res).NotTo(Equal(rutil.DefaultMachineControllerWaitForRunningDelay))
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("time is up"))
+			Expect(res.RequeueAfter).To(Equal(rutil.DefaultMachineControllerRetryDelay))
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(rutil.ConditionTrue(&linodeMachine, ConditionPreflightMetadataSupportConfigured)).To(BeTrue())
 			Expect(rutil.ConditionTrue(&linodeMachine, ConditionPreflightCreated)).To(BeFalse())


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We would like to use fixed backoff than exponential as exponential starts with microseconds and makes 10+ requests before it reaches 10 sec or higher backoff time. Since POST calls to /v4/linode/instances have low limits, we would like to make sure we don't make too many POST calls in case of an error due to exponential backoff. With this fix, we are now retrying at a fixed interval. This also affects other calls which use the same method to calculate how soon it should retry, but having a fixed interval for them is also fine.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


