### PR TITLE
[feat] Add Support for VPC only backends

### DIFF
--- a/api/v1alpha2/linodecluster_types.go
+++ b/api/v1alpha2/linodecluster_types.go
@@ -190,6 +190,16 @@ type NetworkSpec struct {
 	// example: 10.10.10.0/30
 	// +optional
 	NodeBalancerBackendIPv4Range string `json:"nodeBalancerBackendIPv4Range,omitempty"`
+
+	// EnableVPCBackends toggles VPC-scoped NodeBalancer and VPC backend IP usage.
+	// If set to false (default), the NodeBalancer will not be created in a VPC and
+	// backends will use Linode private IPs. If true, the NodeBalancer will be
+	// created in the configured VPC (when VPCRef or VPCID is set) and backends
+	// will use VPC IPs.
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +optional
+	EnableVPCBackends bool `json:"enableVPCBackends,omitempty"`
 }
 
 type LinodeNBPortConfig struct {

--- a/cloud/services/loadbalancers_test.go
+++ b/cloud/services/loadbalancers_test.go
@@ -276,6 +276,7 @@ func TestEnsureNodeBalancer(t *testing.T) {
 							Namespace: "default",
 						},
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 					},
@@ -339,6 +340,7 @@ func TestEnsureNodeBalancer(t *testing.T) {
 						Region: "us-east",
 						VPCID:  ptr.To(456),
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 					},
@@ -393,6 +395,7 @@ func TestEnsureNodeBalancer(t *testing.T) {
 						Region: "us-east",
 						VPCID:  ptr.To(789),
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 					},
@@ -420,6 +423,7 @@ func TestEnsureNodeBalancer(t *testing.T) {
 							Namespace: "default",
 						},
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 					},
@@ -1713,6 +1717,7 @@ func TestAddNodeToNBFullWorkflow(t *testing.T) {
 							Namespace: "default",
 						},
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							NodeBalancerID:                ptr.To(1234),
 							ApiserverNodeBalancerConfigID: ptr.To(5678),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",
@@ -1786,6 +1791,7 @@ func TestAddNodeToNBFullWorkflow(t *testing.T) {
 							Namespace: "default",
 						},
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							NodeBalancerID:                ptr.To(1234),
 							ApiserverNodeBalancerConfigID: ptr.To(5678),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",
@@ -1844,6 +1850,7 @@ func TestAddNodeToNBFullWorkflow(t *testing.T) {
 							Namespace: "default",
 						},
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							NodeBalancerID:                ptr.To(1234),
 							ApiserverNodeBalancerConfigID: ptr.To(5678),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",
@@ -2564,6 +2571,7 @@ func TestAddNodeToNBWithVPC(t *testing.T) {
 					},
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							ApiserverNodeBalancerConfigID: ptr.To(222),
 							NodeBalancerID:                ptr.To(111),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",
@@ -2635,6 +2643,7 @@ func TestAddNodeToNBWithVPC(t *testing.T) {
 					},
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							ApiserverNodeBalancerConfigID: ptr.To(222),
 							NodeBalancerID:                ptr.To(111),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",
@@ -2710,6 +2719,7 @@ func TestAddNodeToNBWithVPC(t *testing.T) {
 					},
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							ApiserverNodeBalancerConfigID: ptr.To(222),
 							NodeBalancerID:                ptr.To(111),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",
@@ -2819,6 +2829,7 @@ func TestAddNodeToNBWithVPC(t *testing.T) {
 					},
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:             true,
 							ApiserverNodeBalancerConfigID: ptr.To(222),
 							NodeBalancerID:                ptr.To(111),
 							NodeBalancerBackendIPv4Range:  "10.0.0.0/24",

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
@@ -155,6 +155,18 @@ spec:
                       Ignored if the LoadBalancerType is set to anything other than dns
                       If not set, CAPL will create a unique identifier for you
                     type: string
+                  enableVPCBackends:
+                    default: false
+                    description: |-
+                      EnableVPCBackends toggles VPC-scoped NodeBalancer and VPC backend IP usage.
+                      If set to false (default), the NodeBalancer will not be created in a VPC and
+                      backends will use Linode private IPs. If true, the NodeBalancer will be
+                      created in the configured VPC (when VPCRef or VPCID is set) and backends
+                      will use VPC IPs.
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Value is immutable
+                      rule: self == oldSelf
                   loadBalancerType:
                     default: NodeBalancer
                     description: LoadBalancerType is the type of load balancer to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclustertemplates.yaml
@@ -151,6 +151,18 @@ spec:
                               Ignored if the LoadBalancerType is set to anything other than dns
                               If not set, CAPL will create a unique identifier for you
                             type: string
+                          enableVPCBackends:
+                            default: false
+                            description: |-
+                              EnableVPCBackends toggles VPC-scoped NodeBalancer and VPC backend IP usage.
+                              If set to false (default), the NodeBalancer will not be created in a VPC and
+                              backends will use Linode private IPs. If true, the NodeBalancer will be
+                              created in the configured VPC (when VPCRef or VPCID is set) and backends
+                              will use VPC IPs.
+                            type: boolean
+                            x-kubernetes-validations:
+                            - message: Value is immutable
+                              rule: self == oldSelf
                           loadBalancerType:
                             default: NodeBalancer
                             description: LoadBalancerType is the type of load balancer

