### PR TITLE
[fix] : use UseURL to correctly parse URLs

### DIFF
--- a/cloud/scope/common.go
+++ b/cloud/scope/common.go
@@ -98,7 +98,10 @@ func CreateLinodeClient(config ClientConfig, opts ...Option) (LinodeClient, erro
 		newClient.SetRootCertificate(config.RootCertificatePath)
 	}
 	if config.BaseUrl != "" {
-		newClient.SetBaseURL(config.BaseUrl)
+		_, err := newClient.UseURL(config.BaseUrl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set base URL: %w", err)
+		}
 	}
 	newClient.SetUserAgent(fmt.Sprintf("CAPL/%s", version.GetVersion()))
 


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Folks keep on using https://api.linode.com/v4 as LINODE_URL. This URL combines both url and api version. When set with SetBaseURL, it incorrectly adds additional /v4 to the URLs and those API calls will fail. Instead of using [SetBaseURL()](https://github.com/linode/linodego/blob/v1.46.0/client.go#L463), we should use [UseURL()](https://github.com/linode/linodego/blob/v1.46.0/client.go#L436) which correctly parses URLs and then itself calls SetBaseURL.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


