### PR TITLE
[fix] Pause placement group when pausing linode machine

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -173,13 +173,13 @@ linters:
     # - revive
     - staticcheck
     # - stylecheck
-    - tenv
     - thelper
     - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - varnamelen
     - whitespace
     # - wrapcheck

--- a/internal/controller/linodecluster_controller.go
+++ b/internal/controller/linodecluster_controller.go
@@ -51,8 +51,8 @@ import (
 )
 
 const (
-	lbTypeDNS string = "dns"
-
+	lbTypeDNS                               string = "dns"
+	pauseAnnotationValue                    string = "true"
 	ConditionPreflightLinodeVPCReady        string = "PreflightLinodeVPCReady"
 	ConditionPreflightLinodeNBFirewallReady string = "PreflightLinodeNBFirewallReady"
 )
@@ -155,7 +155,7 @@ func (r *LinodeClusterReconciler) reconcilePause(ctx context.Context, clusterSco
 		logger.Info("CAPI cluster is paused, pausing VPC")
 		// if we're paused, we should slap the pause annotation on our children
 		// get the vpc & add the annotation
-		annotations[clusterv1.PausedAnnotation] = "true"
+		annotations[clusterv1.PausedAnnotation] = pauseAnnotationValue
 	} else {
 		// we are not paused here, but were previously paused (we can get here only if conditionChanged is true.
 		logger.Info("CAPI cluster is no longer paused, removing pause annotation from VPC")

--- a/internal/controller/linodecluster_controller.go
+++ b/internal/controller/linodecluster_controller.go
@@ -122,12 +122,11 @@ func (r *LinodeClusterReconciler) reconcilePause(ctx context.Context, clusterSco
 	// Pausing a cluster pauses the VPC as well.
 	// First thing to do is handle a paused Cluster. Paused clusters shouldn't be deleted.
 	isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, clusterScope.Client, clusterScope.Cluster, clusterScope.LinodeCluster)
-	if err == nil && !isPaused && !conditionChanged {
-		return nil
-	}
-
 	if err != nil {
 		return err
+	}
+	if !(isPaused || conditionChanged) {
+		return nil
 	}
 
 	if clusterScope.LinodeCluster.Spec.VPCRef == nil {

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -171,21 +171,11 @@ func (r *LinodeMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return r.reconcile(ctx, log, machineScope)
 }
 
-func (r *LinodeMachineReconciler) reconcilePause(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope) error {
-	// Pausing a machine Pauses the firewall referred by the machine
-	isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, machineScope.Client, machineScope.Cluster, machineScope.LinodeMachine)
-
-	if err == nil && !isPaused && !conditionChanged {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
+func (r *LinodeMachineReconciler) pauseReferencedFirewall(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, isPaused bool, conditionChanged bool) error {
 	if machineScope.LinodeMachine.Spec.FirewallRef == nil {
 		logger.Info("Paused reconciliation is skipped due to missing Firewall ref")
 		return nil
 	}
-
 	linodeFW := infrav1alpha2.LinodeFirewall{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: machineScope.LinodeMachine.Spec.FirewallRef.Namespace,
@@ -207,8 +197,8 @@ func (r *LinodeMachineReconciler) reconcilePause(ctx context.Context, logger log
 		// if we're paused, we should slap the pause annotation on our children
 		// get the firewall & add the annotation
 		annotations[clusterv1.PausedAnnotation] = "true"
-	} else {
-		// we are not paused here, but were previously paused (we can get here only if conditionChanged is true.
+	} else if conditionChanged {
+		// we are not paused here, but were previously paused
 		logger.Info("CAPI cluster is no longer paused, removing pause annotation from Firewall")
 		delete(annotations, clusterv1.PausedAnnotation)
 	}
@@ -217,7 +207,72 @@ func (r *LinodeMachineReconciler) reconcilePause(ctx context.Context, logger log
 	if err != nil {
 		return fmt.Errorf("failed to create patch helper for firewalls: %w", err)
 	}
-	return fwPatchHelper.Patch(ctx, &linodeFW)
+	if err := fwPatchHelper.Patch(ctx, &linodeFW); err != nil {
+		return fmt.Errorf("failed to patch firewall: %w", err)
+	}
+	return nil
+}
+
+func (r *LinodeMachineReconciler) pauseReferencedPlacementGroup(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, isPaused bool, conditionChanged bool) error {
+	if machineScope.LinodeMachine.Spec.PlacementGroupRef == nil {
+		logger.Info("Paused reconciliation is skipped due to missing placement group ref")
+		return nil
+	}
+	linodePG := infrav1alpha2.LinodePlacementGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: machineScope.LinodeMachine.Spec.PlacementGroupRef.Namespace,
+			Name:      machineScope.LinodeMachine.Spec.PlacementGroupRef.Name,
+		},
+	}
+
+	if err := machineScope.Client.Get(ctx, client.ObjectKeyFromObject(&linodePG), &linodePG); err != nil {
+		return err
+	}
+
+	annotations := linodePG.ObjectMeta.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	if isPaused {
+		logger.Info("CAPI cluster is paused, pausing Placement Group too")
+		// if we're paused, we should slap the pause annotation on our children
+		// get the firewall & add the annotation
+		annotations[clusterv1.PausedAnnotation] = "true"
+	} else if conditionChanged {
+		// we are not paused here, but were previously paused
+		logger.Info("CAPI cluster is no longer paused, removing pause annotation from Placement Group ")
+		delete(annotations, clusterv1.PausedAnnotation)
+	}
+
+	linodePG.SetAnnotations(annotations)
+	fwPatchHelper, err := patch.NewHelper(&linodePG, machineScope.Client)
+	if err != nil {
+		return fmt.Errorf("failed to create patch helper for firewalls: %w", err)
+	}
+	if err := fwPatchHelper.Patch(ctx, &linodePG); err != nil {
+		return fmt.Errorf("failed to patch firewall: %w", err)
+	}
+	return nil
+}
+
+func (r *LinodeMachineReconciler) reconcilePause(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope) error {
+	// Pausing a machine Pauses the firewall referred by the machine
+	isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, machineScope.Client, machineScope.Cluster, machineScope.LinodeMachine)
+
+	if err == nil && !isPaused && !conditionChanged {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := r.pauseReferencedFirewall(ctx, logger, machineScope, isPaused, conditionChanged); err != nil {
+		return fmt.Errorf("failed to pause referenced firewall: %w", err)
+	}
+	if err := r.pauseReferencedPlacementGroup(ctx, logger, machineScope, isPaused, conditionChanged); err != nil {
+		return fmt.Errorf("failed to pause referenced placement group: %w", err)
+	}
+	return nil
 }
 
 func (r *LinodeMachineReconciler) reconcile(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope) (res ctrl.Result, err error) {

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -171,7 +171,7 @@ func (r *LinodeMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return r.reconcile(ctx, log, machineScope)
 }
 
-func (r *LinodeMachineReconciler) pauseReferencedFirewall(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, isPaused bool, conditionChanged bool) error {
+func (r *LinodeMachineReconciler) pauseReferencedFirewall(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, isPaused, conditionChanged bool) error {
 	if machineScope.LinodeMachine.Spec.FirewallRef == nil {
 		logger.Info("Paused reconciliation is skipped due to missing Firewall ref")
 		return nil
@@ -196,7 +196,7 @@ func (r *LinodeMachineReconciler) pauseReferencedFirewall(ctx context.Context, l
 		logger.Info("CAPI cluster is paused, pausing Firewall too")
 		// if we're paused, we should slap the pause annotation on our children
 		// get the firewall & add the annotation
-		annotations[clusterv1.PausedAnnotation] = "true"
+		annotations[clusterv1.PausedAnnotation] = pauseAnnotationValue
 	} else if conditionChanged {
 		// we are not paused here, but were previously paused
 		logger.Info("CAPI cluster is no longer paused, removing pause annotation from Firewall")
@@ -213,7 +213,7 @@ func (r *LinodeMachineReconciler) pauseReferencedFirewall(ctx context.Context, l
 	return nil
 }
 
-func (r *LinodeMachineReconciler) pauseReferencedPlacementGroup(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, isPaused bool, conditionChanged bool) error {
+func (r *LinodeMachineReconciler) pauseReferencedPlacementGroup(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, isPaused, conditionChanged bool) error {
 	if machineScope.LinodeMachine.Spec.PlacementGroupRef == nil {
 		logger.Info("Paused reconciliation is skipped due to missing placement group ref")
 		return nil
@@ -238,7 +238,7 @@ func (r *LinodeMachineReconciler) pauseReferencedPlacementGroup(ctx context.Cont
 		logger.Info("CAPI cluster is paused, pausing Placement Group too")
 		// if we're paused, we should slap the pause annotation on our children
 		// get the firewall & add the annotation
-		annotations[clusterv1.PausedAnnotation] = "true"
+		annotations[clusterv1.PausedAnnotation] = pauseAnnotationValue
 	} else if conditionChanged {
 		// we are not paused here, but were previously paused
 		logger.Info("CAPI cluster is no longer paused, removing pause annotation from Placement Group ")

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -259,13 +259,13 @@ func (r *LinodeMachineReconciler) pauseReferencedPlacementGroup(ctx context.Cont
 func (r *LinodeMachineReconciler) reconcilePause(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope) error {
 	// Pausing a machine Pauses the firewall referred by the machine
 	isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, machineScope.Client, machineScope.Cluster, machineScope.LinodeMachine)
-
-	if err == nil && !isPaused && !conditionChanged {
-		return nil
-	}
 	if err != nil {
 		return err
 	}
+	if !(isPaused || conditionChanged) {
+		return nil
+	}
+
 	if err := r.pauseReferencedFirewall(ctx, logger, machineScope, isPaused, conditionChanged); err != nil {
 		return fmt.Errorf("failed to pause referenced firewall: %w", err)
 	}


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Placement groups are not paused when a linode machine is paused, they must be paused as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


