### PR TITLE
[improvement] : remove LINODE_CA and use LINODE_CA_BASE64 only

### DIFF
--- a/docs/src/developers/development.md
+++ b/docs/src/developers/development.md
@@ -40,7 +40,7 @@ needed via the make targets, but a recommendation is to
 #### Optional Environment Variables
 ```bash
 export LINODE_URL= # Default unset. Set this to talk to a specific linode api endpoint
-export LINODE_CA= # Default unset. Set this to use a specific CA when talking to the linode API
+export LINODE_CA_BASE64= # Default empty. Set this to base64 encoded content of specific CA when talking to custom linode API
 export CAPL_DEBUG=false # Default false. Set this to true to enable delve integration
 export INSTALL_K3S_PROVIDER=false # Default false. Set this to true to enable k3s capi provider installation
 export INSTALL_RKE2_PROVIDER=false # Default false. Set this to true to enable the RKE2 capi provider installation

--- a/docs/src/topics/linode-cloud-controller-manager.md
+++ b/docs/src/topics/linode-cloud-controller-manager.md
@@ -22,7 +22,6 @@ Check the cert contents and if its a CA, use it.
 Additional vars which needs to be set for custom enviroments:
 ```sh
 export LINODE_URL=<env specific API path>
-export LINODE_CA=<env specific CA file path on disk>
 export LINODE_EXTERNAL_SUBNET=<network to be marked as public network>
 export LINODE_CA_BASE64=<base64 encoded value of LINODE_CA cert content>
 ```


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We set both `LINODE_CA` and `LINODE_CA_BASE64` env vars. When `LINODE_CA` is set, we set `SSL_CERT_DIR` env var within the pod as we use [x509.SystemCertPool()](https://pkg.go.dev/crypto/x509#SystemCertPool) to set [root CAs](https://github.com/linode/cluster-api-provider-linode/blob/cb58ec3e8db7c2d9c0ee8e8003000169c7dcdb9a/cloud/scope/common.go#L81-L85).
`LINODE_CA_BASE64` is used to set CA content in secret used by child clusters as `clusterctl` doesn't allow us to read from file and set the content.
Instead of having two vars, we can remove one and just rely on `LINODE_CA_BASE64`.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


