### PR TITLE
[improvement] Remove v1beta2 conditions package

### DIFF
--- a/api/v1alpha2/linodecluster_types.go
+++ b/api/v1alpha2/linodecluster_types.go
@@ -26,6 +26,7 @@ const (
 	// ClusterFinalizer allows ReconcileLinodeCluster to clean up Linode resources associated
 	// with LinodeCluster before removing it from the apiserver.
 	ClusterFinalizer = "linodecluster.infrastructure.cluster.x-k8s.io"
+	ConditionPaused  = "Paused"
 )
 
 // LinodeClusterSpec defines the desired state of LinodeCluster
@@ -146,7 +147,7 @@ func (lc *LinodeCluster) GetCondition(condType string) *metav1.Condition {
 
 func (lc *LinodeCluster) IsPaused() bool {
 	for i := range lc.Status.Conditions {
-		if lc.Status.Conditions[i].Type == "Paused" {
+		if lc.Status.Conditions[i].Type == ConditionPaused {
 			return lc.Status.Conditions[i].Status == metav1.ConditionTrue
 		}
 	}

--- a/api/v1alpha2/linodefirewall_types.go
+++ b/api/v1alpha2/linodefirewall_types.go
@@ -176,7 +176,7 @@ func (lfw *LinodeFirewall) GetCondition(condType string) *metav1.Condition {
 
 func (lfw *LinodeFirewall) IsPaused() bool {
 	for i := range lfw.Status.Conditions {
-		if lfw.Status.Conditions[i].Type == "Paused" {
+		if lfw.Status.Conditions[i].Type == ConditionPaused {
 			return lfw.Status.Conditions[i].Status == metav1.ConditionTrue
 		}
 	}

--- a/api/v1alpha2/linodefirewall_types.go
+++ b/api/v1alpha2/linodefirewall_types.go
@@ -151,26 +151,36 @@ type LinodeFirewall struct {
 	Status LinodeFirewallStatus `json:"status,omitempty"`
 }
 
-func (lfw *LinodeFirewall) GetConditions() []metav1.Condition {
+func (lfw *LinodeFirewall) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
 	for i := range lfw.Status.Conditions {
-		if lfw.Status.Conditions[i].Reason == "" {
-			lfw.Status.Conditions[i].Reason = DefaultConditionReason
+		if lfw.Status.Conditions[i].Type == cond.Type {
+			lfw.Status.Conditions[i] = cond
+			return
 		}
 	}
-	return lfw.Status.Conditions
+	lfw.Status.Conditions = append(lfw.Status.Conditions, cond)
 }
 
-func (lfw *LinodeFirewall) SetConditions(conditions []metav1.Condition) {
-	lfw.Status.Conditions = conditions
+func (lfw *LinodeFirewall) GetCondition(condType string) *metav1.Condition {
+	for i := range lfw.Status.Conditions {
+		if lfw.Status.Conditions[i].Type == condType {
+			return &lfw.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
-// We need V1Beta2Conditions helpers to be able to use the conditions package from cluster-api
-func (lfw *LinodeFirewall) GetV1Beta2Conditions() []metav1.Condition {
-	return lfw.GetConditions()
-}
-
-func (lfw *LinodeFirewall) SetV1Beta2Conditions(conditions []metav1.Condition) {
-	lfw.SetConditions(conditions)
+func (lfw *LinodeFirewall) IsPaused() bool {
+	for i := range lfw.Status.Conditions {
+		if lfw.Status.Conditions[i].Type == "Paused" {
+			return lfw.Status.Conditions[i].Status == metav1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha2/linodemachine_types.go
+++ b/api/v1alpha2/linodemachine_types.go
@@ -610,7 +610,7 @@ func (lm *LinodeMachine) DeleteCondition(condType string) {
 
 func (lm *LinodeMachine) IsPaused() bool {
 	for i := range lm.Status.Conditions {
-		if lm.Status.Conditions[i].Type == "Paused" {
+		if lm.Status.Conditions[i].Type == ConditionPaused {
 			return lm.Status.Conditions[i].Status == metav1.ConditionTrue
 		}
 	}

--- a/api/v1alpha2/linodemachinetemplate_types.go
+++ b/api/v1alpha2/linodemachinetemplate_types.go
@@ -76,25 +76,18 @@ type LinodeMachineTemplate struct {
 	Status LinodeMachineTemplateStatus `json:"status,omitempty"`
 }
 
-func (lmt *LinodeMachineTemplate) GetConditions() []metav1.Condition {
+func (lmt *LinodeMachineTemplate) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
 	for i := range lmt.Status.Conditions {
-		if lmt.Status.Conditions[i].Reason == "" {
-			lmt.Status.Conditions[i].Reason = DefaultConditionReason
+		if lmt.Status.Conditions[i].Type == cond.Type {
+			lmt.Status.Conditions[i] = cond
+
+			return
 		}
 	}
-	return lmt.Status.Conditions
-}
-
-func (lmt *LinodeMachineTemplate) SetConditions(conditions []metav1.Condition) {
-	lmt.Status.Conditions = conditions
-}
-
-func (lmt *LinodeMachineTemplate) GetV1Beta2Conditions() []metav1.Condition {
-	return lmt.GetConditions()
-}
-
-func (lmt *LinodeMachineTemplate) SetV1Beta2Conditions(conditions []metav1.Condition) {
-	lmt.SetConditions(conditions)
+	lmt.Status.Conditions = append(lmt.Status.Conditions, cond)
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha2/linodeobjectstoragebucket_types.go
+++ b/api/v1alpha2/linodeobjectstoragebucket_types.go
@@ -122,25 +122,28 @@ type LinodeObjectStorageBucket struct {
 	Status LinodeObjectStorageBucketStatus `json:"status,omitempty"`
 }
 
-func (losb *LinodeObjectStorageBucket) GetConditions() []metav1.Condition {
-	for i := range losb.Status.Conditions {
-		if losb.Status.Conditions[i].Reason == "" {
-			losb.Status.Conditions[i].Reason = DefaultConditionReason
+func (lobj *LinodeObjectStorageBucket) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range lobj.Status.Conditions {
+		if lobj.Status.Conditions[i].Type == cond.Type {
+			lobj.Status.Conditions[i] = cond
+
+			return
 		}
 	}
-	return losb.Status.Conditions
+	lobj.Status.Conditions = append(lobj.Status.Conditions, cond)
 }
 
-func (losb *LinodeObjectStorageBucket) SetConditions(conditions []metav1.Condition) {
-	losb.Status.Conditions = conditions
-}
+func (lobj *LinodeObjectStorageBucket) GetCondition(condType string) *metav1.Condition {
+	for i := range lobj.Status.Conditions {
+		if lobj.Status.Conditions[i].Type == condType {
+			return &lobj.Status.Conditions[i]
+		}
+	}
 
-func (losb *LinodeObjectStorageBucket) GetV1Beta2Conditions() []metav1.Condition {
-	return losb.GetConditions()
-}
-
-func (losb *LinodeObjectStorageBucket) SetV1Beta2Conditions(conditions []metav1.Condition) {
-	losb.SetConditions(conditions)
+	return nil
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha2/linodeobjectstoragekey_types.go
+++ b/api/v1alpha2/linodeobjectstoragekey_types.go
@@ -158,25 +158,28 @@ type LinodeObjectStorageKey struct {
 	Status LinodeObjectStorageKeyStatus `json:"status,omitempty"`
 }
 
-func (losk *LinodeObjectStorageKey) GetConditions() []metav1.Condition {
-	for i := range losk.Status.Conditions {
-		if losk.Status.Conditions[i].Reason == "" {
-			losk.Status.Conditions[i].Reason = DefaultConditionReason
+func (key *LinodeObjectStorageKey) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range key.Status.Conditions {
+		if key.Status.Conditions[i].Type == cond.Type {
+			key.Status.Conditions[i] = cond
+
+			return
 		}
 	}
-	return losk.Status.Conditions
+	key.Status.Conditions = append(key.Status.Conditions, cond)
 }
 
-func (losk *LinodeObjectStorageKey) SetConditions(conditions []metav1.Condition) {
-	losk.Status.Conditions = conditions
-}
+func (key *LinodeObjectStorageKey) GetCondition(condType string) *metav1.Condition {
+	for i := range key.Status.Conditions {
+		if key.Status.Conditions[i].Type == condType {
+			return &key.Status.Conditions[i]
+		}
+	}
 
-func (losk *LinodeObjectStorageKey) GetV1Beta2Conditions() []metav1.Condition {
-	return losk.GetConditions()
-}
-
-func (losk *LinodeObjectStorageKey) SetV1Beta2Conditions(conditions []metav1.Condition) {
-	losk.SetConditions(conditions)
+	return nil
 }
 
 // LinodeObjectStorageKeyList contains a list of LinodeObjectStorageKey

--- a/api/v1alpha2/linodeplacementgroup_types.go
+++ b/api/v1alpha2/linodeplacementgroup_types.go
@@ -160,7 +160,7 @@ func (lpg *LinodePlacementGroup) GetCondition(condType string) *metav1.Condition
 
 func (lpg *LinodePlacementGroup) IsPaused() bool {
 	for i := range lpg.Status.Conditions {
-		if lpg.Status.Conditions[i].Type == "Paused" {
+		if lpg.Status.Conditions[i].Type == ConditionPaused {
 			return lpg.Status.Conditions[i].Status == metav1.ConditionTrue
 		}
 	}

--- a/api/v1alpha2/linodeplacementgroup_types.go
+++ b/api/v1alpha2/linodeplacementgroup_types.go
@@ -134,25 +134,37 @@ type LinodePlacementGroup struct {
 	Status LinodePlacementGroupStatus `json:"status,omitempty"`
 }
 
-func (lpg *LinodePlacementGroup) GetConditions() []metav1.Condition {
+func (lpg *LinodePlacementGroup) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
 	for i := range lpg.Status.Conditions {
-		if lpg.Status.Conditions[i].Reason == "" {
-			lpg.Status.Conditions[i].Reason = DefaultConditionReason
+		if lpg.Status.Conditions[i].Type == cond.Type {
+			lpg.Status.Conditions[i] = cond
+
+			return
 		}
 	}
-	return lpg.Status.Conditions
+	lpg.Status.Conditions = append(lpg.Status.Conditions, cond)
 }
 
-func (lpg *LinodePlacementGroup) SetConditions(conditions []metav1.Condition) {
-	lpg.Status.Conditions = conditions
+func (lpg *LinodePlacementGroup) GetCondition(condType string) *metav1.Condition {
+	for i := range lpg.Status.Conditions {
+		if lpg.Status.Conditions[i].Type == condType {
+			return &lpg.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
-func (lpg *LinodePlacementGroup) GetV1Beta2Conditions() []metav1.Condition {
-	return lpg.GetConditions()
-}
-
-func (lpg *LinodePlacementGroup) SetV1Beta2Conditions(conditions []metav1.Condition) {
-	lpg.SetConditions(conditions)
+func (lpg *LinodePlacementGroup) IsPaused() bool {
+	for i := range lpg.Status.Conditions {
+		if lpg.Status.Conditions[i].Type == "Paused" {
+			return lpg.Status.Conditions[i].Status == metav1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha2/linodevpc_types.go
+++ b/api/v1alpha2/linodevpc_types.go
@@ -235,7 +235,7 @@ func (lv *LinodeVPC) GetCondition(condType string) *metav1.Condition {
 
 func (lv *LinodeVPC) IsPaused() bool {
 	for i := range lv.Status.Conditions {
-		if lv.Status.Conditions[i].Type == "Paused" {
+		if lv.Status.Conditions[i].Type == ConditionPaused {
 			return lv.Status.Conditions[i].Status == metav1.ConditionTrue
 		}
 	}

--- a/api/v1alpha2/linodevpc_types.go
+++ b/api/v1alpha2/linodevpc_types.go
@@ -209,25 +209,37 @@ type LinodeVPC struct {
 	Status LinodeVPCStatus `json:"status,omitempty"`
 }
 
-func (lv *LinodeVPC) GetConditions() []metav1.Condition {
+func (lv *LinodeVPC) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
 	for i := range lv.Status.Conditions {
-		if lv.Status.Conditions[i].Reason == "" {
-			lv.Status.Conditions[i].Reason = DefaultConditionReason
+		if lv.Status.Conditions[i].Type == cond.Type {
+			lv.Status.Conditions[i] = cond
+
+			return
 		}
 	}
-	return lv.Status.Conditions
+	lv.Status.Conditions = append(lv.Status.Conditions, cond)
 }
 
-func (lv *LinodeVPC) SetConditions(conditions []metav1.Condition) {
-	lv.Status.Conditions = conditions
+func (lv *LinodeVPC) GetCondition(condType string) *metav1.Condition {
+	for i := range lv.Status.Conditions {
+		if lv.Status.Conditions[i].Type == condType {
+			return &lv.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
-func (lv *LinodeVPC) GetV1Beta2Conditions() []metav1.Condition {
-	return lv.GetConditions()
-}
-
-func (lv *LinodeVPC) SetV1Beta2Conditions(conditions []metav1.Condition) {
-	lv.SetConditions(conditions)
+func (lv *LinodeVPC) IsPaused() bool {
+	for i := range lv.Status.Conditions {
+		if lv.Status.Conditions[i].Type == "Paused" {
+			return lv.Status.Conditions[i].Status == metav1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/linodefirewall_controller.go
+++ b/internal/controller/linodefirewall_controller.go
@@ -31,8 +31,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kutil "sigs.k8s.io/cluster-api/util"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
-	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -116,11 +114,7 @@ func (r *LinodeFirewallReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Only check pause if not deleting or if cluster still exists
 	if linodeFirewall.DeletionTimestamp.IsZero() || cluster != nil {
-		isPaused, _, err := paused.EnsurePausedCondition(ctx, fwScope.Client, fwScope.Cluster, fwScope.LinodeFirewall)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		if isPaused {
+		if fwScope.LinodeFirewall.IsPaused() {
 			log.Info("linodefirewall or linked cluster is paused, skipping reconciliation")
 			return ctrl.Result{}, nil
 		}
@@ -145,7 +139,7 @@ func (r *LinodeFirewallReconciler) reconcile(
 		if err != nil {
 			fwScope.LinodeFirewall.Status.FailureReason = util.Pointer(failureReason)
 			fwScope.LinodeFirewall.Status.FailureMessage = util.Pointer(err.Error())
-			conditions.Set(fwScope.LinodeFirewall, metav1.Condition{
+			fwScope.LinodeFirewall.SetCondition(metav1.Condition{
 				Type:    string(clusterv1.ReadyCondition),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(failureReason),
@@ -192,7 +186,7 @@ func (r *LinodeFirewallReconciler) reconcile(
 		failureReason = infrav1alpha2.CreateFirewallError
 		if err = fwScope.AddCredentialsRefFinalizer(ctx); err != nil {
 			logger.Error(err, "failed to update credentials secret")
-			conditions.Set(fwScope.LinodeFirewall, metav1.Condition{
+			fwScope.LinodeFirewall.SetCondition(metav1.Condition{
 				Type:    string(clusterv1.ReadyCondition),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(failureReason),
@@ -205,7 +199,7 @@ func (r *LinodeFirewallReconciler) reconcile(
 	}
 	if err = reconcileFirewall(ctx, r.Client, fwScope, logger); err != nil {
 		logger.Error(err, fmt.Sprintf("failed to %s Firewall", action))
-		conditions.Set(fwScope.LinodeFirewall, metav1.Condition{
+		fwScope.LinodeFirewall.SetCondition(metav1.Condition{
 			Type:    string(clusterv1.ReadyCondition),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(failureReason),
@@ -217,7 +211,7 @@ func (r *LinodeFirewallReconciler) reconcile(
 		case errors.Is(err, errTooManyIPs):
 			// Cannot reconcile firewall with too many ips, wait for an update to the spec
 			return ctrl.Result{}, nil
-		case util.IsRetryableError(err) && !reconciler.HasStaleCondition(fwScope.LinodeFirewall, string(clusterv1.ReadyCondition),
+		case util.IsRetryableError(err) && !reconciler.HasStaleCondition(fwScope.LinodeFirewall.GetCondition(string(clusterv1.ReadyCondition)),
 			reconciler.DefaultTimeout(r.ReconcileTimeout, reconciler.DefaultFWControllerReconcileTimeout)):
 			logger.Info(fmt.Sprintf("re-queuing Firewall %s", action))
 

--- a/internal/controller/linodefirewall_controller_test.go
+++ b/internal/controller/linodefirewall_controller_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -208,7 +207,7 @@ var _ = Describe("lifecycle", Ordered, Label("firewalls", "lifecycle"), func() {
 				}),
 				OneOf(
 					Path(Result("update requeues for update rules error", func(ctx context.Context, mck Mock) {
-						conditions.Set(fwScope.LinodeFirewall, metav1.Condition{
+						fwScope.LinodeFirewall.SetCondition(metav1.Condition{
 							Type:    string(clusterv1.ReadyCondition),
 							Status:  metav1.ConditionFalse,
 							Reason:  "test",

--- a/internal/controller/linodemachine_controller_helpers.go
+++ b/internal/controller/linodemachine_controller_helpers.go
@@ -1302,7 +1302,7 @@ func configureDisk(ctx context.Context, logger logr.Logger, machineScope *scope.
 			logger.Error(err, "Failed to create disk", "DiskLabel", label)
 		}
 
-		conditions.Set(machineScope.LinodeMachine, metav1.Condition{
+		machineScope.LinodeMachine.SetCondition(metav1.Condition{
 			Type:    ConditionPreflightAdditionalDisksCreated,
 			Status:  metav1.ConditionFalse,
 			Reason:  util.CreateError,

--- a/internal/controller/linodemachinetemplate_controller.go
+++ b/internal/controller/linodemachinetemplate_controller.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,14 +88,14 @@ func (lmtr *LinodeMachineTemplateReconciler) reconcile(ctx context.Context, lmtS
 	//nolint:dupl // Code duplication is simplicity in this case.
 	defer func() {
 		if outErr != nil {
-			conditions.Set(lmtScope.LinodeMachineTemplate, metav1.Condition{
+			lmtScope.LinodeMachineTemplate.SetCondition(metav1.Condition{
 				Type:    string(clusterv1.ReadyCondition),
 				Status:  metav1.ConditionFalse,
 				Reason:  failureReason,
 				Message: outErr.Error(),
 			})
 		} else {
-			conditions.Set(lmtScope.LinodeMachineTemplate, metav1.Condition{
+			lmtScope.LinodeMachineTemplate.SetCondition(metav1.Condition{
 				Type:    string(clusterv1.ReadyCondition),
 				Status:  metav1.ConditionTrue,
 				Reason:  "Reconciled",

--- a/internal/controller/linodeobjectstoragebucket_controller.go
+++ b/internal/controller/linodeobjectstoragebucket_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kutil "sigs.k8s.io/cluster-api/util"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -152,7 +151,7 @@ func (r *LinodeObjectStorageBucketReconciler) reconcile(ctx context.Context, bSc
 func (r *LinodeObjectStorageBucketReconciler) setFailure(bScope *scope.ObjectStorageBucketScope, err error) {
 	bScope.Bucket.Status.FailureMessage = util.Pointer(err.Error())
 	r.Recorder.Event(bScope.Bucket, corev1.EventTypeWarning, "Failed", err.Error())
-	conditions.Set(bScope.Bucket, metav1.Condition{
+	bScope.Bucket.SetCondition(metav1.Condition{
 		Type:    string(clusterv1.ReadyCondition),
 		Status:  metav1.ConditionFalse,
 		Reason:  "Failed",
@@ -192,7 +191,7 @@ func (r *LinodeObjectStorageBucketReconciler) reconcileApply(ctx context.Context
 	r.Recorder.Event(bScope.Bucket, corev1.EventTypeNormal, "Synced", "Object storage bucket synced")
 
 	bScope.Bucket.Status.Ready = true
-	conditions.Set(bScope.Bucket, metav1.Condition{
+	bScope.Bucket.SetCondition(metav1.Condition{
 		Type:   string(clusterv1.ReadyCondition),
 		Status: metav1.ConditionTrue,
 		Reason: "ObjectStorageBucketReady", // We have to set the reason to not fail object patching

--- a/internal/controller/linodeobjectstoragebucket_controller_test.go
+++ b/internal/controller/linodeobjectstoragebucket_controller_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -149,7 +148,7 @@ var _ = Describe("lifecycle", Ordered, Label("bucket", "lifecycle"), func() {
 					Expect(obj.Status.Ready).To(BeTrue())
 					Expect(obj.Status.FailureMessage).To(BeNil())
 					Expect(obj.Status.Conditions).To(HaveLen(1))
-					readyCond := conditions.Get(&obj, string(clusterv1.ReadyCondition))
+					readyCond := obj.GetCondition(string(clusterv1.ReadyCondition))
 					Expect(readyCond).NotTo(BeNil())
 					Expect(*obj.Status.Hostname).To(Equal("hostname"))
 					Expect(obj.Status.CreationTime).NotTo(BeNil())

--- a/internal/controller/linodeobjectstoragekey_controller.go
+++ b/internal/controller/linodeobjectstoragekey_controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kutil "sigs.k8s.io/cluster-api/util"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/predicates"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -162,7 +161,7 @@ func (r *LinodeObjectStorageKeyReconciler) reconcile(ctx context.Context, keySco
 func (r *LinodeObjectStorageKeyReconciler) setFailure(keyScope *scope.ObjectStorageKeyScope, err error) {
 	keyScope.Key.Status.FailureMessage = util.Pointer(err.Error())
 	r.Recorder.Event(keyScope.Key, corev1.EventTypeWarning, "Failed", err.Error())
-	conditions.Set(keyScope.Key, metav1.Condition{
+	keyScope.Key.SetCondition(metav1.Condition{
 		Type:    string(clusterv1.ReadyCondition),
 		Status:  metav1.ConditionFalse,
 		Reason:  "Failed",
@@ -259,7 +258,7 @@ func (r *LinodeObjectStorageKeyReconciler) reconcileApply(ctx context.Context, k
 	keyScope.Key.Status.LastKeyGeneration = &keyScope.Key.Spec.KeyGeneration
 	keyScope.Key.Status.Ready = true
 
-	conditions.Set(keyScope.Key, metav1.Condition{
+	keyScope.Key.SetCondition(metav1.Condition{
 		Type:   string(clusterv1.ReadyCondition),
 		Status: metav1.ConditionTrue,
 		Reason: "LinodeObjectStorageKeySynced", // We have to set the reason to not fail object patching

--- a/internal/controller/linodeobjectstoragekey_controller_test.go
+++ b/internal/controller/linodeobjectstoragekey_controller_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/utils/ptr"
 	clusteraddonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -126,7 +125,7 @@ var _ = Describe("lifecycle", Ordered, Label("key", "key-lifecycle"), func() {
 					Expect(key.Status.Ready).To(BeTrue())
 					Expect(key.Status.FailureMessage).To(BeNil())
 					Expect(key.Status.Conditions).To(HaveLen(1))
-					readyCond := conditions.Get(&key, string(clusterv1.ReadyCondition))
+					readyCond := key.GetCondition(string(clusterv1.ReadyCondition))
 					Expect(readyCond).NotTo(BeNil())
 					Expect(key.Status.CreationTime).NotTo(BeNil())
 					Expect(*key.Status.LastKeyGeneration).To(Equal(key.Spec.KeyGeneration))

--- a/internal/controller/linodevpc_controller_test.go
+++ b/internal/controller/linodevpc_controller_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -170,7 +169,7 @@ var _ = Describe("lifecycle", Ordered, Label("vpc", "lifecycle"), func() {
 				}),
 				OneOf(
 					Path(Result("update requeues", func(ctx context.Context, mck Mock) {
-						conditions.Set(vpcScope.LinodeVPC, metav1.Condition{
+						vpcScope.LinodeVPC.SetCondition(metav1.Condition{
 							Type:    string(clusterv1.ReadyCondition),
 							Status:  metav1.ConditionFalse,
 							Reason:  "test",

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -56,6 +56,11 @@ var (
 	basepath          = filepath.Dir(b)
 )
 
+const (
+	defaultNamespace    = "default"
+	gzipCompressionFlag = false
+)
+
 func TestControllers(t *testing.T) {
 	t.Parallel()
 

--- a/util/reconciler/conditions.go
+++ b/util/reconciler/conditions.go
@@ -4,27 +4,15 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 )
 
-func ConditionTrue(from conditions.Getter, typ string) bool {
-	return HasConditionStatus(from, typ, metav1.ConditionTrue)
-}
-
-func HasConditionStatus(from conditions.Getter, typ string, status metav1.ConditionStatus) bool {
-	cond := conditions.Get(from, typ)
+func HasStaleCondition(cond *metav1.Condition, timeout time.Duration) bool {
 	if cond == nil {
 		return false
 	}
-
-	return cond.Status == status
-}
-
-func HasStaleCondition(from conditions.Getter, typ string, timeout time.Duration) bool {
-	cond := conditions.Get(from, typ)
-	if cond == nil {
-		return false
-	}
-
 	return time.Now().After(cond.LastTransitionTime.Add(timeout))
+}
+
+func ConditionTrue(cond *metav1.Condition) bool {
+	return cond != nil && cond.Status == metav1.ConditionTrue
 }


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: Following up from https://github.com/linode/cluster-api-provider-linode/pull/590 and to prepare for updating the CAPI dependency (#858) we need to remove the v1beta2 conditions package
This is not breaking since we already changed the Conditions type in the Statuses to be `metav1.Conditions`, this just removes the package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


