### PR TITLE
[fix] disk_setup for additional user data in RKE2

### DIFF
--- a/templates/flavors/rke2/etcd-disk/kustomization.yaml
+++ b/templates/flavors/rke2/etcd-disk/kustomization.yaml
@@ -35,7 +35,7 @@ patches:
         agentConfig:
           additionalUserData:
             config: |-
-              diskSetup:
+              disk_setup:
                 /dev/sdc:
                   layout: true
               fs_setup:

--- a/templates/flavors/rke2/full-vpcless/kustomization.yaml
+++ b/templates/flavors/rke2/full-vpcless/kustomization.yaml
@@ -64,7 +64,7 @@ patches:
         agentConfig:
           additionalUserData:
             config: |-
-              diskSetup:
+              disk_setup:
                 /dev/sdc:
                   layout: true
               fs_setup:

--- a/templates/flavors/rke2/full/kustomization.yaml
+++ b/templates/flavors/rke2/full/kustomization.yaml
@@ -64,7 +64,7 @@ patches:
         agentConfig:
           additionalUserData:
             config: |-
-              diskSetup:
+              disk_setup:
                 /dev/sdc:
                   layout: true
               fs_setup:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: The other flavors use diskSetup to convert it to disk_setup for cloud-init but for RKE2 it needs to be directly in cloud-init format to work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


