### PR TITLE
Increase assert timeout for e2e test in GHA

### DIFF
--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -106,7 +106,7 @@ jobs:
         exclude:
           - flavor: src
         include:
-          - flavor: 'all'
+          - flavor: ${{ github.ref == 'refs/heads/main' && 'all' || 'quick' }}
     uses: ./.github/workflows/e2e-test.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -106,12 +106,12 @@ jobs:
         exclude:
           - flavor: src
         include:
-          - flavor: ${{ github.ref == 'refs/heads/main' && 'all' || 'quick' }}
+          - flavor: 'all'
     uses: ./.github/workflows/e2e-test.yaml
     secrets: inherit
     with:
       e2e-selector: ${{ matrix.flavor }}
-      e2e-flags: ${{ matrix.flavor == 'quick' && ''  || '--assert-timeout 15m0s'}}
+      e2e-flags: ${{ matrix.flavor == 'quick' && ''  || '--assert-timeout 20m0s'}}
 
 
   docker-build:

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
 
 permissions:
@@ -83,11 +80,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Check current code version
-        run: |
-          echo "Current branch: $(git branch --show-current)"
-          echo "Current commit: $(git rev-parse HEAD)"
 
       - name: Run Upgrade Test
         env:

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -84,6 +84,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check current code version
+        run: |
+          echo "Current branch: $(git branch --show-current)"
+          echo "Current commit: $(git rev-parse HEAD)"
+
       - name: Run Upgrade Test
         env:
           LINODE_REGION: us-sea

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - "*"
   workflow_dispatch:
 
 permissions:
@@ -87,6 +90,7 @@ jobs:
           LINODE_CONTROL_PLANE_MACHINE_TYPE: g6-standard-2
           LINODE_MACHINE_TYPE: g6-standard-2
           CLUSTERCTL_CONFIG: /home/runner/work/cluster-api-provider-linode/cluster-api-provider-linode/e2e/gha-clusterctl-config.yaml
+          E2E_FLAGS: --assert-timeout 20m0s
         run: make test-upgrade
 
       - name: cleanup stale clusters

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ test: generate fmt vet envtest ## Run tests.
 
 .PHONY: e2etest
 e2etest: generate local-release local-deploy chainsaw s5cmd
-	GIT_REF=$(GIT_REF) SSE_KEY=$$(openssl rand -base64 32) LOCALBIN=$(CACHE_BIN) $(CHAINSAW) test ./e2e --selector $(E2E_SELECTOR) $(E2E_FLAGS)
+	GIT_REF=$(GIT_REF) SSE_KEY=$$(openssl rand -base64 32) LOCALBIN=$(CACHE_BIN) $(CHAINSAW) test ./e2e --parallel 2 --selector $(E2E_SELECTOR) $(E2E_FLAGS)
 
 .PHONY: local-deploy
 local-deploy: kind-cluster tilt kustomize clusterctl
@@ -190,7 +190,7 @@ last-release-cluster: kind ctlptl tilt kustomize clusterctl chainsaw kind-cluste
 test-upgrade: last-release-cluster checkout-latest-commit
 	$(MAKE) local-release
 	$(MAKE) local-deploy
-	GIT_REF=$(COMMON_CLUSTER_REF) LOCALBIN=$(CACHE_BIN) CLUSTERCTL_CONFIG=$(CLUSTERCTL_CONFIG) $(CHAINSAW) test --namespace $(COMMON_NAMESPACE) --assert-timeout 600s ./e2e/capl-cluster-flavors/kubeadm-capl-cluster
+	GIT_REF=$(COMMON_CLUSTER_REF) LOCALBIN=$(CACHE_BIN) CLUSTERCTL_CONFIG=$(CLUSTERCTL_CONFIG) $(CHAINSAW) test --namespace $(COMMON_NAMESPACE) --assert-timeout 800s ./e2e/capl-cluster-flavors/kubeadm-capl-cluster
 
 .PHONY: clean-kind-cluster
 clean-kind-cluster: ctlptl

--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -146,10 +146,10 @@ spec:
                 echo "Skipping deletion of child cluster"
                 exit 0
               fi
-              kubectl delete cluster $CLUSTER -n $NAMESPACE --timeout=60s || { echo "deletion failed!"; exit 1; }
-              kubectl delete linodevpc $CLUSTER -n $NAMESPACE --timeout=60s || { echo "deletion failed!"; exit 1; }
-              kubectl delete linodefirewall $CLUSTER -n $NAMESPACE --timeout=60s || { echo "deletion failed!"; exit 1; }
-              kubectl delete linodefirewall $CLUSTER-nb -n $NAMESPACE --timeout=60s || { echo "deletion failed!"; exit 1; }
+              kubectl delete cluster $CLUSTER -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
+              kubectl delete linodevpc $CLUSTER -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
+              kubectl delete linodefirewall $CLUSTER -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
+              kubectl delete linodefirewall $CLUSTER-nb -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
             check:
               ($error == null): true
               (contains($stdout, 'deletion failed')): false


### PR DESCRIPTION
Some of our tests require a little bit more time to finish. We need to increase the assertion timeout time to 20m to account for those test. Also need to increase deletion timeout for kubectl commands in default-capl-cluster e2e test.

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


