### PR TITLE
[feat] : add nodeipam-ccm flavor

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
       - [rke2](./topics/flavors/rke2.md)
       - [vpcless](./topics/flavors/vpcless.md)
       - [konnectivity (kubeadm)](./topics/flavors/konnectivity.md)
+      - [NodeIPAM CCM (kubeadm)](./topics/flavors/nodeipam-ccm.md)
       - [DNS based apiserver Load Balancing](./topics/flavors/dns-loadbalancing.md)
       - [Flatcar](./topics/flavors/flatcar.md)
     - [Etcd](./topics/etcd.md)

--- a/docs/src/topics/flavors/nodeipam-ccm.md
+++ b/docs/src/topics/flavors/nodeipam-ccm.md
@@ -1,0 +1,26 @@
+# Node IPAM using CCM
+
+This flavor enables linode-cloud-controller-manager to perform nodeipam allocation. Nodeipam controller is disabled within kube-controller-manager and is enabled within CCM.
+
+## Specification
+| Supported Control Plane | CNI    | Default OS   | Installs ClusterClass | IPv4 | IPv6 |
+|-------------------------|--------|--------------|-----------------------|------|------|
+| kubeadm                 | Cilium | Ubuntu 22.04 | No                    | Yes  | No   |
+
+## Prerequisites
+[Quickstart](../getting-started.md) completed
+
+## Notes
+This flavor is identical to the default flavor with the exception that it disables nodeipam controller within kube-controller-manager and uses nodeipam controller within CCM to allocate pod cidrs to nodes.
+
+## Usage
+1. Generate cluster yaml
+    ```bash
+    clusterctl generate cluster test-cluster \
+        --infrastructure linode-linode \
+        --flavor <controlplane>-nodeipam-ccm > test-cluster.yaml
+    ```
+2. Apply cluster yaml
+    ```bash
+    kubectl apply -f test-cluster.yaml
+    ```

--- a/docs/src/topics/linode-cloud-controller-manager.md
+++ b/docs/src/topics/linode-cloud-controller-manager.md
@@ -9,6 +9,7 @@ CCM is linode specific implementation of [Cloud Controller Manager](https://kube
 * Node Controller: used for managing node objects in k8s cluster
 * Service Controller: used for managing services and exposing them to outside world
 * Route Controller: used for managing routes when running k8s cluster within VPC
+* Node IPAM Controller: if enabled, it allocates pod cidrs to nodes
 
 ## Installing CCM in custom environments (linode specific only)
 

--- a/templates/addons/ccm-linode/ccm-linode.yaml
+++ b/templates/addons/ccm-linode/ccm-linode.yaml
@@ -9,7 +9,7 @@ spec:
   repoURL: https://linode.github.io/linode-cloud-controller-manager/
   chartName: ccm-linode
   namespace: kube-system
-  version: ${LINODE_CCM_VERSION:=v0.5.2}
+  version: ${LINODE_CCM_VERSION:=v0.6.0}
   options:
     waitForJobs: true
     wait: true

--- a/templates/flavors/kubeadm/nodeipam-ccm/kustomization.yaml
+++ b/templates/flavors/kubeadm/nodeipam-ccm/kustomization.yaml
@@ -1,0 +1,80 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../default
+
+patches:
+  - target:
+      kind: HelmChartProxy
+      name: .*-linode-cloud-controller-manager
+    patch: |-
+      - op: replace
+        path: /spec/valuesTemplate
+        value: |
+          routeController:
+            vpcNames: {{ .InfraCluster.spec.vpcRef.name }}
+            clusterCIDR: ${VPC_NETWORK_CIDR:=10.192.0.0/10}
+            configureCloudRoutes: true
+          secretRef:
+            name: "linode-token-region"
+          image:
+            pullPolicy: IfNotPresent
+          enableNodeIPAM: true
+          tolerations:
+          # The CCM can run on Nodes tainted as masters
+            - key: "node-role.kubernetes.io/control-plane"
+              effect: "NoSchedule"
+            # The CCM is a "critical addon"
+            - key: "CriticalAddonsOnly"
+              operator: "Exists"
+            # This taint is set on all Nodes when an external CCM is used
+            - key: node.cloudprovider.kubernetes.io/uninitialized
+              value: "true"
+              effect: NoSchedule
+            - key: node.kubernetes.io/not-ready
+              operator: Exists
+              effect: NoSchedule
+            - key: node.kubernetes.io/unreachable
+              operator: Exists
+              effect: NoSchedule
+            - key: node.cilium.io/agent-not-ready
+              operator: Exists
+              effect: NoSchedule
+          env:
+            - name: LINODE_EXTERNAL_SUBNET
+              value: ${LINODE_EXTERNAL_SUBNET:=""}
+            - name: LINODE_URL
+              value: ${LINODE_URL:="https://api.linode.com"}
+            - name: SSL_CERT_DIR
+              value: "/tls"
+            - name: LINODE_API_VERSION
+              value: v4beta
+            - name: KUBERNETES_SERVICE_HOST
+              value: "{{ .InfraCluster.spec.controlPlaneEndpoint.host }}"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "{{ .InfraCluster.spec.controlPlaneEndpoint.port }}"
+          volumeMounts:
+            - name: cacert
+              mountPath: /tls
+              readOnly: true
+          volumes:
+            - name: cacert
+              secret:
+                secretName: linode-ca
+                defaultMode: 420
+
+  - target:
+      group: controlplane.cluster.x-k8s.io
+      version: v1beta1
+      kind: KubeadmControlPlane
+    patch: |-
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlane
+      metadata:
+        name: ${CLUSTER_NAME}-control-plane
+      spec:
+        kubeadmConfigSpec:
+          clusterConfiguration:
+            controllerManager:
+              extraArgs:
+                allocate-node-cidrs: "false"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR adds nodeipam-ccm flavor for kubeadm based clusters. It disables nodeipam controller within kube-controller-manager and enables it within CCM which does the ipv4 node ipam for the cluster.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


