### PR TITLE
[CI] : increase assert timeout from 5m to 10m

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -5,7 +5,7 @@ metadata:
   name: configuration
 spec:
   timeouts:
-    assert: 5m0s
+    assert: 10m0s
     cleanup: 5m0s
     delete: 5m0s
     error: 5m0s


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Sometimes, e2e tests fail randomly because a deployment or resource is not ready in default 5min interval. Example failure:
```
    l.go:52: | 16:26:13 | kubeadm-full-capl-cluster | @chainsaw                                       | CLEANUP   | END   |
=== NAME  chainsaw/rke2-capl-cluster
    l.go:52: | 16:30:32 | rke2-capl-cluster | Check child cluster resources                | ASSERT    | ERROR | apps/v1/Deployment @ kube-system/rke2-coredns-rke2-coredns
        === ERROR
        --------------------------------------------------------
        apps/v1/Deployment/kube-system/rke2-coredns-rke2-coredns
        --------------------------------------------------------
        * status.availableReplicas: Invalid value: 1: Expected value: 2
        * status.readyReplicas: Invalid value: 1: Expected value: 2
        
        --- expected
        +++ actual
        @@ -4,6 +4,6 @@
           name: rke2-coredns-rke2-coredns
           namespace: kube-system
         status:
        -  availableReplicas: 2
        -  readyReplicas: 2
        +  availableReplicas: 1
        +  readyReplicas: 1
    l.go:52: | 16:30:32 | rke2-capl-cluster | Check child cluster resources                | TRY       | END   |
    l.go:52: | 16:30:32 | rke2-capl-cluster | Check child cluster resources                | CATCH     | BEGIN |
    l.go:52: | 16:30:32 | rke2-capl-cluster | Check child cluster resources                | CMD       | RUN   |
        === COMMAND
```
We have seen sometimes deployments take a bit longer to come up and that causes e2e tests to just flake and error out. I've seen deployments/daemonsets sometimes taking 8 mins to become ready and hence bumping the assert timeout value to 10m.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


