### PR TITLE
[improvement] : allow csi driver to run in different environments

### DIFF
--- a/templates/addons/csi-driver-linode/linode-csi.yaml
+++ b/templates/addons/csi-driver-linode/linode-csi.yaml
@@ -9,7 +9,7 @@ spec:
   repoURL: https://linode.github.io/linode-blockstorage-csi-driver/
   chartName: linode-blockstorage-csi-driver
   namespace: kube-system
-  version: ${LINODE_CSI_VERSION:=v0.8.4}
+  version: ${LINODE_CSI_VERSION:=v1.0.3}
   options:
     waitForJobs: true
     wait: true
@@ -18,3 +18,18 @@ spec:
     secretRef:
       name: "linode-token-region"
       apiTokenRef: "apiToken"
+    csiLinodePlugin:
+      env:
+        - name: LINODE_URL
+          value: ${LINODE_URL:="https://api.linode.com"}
+        - name: SSL_CERT_DIR
+          value: "/tls"
+      volumeMounts:
+        - name: cacert
+          mountPath: /tls
+          readOnly: true
+      volumes:
+        - name: cacert
+          secret:
+            secretName: linode-ca
+            defaultMode: 420


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR allows us to run CSI driver in different environments.

NOTE: This PR is dependent on https://github.com/linode/linode-blockstorage-csi-driver/pull/348 to be merged and release v1.0.3 cut for csi driver.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


