### PR TITLE
[improvement] : allow CCM to work with different environments in CAPL

### DIFF
--- a/templates/addons/ccm-linode/ccm-linode.yaml
+++ b/templates/addons/ccm-linode/ccm-linode.yaml
@@ -9,7 +9,7 @@ spec:
   repoURL: https://linode.github.io/linode-cloud-controller-manager/
   chartName: ccm-linode
   namespace: kube-system
-  version: ${LINODE_CCM_VERSION:=v0.4.21}
+  version: ${LINODE_CCM_VERSION:=v0.4.22}
   options:
     waitForJobs: true
     wait: true

--- a/templates/addons/ccm-linode/ccm-linode.yaml
+++ b/templates/addons/ccm-linode/ccm-linode.yaml
@@ -23,3 +23,19 @@ spec:
       name: "linode-token-region"
     image:
       pullPolicy: IfNotPresent
+    env:
+      - name: LINODE_EXTERNAL_SUBNET
+        value: ${LINODE_EXTERNAL_SUBNET:=""}
+      - name: LINODE_URL
+        value: ${LINODE_URL:="https://api.linode.com"}
+      - name: SSL_CERT_DIR
+        value: "/tls"
+    volumeMounts:
+      - name: cacert
+        mountPath: /tls
+        readOnly: true
+    volumes:
+      - name: cacert
+        secret:
+          secretName: linode-ca
+          defaultMode: 420

--- a/templates/addons/cluster-resource-set/secret.yaml
+++ b/templates/addons/cluster-resource-set/secret.yaml
@@ -14,6 +14,21 @@ stringData:
       apiToken: ${LINODE_TOKEN}
       region: ${LINODE_REGION}
 ---
+apiVersion: v1
+kind: Secret
+type: addons.cluster.x-k8s.io/resource-set
+metadata:
+  name: linode-${CLUSTER_NAME}-crs-1
+stringData:
+  linode-ca.yaml: |-
+    kind: Secret
+    apiVersion: v1
+    metadata:
+      name: linode-ca
+      namespace: kube-system
+    data:
+      cacert.pem: ${LINODE_CA_BASE64:=""}
+---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
@@ -25,5 +40,6 @@ spec:
   resources:
     - kind: Secret
       name: linode-${CLUSTER_NAME}-crs-0
+    - kind: Secret
+      name: linode-${CLUSTER_NAME}-crs-1
   strategy: Reconcile
----

--- a/templates/addons/cluster-resource-set/secret.yaml
+++ b/templates/addons/cluster-resource-set/secret.yaml
@@ -13,13 +13,6 @@ stringData:
     stringData:
       apiToken: ${LINODE_TOKEN}
       region: ${LINODE_REGION}
----
-apiVersion: v1
-kind: Secret
-type: addons.cluster.x-k8s.io/resource-set
-metadata:
-  name: linode-${CLUSTER_NAME}-crs-1
-stringData:
   linode-ca.yaml: |-
     kind: Secret
     apiVersion: v1
@@ -40,6 +33,4 @@ spec:
   resources:
     - kind: Secret
       name: linode-${CLUSTER_NAME}-crs-0
-    - kind: Secret
-      name: linode-${CLUSTER_NAME}-crs-1
   strategy: Reconcile

--- a/templates/flavors/k3s/default/kustomization.yaml
+++ b/templates/flavors/k3s/default/kustomization.yaml
@@ -53,3 +53,19 @@ patches:
             name: "linode-token-region"
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420

--- a/templates/flavors/k3s/full-vpcless/kustomization.yaml
+++ b/templates/flavors/k3s/full-vpcless/kustomization.yaml
@@ -23,6 +23,22 @@ patches:
             pullPolicy: IfNotPresent
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
   - target:
       kind: LinodeVPC
     patch: |-

--- a/templates/flavors/k3s/vpcless/kustomization.yaml
+++ b/templates/flavors/k3s/vpcless/kustomization.yaml
@@ -17,6 +17,22 @@ patches:
             pullPolicy: IfNotPresent
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
   - target:
       kind: LinodeVPC
     patch: |-

--- a/templates/flavors/kubeadm/cilium-bgp-lb/kustomization.yaml
+++ b/templates/flavors/kubeadm/cilium-bgp-lb/kustomization.yaml
@@ -39,6 +39,10 @@ patches:
               value: ${LINODE_URL:="https://api.linode.com"}
             - name: SSL_CERT_DIR
               value: "/tls"
+            - name: BGP_PEER_PREFIX
+              value: ${BGP_PEER_PREFIX:=""}
+            - name: BGP_CUSTOM_ID_MAP
+              value: ${BGP_CUSTOM_ID_MAP:=""}
           volumeMounts:
             - name: cacert
               mountPath: /tls

--- a/templates/flavors/kubeadm/cilium-bgp-lb/kustomization.yaml
+++ b/templates/flavors/kubeadm/cilium-bgp-lb/kustomization.yaml
@@ -33,8 +33,21 @@ patches:
           image:
             pullPolicy: IfNotPresent
           env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
             - name: LINODE_URL
-              value: https://api.linode.com/v4beta
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
 transformers:
   - |
     apiVersion: builtin

--- a/templates/flavors/kubeadm/full-vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/full-vpcless/kustomization.yaml
@@ -44,6 +44,22 @@ patches:
             name: "linode-token-region"
           image:
             pullPolicy: IfNotPresent
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
   - target:
       kind: LinodeVPC
     patch: |-

--- a/templates/flavors/kubeadm/vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/vpcless/kustomization.yaml
@@ -39,7 +39,22 @@ patches:
             name: "linode-token-region"
           image:
             pullPolicy: IfNotPresent
-
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
   - target:
       kind: ConfigMap
       name: .*-cilium-policy

--- a/templates/flavors/rke2/default/kustomization.yaml
+++ b/templates/flavors/rke2/default/kustomization.yaml
@@ -55,3 +55,19 @@ patches:
             name: "linode-token-region"
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420

--- a/templates/flavors/rke2/vlan/kustomization.yaml
+++ b/templates/flavors/rke2/vlan/kustomization.yaml
@@ -15,6 +15,22 @@ patches:
             name: "linode-token-region"
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
   - target:
       kind: LinodeVPC
     patch: |-

--- a/templates/flavors/rke2/vpcless/kustomization.yaml
+++ b/templates/flavors/rke2/vpcless/kustomization.yaml
@@ -40,6 +40,22 @@ patches:
             pullPolicy: IfNotPresent
           nodeSelector:
             node-role.kubernetes.io/control-plane: "true"
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
   - target:
       kind: LinodeVPC
     patch: |-


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR allows CCM to work with different environments. Support to allow CAPL to work with different environments was added in https://github.com/linode/cluster-api-provider-linode/pull/546. This PR fixes CCM for child clusters. Along with other necessary vars required to provision a cluster, following vars also need to be set accordingly:
```
export LINODE_URL=<path of env's API>
export LINODE_CA=<env's CA file path on disk>
export LINODE_EXTERNAL_SUBNET=<network to be marked as public network>
export LINODE_CA_BASE64=<base64 encoded value of LINODE_CA>
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


