### PR TITLE
[improvement] : allow configuring timeout value for linodeclient

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -135,6 +135,7 @@ jobs:
           LINODE_CONTROL_PLANE_MACHINE_TYPE: g6-standard-2
           LINODE_MACHINE_TYPE: g6-standard-2
           CLUSTERCTL_CONFIG: /home/runner/work/cluster-api-provider-linode/cluster-api-provider-linode/e2e/gha-clusterctl-config.yaml
+          LINODE_CLIENT_TIMEOUT: 30
         run: make e2etest
 
       - name: cleanup stale clusters

--- a/Tiltfile
+++ b/Tiltfile
@@ -196,6 +196,13 @@ for resource in manager_yaml:
         resource["spec"]["template"]["spec"].pop("securityContext")
         for container in resource["spec"]["template"]["spec"]["containers"]:
             container.pop("securityContext")
+            timeout_value = os.getenv("LINODE_CLIENT_TIMEOUT")
+            if timeout_value:
+                env = container.setdefault("env", [])
+                env.append({
+                    "name": "LINODE_CLIENT_TIMEOUT",
+                    "value": timeout_value
+                })
 
 k8s_yaml(encode_yaml_stream(manager_yaml))
 

--- a/docs/src/topics/troubleshooting.md
+++ b/docs/src/topics/troubleshooting.md
@@ -73,3 +73,20 @@ You can also see which images have cloud-init support via the [linode-cli](https
 
 Please refer to the [Troubleshoot Metadata and Cloud-Init section of the Linode Metadata Service Guide](https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/?tabs=linode-api%2Cmacos#troubleshoot-metadata-and-cloud-init).
 
+## Increasing Linode API timeout values
+If the Linode API is slow to provision resources and you need to increase the timeout for API calls, you can set the LINODE_CLIENT_TIMEOUT environment variable to a higher value (in seconds). CAPL will automatically use this value when interacting with the Linode API.
+
+```bash
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: LINODE_CLIENT_TIMEOUT
+              value: "60"  # Timeout in seconds
+```


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR allows us to have custom timeout value for linode client. If the relevant env var is set, capl-controller-manager deployment will get the flag set via tilt.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


