### PR TITLE
[improvement] toggle cis hardening for rke2 clusters

### DIFF
--- a/docs/src/topics/flavors/rke2.md
+++ b/docs/src/topics/flavors/rke2.md
@@ -1,13 +1,6 @@
 # RKE2
 
-This flavor uses RKE2 for the kubernetes distribution. By default it configures the cluster
-with the [CIS profile](https://docs.rke2.io/security/hardening_guide#rke2-configuration):
-> Using the generic cis profile will ensure that the cluster passes the CIS benchmark (rke2-cis-1.XX-profile-hardened) associated with the Kubernetes version that RKE2 is running. For example, RKE2 v1.28.XX with the profile: cis will pass the rke2-cis-1.7-profile-hardened in Rancher.
-
-```admonish warning
-Until [this upstream PR](https://github.com/rancher-sandbox/cluster-api-provider-rke2/pull/301) is merged, CIS profile enabling
-will not work for RKE2 versions >= v1.29.
-```
+This flavor uses RKE2 for the kubernetes distribution.
 
 ## Specification
 | Control Plane                 | CNI    | Default OS   | Installs ClusterClass | IPv4 | IPv6 |
@@ -20,6 +13,15 @@ will not work for RKE2 versions >= v1.29.
   ```shell
   clusterctl init --bootstrap rke2 --control-plane rke2
   ```
+
+### CIS Hardening
+The default configuration does not enable [CIS hardening](https://docs.rke2.io/security/hardening_guide#rke2-configuration).
+To enable this, set the following variables:
+```bash
+export CIS_PROFILE=cis
+export CIS_ENABLED=true
+```
+
 ## Usage
 1. Generate cluster yaml
     ```bash
@@ -32,3 +34,4 @@ will not work for RKE2 versions >= v1.29.
     ```bash
     kubectl apply -f test-rke2-cluster.yaml
     ```
+

--- a/templates/flavors/rke2/default/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/default/rke2ConfigTemplate.yaml
@@ -8,8 +8,8 @@ spec:
     spec:
       agentConfig:
         nodeName: '{{ ds.meta_data.label }}'
-        cisProfile: ${CIS_PROFILE:-"cis-1.23"}
-        protectKernelDefaults: true
+        cisProfile: ${CIS_PROFILE:-""}
+        protectKernelDefaults: ${CIS_ENABLED:-false}
         kubelet:
           extraArgs:
             - "provider-id=linode://{{ ds.meta_data.id }}"

--- a/templates/flavors/rke2/default/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/default/rke2ControlPlane.yaml
@@ -24,8 +24,8 @@ spec:
         - "kubeProxy"
   agentConfig:
     nodeName: '{{ ds.meta_data.label }}'
-    cisProfile: ${CIS_PROFILE:-"cis-1.23"}
-    protectKernelDefaults: true
+    cisProfile: ${CIS_PROFILE:-""}
+    protectKernelDefaults: ${CIS_ENABLED:-false}
   preRKE2Commands:
     - sed -i '/swap/d' /etc/fstab
     - swapoff -a


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: RKE2 clusters have CIS hardening hard-coded to on. This makes that configurable and defaults it to off, mainly because templating the CIS_PROFILE is finicky. Trying to set the value to an empty string gets interpreted as unset which causes the empty value to be overwritten to enabled on the `clusterctl generate`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


