### PR TITLE
chore: enable metadata gzip compression

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,8 @@ spec:
                   fieldPath: metadata.name
             - name: SSL_CERT_DIR
               value: /tls
+            - name: GZIP_COMPRESSION_ENABLED
+              value: "true"
           envFrom: # allows configuring additional stuff like LINODE_URL
             - secretRef:
                 name: capl-manager-credentials

--- a/e2e/linodemachine-controller/metadata-gzip-compression/assert-capi-resources.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/assert-capi-resources.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+  namespace: capl-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: kubeadm-bootstrap-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: kubeadm-control-plane-system
+status:
+  availableReplicas: 1

--- a/e2e/linodemachine-controller/metadata-gzip-compression/assert-linodemachine.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/assert-linodemachine.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  region: us-sea
+  type: g6-nanode-1
+status:
+  ready: true
+  instanceState: running
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Machine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  clusterName: ($cluster)
+status:
+  bootstrapReady: true
+  infrastructureReady: true

--- a/e2e/linodemachine-controller/metadata-gzip-compression/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/chainsaw-test.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: metadata-gzip-compression
+  # Label to trigger the test on every PR
+  labels:
+    all:
+    linodemachine:
+spec:
+  bindings:
+    # A short identifier for the E2E test run
+    - name: run
+      value: (join('-', ['e2e', 'metadata-gzip', env('GIT_REF')]))
+    - name: cluster
+      # Format the cluster name
+      value: (trim((truncate(($run), `29`)), '-'))
+  template: true
+  steps:
+    - name: Check if CAPI provider resources exist
+      try:
+        - assert:
+            file: assert-capi-resources.yaml
+    - name: Create Cluster resource
+      try:
+        - apply:
+            file: create-cluster.yaml
+      catch:
+        - describe:
+            apiVersion: cluster.x-k8s.io/v1beta1
+            kind: Cluster
+    - name: Generate dummy cloud-config data
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -e
+
+              # Some very compressible data
+              printf %102400s | tr ' ' '🫵🤓' > chonk.txt
+              kubectl -n $NAMESPACE create secret generic chonk-secret --from-file=chonk.txt
+            check:
+              ($error): ~
+    - name: Create LinodeMachine resource
+      try:
+        - apply:
+            file: create-linodemachine.yaml
+        - assert:
+            file: assert-linodemachine.yaml
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachineTemplate
+        - describe:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlane
+    - name: Delete Cluster resource
+      try:
+        - delete:
+            ref:
+              apiVersion: cluster.x-k8s.io/v1beta1
+              kind: Cluster
+              name: ($cluster)
+        - error:
+            file: check-linodemachine-deletion.yaml

--- a/e2e/linodemachine-controller/metadata-gzip-compression/check-linodemachine-deletion.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/check-linodemachine-deletion.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)

--- a/e2e/linodemachine-controller/metadata-gzip-compression/create-cluster.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/create-cluster.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ($cluster)
+spec:
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ($cluster)
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: LinodeCluster
+    name: ($cluster)
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeCluster
+metadata:
+  name: ($cluster)
+spec:
+  region: us-sea

--- a/e2e/linodemachine-controller/metadata-gzip-compression/create-linodemachine.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/create-linodemachine.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+    name: ($cluster)
+spec:
+    kubeadmConfigSpec:
+        files:
+            - path: /chonk.txt
+              contentFrom:
+                  secret:
+                      key: chonk.txt
+                      name: chonk-secret
+        clusterConfiguration:
+            apiServer:
+                extraArgs:
+                    cloud-provider: external
+            controllerManager:
+                extraArgs:
+                    cloud-provider: external
+    machineTemplate:
+        infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachineTemplate
+            name: ($cluster)
+    replicas: 1
+    version: 1.29.1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachineTemplate
+metadata:
+    name: ($cluster)
+spec:
+    template:
+        spec:
+            region: us-sea
+            type: g6-nanode-1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Enables gzip compression by default for Linode's [Metadata service](https://techdocs.akamai.com/cloud-computing/docs/overview-of-the-metadata-service) when deploying Linode infrastructure instances.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The accompanying E2E test (`metadata-gzip-compression`) runs on the following suites/selectors: `linodemachine`, `all`

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests


