### PR TITLE
[fix] Remove deletion of LinodeVPC and LinodeFirewall in e2etest

### DIFF
--- a/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
@@ -130,21 +130,6 @@ spec:
               apiVersion: cluster.x-k8s.io/v1beta1
               kind: Cluster
               name: ($cluster)
-        - delete:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-              kind: LinodeVPC
-              name: ($cluster)
-        - delete:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-              kind: LinodeFirewall
-              name: ($cluster)
-        - delete:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-              kind: LinodeFirewall
-              name: ($cluster)-nb
         - error:
             file: check-child-cluster-vpc-and-firewall-deleted.yaml
     - name: Check if the linodes are deleted

--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -147,9 +147,6 @@ spec:
                 exit 0
               fi
               kubectl delete cluster $CLUSTER -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
-              kubectl delete linodevpc $CLUSTER -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
-              kubectl delete linodefirewall $CLUSTER -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
-              kubectl delete linodefirewall $CLUSTER-nb -n $NAMESPACE --timeout=120s || { echo "deletion failed!"; exit 1; }
             check:
               ($error == null): true
               (contains($stdout, 'deletion failed')): false

--- a/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
@@ -129,21 +129,6 @@ spec:
               apiVersion: cluster.x-k8s.io/v1beta1
               kind: Cluster
               name: ($cluster)
-        - delete:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-              kind: LinodeVPC
-              name: ($cluster)
-        - delete:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-              kind: LinodeFirewall
-              name: ($cluster)
-        - delete:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-              kind: LinodeFirewall
-              name: ($cluster)-nb
         - error:
             file: check-child-cluster-vpc-and-firewall-deleted.yaml
     - name: Check if the linodes are deleted


### PR DESCRIPTION
**What this PR does / why we need it**:
We not longer need to delete them explicitly since we have now implemented ownerRefs. Just deleting `Cluster` will cascade the deletion to all the other resources like `LinodeVPC`, `LinodeFirewall`, `LinodePlacementgroyp`, etc.

We are seeing the e2e tests fail because we are trying to delete resources that were already deleted when `Cluster` was deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests


