### PR TITLE
[CI] : allow all githubusercontent.com calls

### DIFF
--- a/.github/workflows/build_test_ci.yml
+++ b/.github/workflows/build_test_ci.yml
@@ -56,12 +56,11 @@ jobs:
             golang.org:443
             proxy.golang.org:443
             sum.golang.org:443
-            objects.githubusercontent.com:443
+            *.githubusercontent.com:443
             storage.googleapis.com:443
             cli.codecov.io:443
             api.codecov.io:443
             ingest.codecov.io:443
-            raw.githubusercontent.com:443
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/go-analyze.yml
+++ b/.github/workflows/go-analyze.yml
@@ -29,6 +29,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            *.githubusercontent.com:443
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -49,8 +50,7 @@ jobs:
             github.com:443
             proxy.golang.org:443
             sum.golang.org:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
+            *.githubusercontent.com:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
             vuln.go.dev:443

--- a/.github/workflows/pull_request_ci.yaml
+++ b/.github/workflows/pull_request_ci.yaml
@@ -59,12 +59,11 @@ jobs:
             golang.org:443
             proxy.golang.org:443
             sum.golang.org:443
-            objects.githubusercontent.com:443
+            *.githubusercontent.com:443
             storage.googleapis.com:443
             cli.codecov.io:443
             api.codecov.io:443
             ingest.codecov.io:443
-            raw.githubusercontent.com:443
 
       - uses: actions/checkout@v4
 
@@ -101,7 +100,7 @@ jobs:
             go.dev:443
             dl.google.com:443
             golang.org:443
-            objects.githubusercontent.com:443
+            *.githubusercontent.com:443
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We are seeing `release-assets.githubusercontent.com` getting blocked in GHA runs. This PR allows all `*.githubusercontent.com`
Example: https://app.stepsecurity.io/github/linode/cluster-api-provider-linode/actions/runs/16310435533
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