--- a/docs/src/reference/out.md
+++ b/docs/src/reference/out.md
@@ -1170,6 +1170,7 @@ _Appears in:_
 | `subnetName` _string_ | subnetName is the name/label of the VPC subnet to be used by the cluster |  |  |
 | `useVlan` _boolean_ | UseVlan provisions a cluster that uses VLANs instead of VPCs. IPAM is managed internally. |  |  |
 | `nodeBalancerBackendIPv4Range` _string_ | NodeBalancerBackendIPv4Range is the subnet range we want to provide for creating nodebalancer in VPC.<br />example: 10.10.10.0/30 |  |  |
+| `enableVPCBackends` _boolean_ | EnableVPCBackends toggles VPC-scoped NodeBalancer and VPC backend IP usage.<br />If set to false (default), the NodeBalancer will not be created in a VPC and<br />backends will use Linode private IPs. If true, the NodeBalancer will be<br />created in the configured VPC (when VPCRef or VPCID is set) and backends<br />will use VPC IPs. | false |  |
 
 
 #### ObjectStorageACL

--- a/hack/generate-flavors.sh
+++ b/hack/generate-flavors.sh
@@ -16,7 +16,7 @@ SUPPORTED_CLUSTERCLASSES=(
 for clusterclass in ${SUPPORTED_CLUSTERCLASSES[@]}; do
     # clusterctl expects clusterclass not have the "cluster-template" prefix
     # except for the actual cluster template using the clusterclass
-    echo "****** Generating clusterclass-${clusterclass} flavor ******"
+    echo "****** Generating ${clusterclass} flavor ******"
     kustomize build "${FLAVORS_DIR}/${clusterclass}" > "${REPO_ROOT}/templates/${clusterclass}.yaml"
     cp "${FLAVORS_DIR}/${clusterclass}/cluster-template.yaml" "${REPO_ROOT}/templates/cluster-template-${clusterclass}.yaml"
 done

--- a/internal/controller/linodecluster_controller_helpers_test.go
+++ b/internal/controller/linodecluster_controller_helpers_test.go
@@ -93,6 +93,7 @@ func TestGetIPPortCombo(t *testing.T) {
 				LinodeCluster: &infrav1alpha2.LinodeCluster{
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 						VPCRef: &corev1.ObjectReference{
@@ -127,6 +128,7 @@ func TestGetIPPortCombo(t *testing.T) {
 				LinodeCluster: &infrav1alpha2.LinodeCluster{
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 						VPCRef: &corev1.ObjectReference{
@@ -192,6 +194,7 @@ func TestGetIPPortCombo(t *testing.T) {
 				LinodeCluster: &infrav1alpha2.LinodeCluster{
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 							AdditionalPorts: []infrav1alpha2.LinodeNBPortConfig{
 								{
@@ -227,6 +230,7 @@ func TestGetIPPortCombo(t *testing.T) {
 				LinodeCluster: &infrav1alpha2.LinodeCluster{
 					Spec: infrav1alpha2.LinodeClusterSpec{
 						Network: infrav1alpha2.NetworkSpec{
+							EnableVPCBackends:            true,
 							NodeBalancerBackendIPv4Range: "10.0.0.0/24",
 						},
 						VPCRef: &corev1.ObjectReference{

--- a/internal/controller/linodecluster_controller_test.go
+++ b/internal/controller/linodecluster_controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("cluster-lifecycle", Ordered, Label("cluster", "cluster-lifecyc
 		Spec: infrav1alpha2.LinodeVPCSpec{
 			Region: "us-ord",
 			Subnets: []infrav1alpha2.VPCSubnetCreateOptions{
-				{Label: "subnet1", IPv4: "10.0.0.0/8"},
+				{Label: "subnet1", IPv4: "10.0.0.0/8", SubnetID: 123},
 			},
 		},
 	}
@@ -787,7 +787,8 @@ var _ = Describe("cluster-with-direct-vpcid", Ordered, Label("cluster", "direct-
 									Label: "subnet-1",
 								},
 							},
-						}, nil)
+						}, nil).
+						AnyTimes()
 
 					// Mock the CreateNodeBalancer call to avoid unexpected call error
 					mck.LinodeClient.EXPECT().CreateNodeBalancer(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
### Summary
Feature-flagged support for VPC-scoped NodeBalancer backends. When enabled, control plane backends use VPC internal IPs and the NodeBalancer is created inside the target VPC. External traffic continues to egress via VPC NAT with a public IP.

### Key changes
- **API**: Add `spec.network.enableVPCBackends` (default `false`, immutable). When `true` and either `spec.VPCRef` or `spec.VPCID` is set, create the NodeBalancer in the VPC and prefer VPC backend IPs. Optional `spec.network.nodeBalancerBackendIPv4Range` is honored if provided.
- **Services**:
  - New helpers: `ShouldUseVPC(scope)` and `DetermineAPIServerLBPort(scope)`.
  - NodeBalancer creation uses VPC `SubnetID` and optional `IPv4Range`; backend registration prefers VPC internal IPs, falls back to Linode private IPs when the flag is disabled.
- **Controller**: `getIPPortCombo` now prefers VPC IPs when enabled; factored helpers to select IPs and compose port pairs; DNS endpoint now reuses `DetermineAPIServerLBPort`.
- **CRDs & Docs**: CRDs extended with `enableVPCBackends` (default `false`, immutable); docs updated accordingly.

### Decisions
- Backwards-compatible: default behavior unchanged unless `enableVPCBackends` is explicitly set to `true`.
- Template updates (including CCM changes) are intentionally excluded from this PR and will be proposed in a separate templates-only PR. Here is the draft PR: https://github.com/linode/cluster-api-provider-linode/pull/825

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


