### PR TITLE
[improvement] Add default machine count values for control plane and worker nodes

### DIFF
--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -42,7 +42,6 @@ spec:
               clusterctl generate cluster $CLUSTER -n $NAMESPACE \
               --kubernetes-version ${KUBERNETES_VERSION} \
               --infrastructure local-linode:v0.0.0 \
-              --control-plane-machine-count 1 --worker-machine-count 1 \
               --config ${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml} > default-cluster.yaml
             check:
               ($error == null): true

--- a/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
@@ -79,7 +79,6 @@ spec:
               clusterctl generate cluster $CLUSTER -n $NAMESPACE \
               --kubernetes-version ${KUBERNETES_VERSION} \
               --infrastructure local-linode:v0.0.0 \
-              --control-plane-machine-count 1 --worker-machine-count 1 \
               --flavor kubeadm-flatcar \
               --config ${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml} > flatcar-cluster.yaml
             check:

--- a/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
@@ -55,7 +55,6 @@ spec:
                 clusterctl generate cluster $CLUSTER -n $NAMESPACE \
                 --flavor kubeadm-full --kubernetes-version ${KUBERNETES_VERSION} \
                 --infrastructure local-linode:v0.0.0 \
-                --control-plane-machine-count 1 --worker-machine-count 1 \
                 --config ${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml} > kubeadm-full-cluster.yaml
               fi
             check:

--- a/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
@@ -39,7 +39,6 @@ spec:
               clusterctl generate cluster $CLUSTER -n $NAMESPACE \
               --flavor rke2 --kubernetes-version ${KUBERNETES_VERSION}+rke2r1 \
               --infrastructure local-linode:v0.0.0 \
-              --control-plane-machine-count 1 --worker-machine-count 1 \
               --config ${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml} > rke2-cluster.yaml
             check:
               ($error == null): true

--- a/templates/addons/konnectivity/konnectivity.yaml
+++ b/templates/addons/konnectivity/konnectivity.yaml
@@ -17,5 +17,5 @@ spec:
   valuesTemplate: |
     proxyServerHost: {{ .InfraCluster.spec.controlPlaneEndpoint.host }}
     proxyServerPort: ${KONNECTIVITY_PORT:=8132}
-    serverCount: ${CONTROL_PLANE_MACHINE_COUNT}
+    serverCount: ${CONTROL_PLANE_MACHINE_COUNT:=1}
     agentReplicas: ${KONNECTIVITY_AGENT_REPLICAS:=3}

--- a/templates/flavors/clusterclass-kubeadm/cluster-template.yaml
+++ b/templates/flavors/clusterclass-kubeadm/cluster-template.yaml
@@ -22,9 +22,9 @@ spec:
       - name: workerMachineType
         value: ${LINODE_MACHINE_TYPE}
     controlPlane:
-      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
     workers:
       machineDeployments:
         - class: default-worker
           name: md-0
-          replicas: ${WORKER_MACHINE_COUNT}
+          replicas: ${WORKER_MACHINE_COUNT:=1}

--- a/templates/flavors/k3s/default/k3sControlPlane.yaml
+++ b/templates/flavors/k3s/default/k3sControlPlane.yaml
@@ -72,5 +72,5 @@ spec:
       - sed -i '/swap/d' /etc/fstab
       - swapoff -a
       - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   version: ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -4,7 +4,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: ${CLUSTER_NAME}-control-plane
 spec:
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   machineTemplate:
     infrastructureRef:
       kind: LinodeMachineTemplate

--- a/templates/flavors/kubeadm/flatcar/patch-flatcar.yaml
+++ b/templates/flavors/kubeadm/flatcar/patch-flatcar.yaml
@@ -4,7 +4,7 @@ kind: KubeadmControlPlane
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
   kubeadmConfigSpec:
     joinConfiguration:
       nodeRegistration:

--- a/templates/flavors/rke2/default/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/default/rke2ControlPlane.yaml
@@ -30,4 +30,4 @@ spec:
     - sed -i '/swap/d' /etc/fstab
     - swapoff -a
     - hostnamectl set-hostname '{{ ds.meta_data.label }}' && hostname -F /etc/hostname
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}

--- a/templates/infra/machineDeployment.yaml
+++ b/templates/infra/machineDeployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ${CLUSTER_NAME}-md-0
 spec:
   clusterName: ${CLUSTER_NAME}
-  replicas: ${WORKER_MACHINE_COUNT}
+  replicas: ${WORKER_MACHINE_COUNT:=1}
   selector:
     matchLabels:
   template:


### PR DESCRIPTION
**Reason for change**:
This change adds default values of `1` for the `CONTROL_PLANE_MACHINE_COUNT` and `WORKER_MACHINE_COUNT` variables if they're not set in the user's environment variables. This prevents an issue where a cluster starts up with no machine deployments because the machine count environment variables aren't set and `replicas` is set to 0.

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [X] adds or updates e2e tests


