### PR TITLE
Refactor reconciliation logic in Linode controllers to handle deletion cases gracefully

### DIFF
--- a/internal/controller/linodemachine_controller_helpers.go
+++ b/internal/controller/linodemachine_controller_helpers.go
@@ -202,7 +202,7 @@ func buildInstanceAddrs(ctx context.Context, machineScope *scope.MachineScope, i
 
 	// check if a node has vpc specific ip and store it
 	for _, vpcIP := range addresses.IPv4.VPC {
-		if *vpcIP.Address != "" {
+		if vpcIP.Address != nil && *vpcIP.Address != "" {
 			ips = append(ips, clusterv1.MachineAddress{
 				Address: *vpcIP.Address,
 				Type:    clusterv1.MachineInternalIP,


### PR DESCRIPTION
Updated the Reconcile methods in LinodeFirewall, LinodePlacementGroup, and LinodeVPC controllers to allow for successful reconciliation when the associated cluster is not found during deletion. Added logging to indicate when a cluster is not found but the resource is being deleted, ensuring that the deletion process continues smoothly. Additionally, modified the pause logic to only check for paused conditions if the resource is not being deleted or if the cluster still exists.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


