### PR TITLE
[improvement] enable SSA tag linter

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -18,8 +18,9 @@ linters:
           linters:
             # TODO: remove linters from this list as we add support from them
             disable:
-              - "ssatags"
+              # integers linter will force type change from int to int32/int64, we are going to wait for v1beta1 to enable this
               - "integers"
+              # jsontags linter will force the json fields to go from _ usage to camelCase, we will wait for v1beta1 to enable this
               - "jsontags"
               - "requiredfields"
               - "optionalfields"

--- a/api/v1alpha2/firewallrule_types.go
+++ b/api/v1alpha2/firewallrule_types.go
@@ -52,6 +52,7 @@ type FirewallRuleSpec struct {
 	// addressSetRefs is a list of references to AddressSets as an alternative to
 	// using Addresses but can be used in conjunction with it.
 	// +optional
+	// +listType=atomic
 	AddressSetRefs []*corev1.ObjectReference `json:"addressSetRefs,omitempty"`
 }
 

--- a/api/v1alpha2/linodecluster_types.go
+++ b/api/v1alpha2/linodecluster_types.go
@@ -213,6 +213,8 @@ type NetworkSpec struct {
 
 	// additionalPorts contains list of ports to be configured with NodeBalancer.
 	// +optional
+	// +listType=map
+	// +listMapKey=port
 	AdditionalPorts []LinodeNBPortConfig `json:"additionalPorts,omitempty"`
 
 	// subnetName is the name/label of the VPC subnet to be used by the cluster

--- a/api/v1alpha2/linodefirewall_types.go
+++ b/api/v1alpha2/linodefirewall_types.go
@@ -40,11 +40,13 @@ type LinodeFirewallSpec struct {
 
 	// inboundRules is a list of FirewallRules that will be applied to the Firewall.
 	// +optional
+	// +listType=atomic
 	InboundRules []FirewallRuleSpec `json:"inboundRules,omitempty"`
 
 	// inboundRuleRefs is a list of references to FirewallRules as an alternative to
 	// using InboundRules but can be used in conjunction with it
 	// +optional
+	// +listType=atomic
 	InboundRuleRefs []*corev1.ObjectReference `json:"inboundRuleRefs,omitempty"`
 
 	// inboundPolicy determines if traffic by default should be ACCEPTed or DROPped. Defaults to ACCEPT if not defined.
@@ -55,11 +57,13 @@ type LinodeFirewallSpec struct {
 
 	// outboundRules is a list of FirewallRules that will be applied to the Firewall.
 	// +optional
+	// +listType=atomic
 	OutboundRules []FirewallRuleSpec `json:"outboundRules,omitempty"`
 
 	// outboundRuleRefs is a list of references to FirewallRules as an alternative to
 	// using OutboundRules but can be used in conjunction with it
 	// +optional
+	// +listType=atomic
 	OutboundRuleRefs []*corev1.ObjectReference `json:"outboundRuleRefs,omitempty"`
 
 	// outboundPolicy determines if traffic by default should be ACCEPTed or DROPped. Defaults to ACCEPT if not defined.

--- a/api/v1alpha2/linodemachine_types.go
+++ b/api/v1alpha2/linodemachine_types.go
@@ -64,11 +64,13 @@ type LinodeMachineSpec struct {
 	// authorizedKeys is a list of SSH public keys to add to the instance.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +listType=set
 	AuthorizedKeys []string `json:"authorizedKeys,omitempty"`
 
 	// authorizedUsers is a list of usernames to add to the instance.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +listType=set
 	AuthorizedUsers []string `json:"authorizedUsers,omitempty"`
 
 	// backupID is the ID of the backup to restore the instance from.
@@ -84,12 +86,14 @@ type LinodeMachineSpec struct {
 	// interfaces is a list of legacy network interfaces to use for the instance.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +listType=atomic
 	Interfaces []InstanceConfigInterfaceCreateOptions `json:"interfaces,omitempty"`
 
 	// linodeInterfaces is a list of Linode network interfaces to use for the instance. Requires Linode Interfaces beta opt-in to use.
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// +kubebuilder:object:generate=true
+	// +listType=atomic
 	LinodeInterfaces []LinodeInterfaceCreateOptions `json:"linodeInterfaces,omitempty"`
 
 	// backupsEnabled is a boolean indicating whether backups should be enabled for the instance.
@@ -104,6 +108,7 @@ type LinodeMachineSpec struct {
 
 	// tags is a list of tags to apply to the Linode instance.
 	// +optional
+	// +listType=set
 	Tags []string `json:"tags,omitempty"`
 
 	// firewallID is the id of the cloud firewall to apply to the Linode Instance
@@ -298,6 +303,7 @@ type InstanceConfigInterfaceCreateOptions struct {
 
 	// ipRanges is a list of IPv4 ranges to assign to the interface.
 	// +optional
+	// +listType=set
 	IPRanges []string `json:"ipRanges,omitempty"`
 }
 
@@ -350,6 +356,8 @@ type PublicInterfaceCreateOptions struct {
 type PublicInterfaceIPv4CreateOptions struct {
 	// addresses is the IPv4 addresses for the public interface.
 	// +optional
+	// +listType=map
+	// +listMapKey=address
 	Addresses []PublicInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
 }
 
@@ -368,6 +376,8 @@ type PublicInterfaceIPv4AddressCreateOptions struct {
 type PublicInterfaceIPv6CreateOptions struct {
 	// ranges is the IPv6 ranges for the public interface.
 	// +optional
+	// +listType=map
+	// +listMapKey=range
 	Ranges []PublicInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
 }
 
@@ -397,10 +407,14 @@ type VPCInterfaceCreateOptions struct {
 type VPCInterfaceIPv6CreateOptions struct {
 	// slaac is the IPv6 SLAAC configuration for the interface.
 	// +optional
+	// +listType=map
+	// +listMapKey=range
 	SLAAC []VPCInterfaceIPv6SLAACCreateOptions `json:"slaac,omitempty"`
 
 	// ranges is the IPv6 ranges for the interface.
 	// +optional
+	// +listType=map
+	// +listMapKey=range
 	Ranges []VPCInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
 
 	// is_public is a boolean indicating whether the interface is public.
@@ -426,10 +440,14 @@ type VPCInterfaceIPv6RangeCreateOptions struct {
 type VPCInterfaceIPv4CreateOptions struct {
 	// addresses is the IPv4 addresses for the interface.
 	// +optional
+	// +listType=map
+	// +listMapKey=address
 	Addresses []VPCInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
 
 	// ranges is the IPv4 ranges for the interface.
 	// +optional
+	// +listType=map
+	// +listMapKey=range
 	Ranges []VPCInterfaceIPv4RangeCreateOptions `json:"ranges,omitempty"`
 }
 
@@ -494,6 +512,8 @@ type LinodeMachineStatus struct {
 
 	// addresses contains the Linode instance associated addresses.
 	// +optional
+	// +listType=map
+	// +listMapKey=address
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
 	// cloudinitMetadataSupport determines whether to use cloud-init or not.
@@ -547,6 +567,7 @@ type LinodeMachineStatus struct {
 
 	// tags are the tags applied to the Linode Machine.
 	// +optional
+	// +listType=set
 	Tags []string `json:"tags,omitempty"`
 }
 

--- a/api/v1alpha2/linodemachinetemplate_types.go
+++ b/api/v1alpha2/linodemachinetemplate_types.go
@@ -40,6 +40,7 @@ type LinodeMachineTemplateStatus struct {
 
 	// tags that are currently applied to the LinodeMachineTemplate.
 	// +optional
+	// +listType=set
 	Tags []string `json:"tags,omitempty"`
 
 	// firewallID that is currently applied to the LinodeMachineTemplate.

--- a/api/v1alpha2/linodeobjectstoragekey_types.go
+++ b/api/v1alpha2/linodeobjectstoragekey_types.go
@@ -68,6 +68,7 @@ type LinodeObjectStorageKeySpec struct {
 	// bucketAccess is the list of object storage bucket labels which can be accessed using the key
 	// +kubebuilder:validation:MinItems=1
 	// +required
+	// +listType=atomic
 	BucketAccess []BucketAccessRef `json:"bucketAccess"`
 
 	// credentialsRef is a reference to a Secret that contains the credentials to use for generating access keys.

--- a/api/v1alpha2/linodevpc_types.go
+++ b/api/v1alpha2/linodevpc_types.go
@@ -47,16 +47,20 @@ type LinodeVPCSpec struct {
 	// Once ranges are allocated based on the IPv6Range field, they will be
 	// added to this field.
 	// +optional
+	// +listType=map
+	// +listMapKey=range
 	IPv6 []linodego.VPCIPv6Range `json:"ipv6,omitempty"`
 
 	// ipv6Range is a list of IPv6 ranges to allocate to the VPC.
 	// If not specified, the VPC will not have an IPv6 range allocated.
 	// Once ranges are allocated, they will be added to the IPv6 field.
 	// +optional
+	// +listType=atomic
 	IPv6Range []VPCCreateOptionsIPv6 `json:"ipv6Range,omitempty"`
 
 	// subnets is a list of subnets to create in the VPC.
 	// +optional
+	// +listType=atomic
 	Subnets []VPCSubnetCreateOptions `json:"subnets,omitempty"`
 
 	// retain allows you to keep the VPC after the LinodeVPC object is deleted.
@@ -103,12 +107,15 @@ type VPCSubnetCreateOptions struct {
 	// Once ranges are allocated based on the IPv6Range field, they will be
 	// added to this field.
 	// +optional
+	// +listType=map
+	// +listMapKey=range
 	IPv6 []linodego.VPCIPv6Range `json:"ipv6,omitempty"`
 
 	// ipv6Range is a list of IPv6 ranges to allocate to the subnet.
 	// If not specified, the subnet will not have an IPv6 range allocated.
 	// Once ranges are allocated, they will be added to the IPv6 field.
 	// +optional
+	// +listType=atomic
 	IPv6Range []VPCSubnetCreateOptionsIPv6 `json:"ipv6Range,omitempty"`
 
 	// subnetID is subnet id for the subnet

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_firewallrules.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_firewallrules.yaml
@@ -97,6 +97,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+                x-kubernetes-list-type: atomic
               addresses:
                 description: addresses is a list of addresses to apply the rule to.
                 properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclusters.yaml
@@ -111,6 +111,9 @@ spec:
                       - port
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - port
+                    x-kubernetes-list-type: map
                   apiserverLoadBalancerPort:
                     description: |-
                       apiserverLoadBalancerPort used by the api server. It must be valid ports range (1-65535).

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeclustertemplates.yaml
@@ -107,6 +107,9 @@ spec:
                               - port
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            x-kubernetes-list-type: map
                           apiserverLoadBalancerPort:
                             description: |-
                               apiserverLoadBalancerPort used by the api server. It must be valid ports range (1-65535).

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodefirewalls.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodefirewalls.yaml
@@ -130,6 +130,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+                x-kubernetes-list-type: atomic
               inboundRules:
                 description: inboundRules is a list of FirewallRules that will be
                   applied to the Firewall.
@@ -188,6 +189,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
+                      x-kubernetes-list-type: atomic
                     addresses:
                       description: addresses is a list of addresses to apply the rule
                         to.
@@ -226,6 +228,7 @@ spec:
                   - protocol
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               outboundPolicy:
                 default: ACCEPT
                 description: outboundPolicy determines if traffic by default should
@@ -283,6 +286,7 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+                x-kubernetes-list-type: atomic
               outboundRules:
                 description: outboundRules is a list of FirewallRules that will be
                   applied to the Firewall.
@@ -341,6 +345,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       type: array
+                      x-kubernetes-list-type: atomic
                     addresses:
                       description: addresses is a list of addresses to apply the rule
                         to.
@@ -379,6 +384,7 @@ spec:
                   - protocol
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
             type: object
           status:
             description: status is the observed state of the LinodeFirewall.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
@@ -71,6 +71,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
@@ -80,6 +81,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
@@ -441,6 +443,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     ipamAddress:
                       description: ipamAddress is the IP address to assign to the
                         interface.
@@ -473,6 +476,7 @@ spec:
                       type: integer
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
@@ -563,6 +567,9 @@ spec:
                                 - address
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - address
+                              x-kubernetes-list-type: map
                           type: object
                         ipv6:
                           description: ipv6 is the IPv6 configuration for the public
@@ -583,6 +590,9 @@ spec:
                                 - range
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - range
+                              x-kubernetes-list-type: map
                           type: object
                       type: object
                     vlan:
@@ -629,6 +639,9 @@ spec:
                                 - address
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - address
+                              x-kubernetes-list-type: map
                             ranges:
                               description: ranges is the IPv4 ranges for the interface.
                               items:
@@ -642,6 +655,9 @@ spec:
                                 - range
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - range
+                              x-kubernetes-list-type: map
                           type: object
                         ipv6:
                           description: ipv6 is the IPv6 configuration for the interface.
@@ -663,6 +679,9 @@ spec:
                                 - range
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - range
+                              x-kubernetes-list-type: map
                             slaac:
                               description: slaac is the IPv6 SLAAC configuration for
                                 the interface.
@@ -677,6 +696,9 @@ spec:
                                 - range
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                              - range
+                              x-kubernetes-list-type: map
                           required:
                           - is_public
                           type: object
@@ -689,6 +711,7 @@ spec:
                       type: object
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
                 - message: Value is immutable
                   rule: self == oldSelf
@@ -809,6 +832,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
               type:
                 description: type is the Linode instance type to create.
                 type: string
@@ -903,6 +927,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - address
+                x-kubernetes-list-type: map
               cloudinitMetadataSupport:
                 default: true
                 description: |-
@@ -1020,6 +1047,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
             type: object
         type: object
     served: true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
@@ -59,6 +59,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
@@ -68,6 +69,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
@@ -445,6 +447,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: set
                             ipamAddress:
                               description: ipamAddress is the IP address to assign
                                 to the interface.
@@ -480,6 +483,7 @@ spec:
                               type: integer
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
@@ -573,6 +577,9 @@ spec:
                                         - address
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - address
+                                      x-kubernetes-list-type: map
                                   type: object
                                 ipv6:
                                   description: ipv6 is the IPv6 configuration for
@@ -593,6 +600,9 @@ spec:
                                         - range
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - range
+                                      x-kubernetes-list-type: map
                                   type: object
                               type: object
                             vlan:
@@ -641,6 +651,9 @@ spec:
                                         - address
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - address
+                                      x-kubernetes-list-type: map
                                     ranges:
                                       description: ranges is the IPv4 ranges for the
                                         interface.
@@ -656,6 +669,9 @@ spec:
                                         - range
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - range
+                                      x-kubernetes-list-type: map
                                   type: object
                                 ipv6:
                                   description: ipv6 is the IPv6 configuration for
@@ -680,6 +696,9 @@ spec:
                                         - range
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - range
+                                      x-kubernetes-list-type: map
                                     slaac:
                                       description: slaac is the IPv6 SLAAC configuration
                                         for the interface.
@@ -695,6 +714,9 @@ spec:
                                         - range
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                      - range
+                                      x-kubernetes-list-type: map
                                   required:
                                   - is_public
                                   type: object
@@ -707,6 +729,7 @@ spec:
                               type: object
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: Value is immutable
                           rule: self == oldSelf
@@ -830,6 +853,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                       type:
                         description: type is the Linode instance type to create.
                         type: string
@@ -972,6 +996,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: set
             type: object
         type: object
     served: true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeobjectstoragekeys.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodeobjectstoragekeys.yaml
@@ -82,6 +82,7 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-type: atomic
               credentialsRef:
                 description: |-
                   credentialsRef is a reference to a Secret that contains the credentials to use for generating access keys.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodevpcs.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodevpcs.yaml
@@ -84,6 +84,9 @@ spec:
                   - range
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - range
+                x-kubernetes-list-type: map
               ipv6Range:
                 description: |-
                   ipv6Range is a list of IPv6 ranges to allocate to the VPC.
@@ -105,6 +108,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               region:
                 description: region is the region to create the VPC in.
                 type: string
@@ -143,6 +147,9 @@ spec:
                         - range
                         type: object
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - range
+                      x-kubernetes-list-type: map
                     ipv6Range:
                       description: |-
                         ipv6Range is a list of IPv6 ranges to allocate to the subnet.
@@ -160,6 +167,7 @@ spec:
                             type: string
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     label:
                       description: label is the label of the subnet.
                       maxLength: 63
@@ -176,6 +184,7 @@ spec:
                       type: integer
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               vpcID:
                 description: vpcID is the ID of the VPC.
                 type: integer


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This PR enables the [SSATag](https://github.com/kubernetes-sigs/kube-api-linter/blob/main/docs/linters.md#ssatags) linter from KAL. as part of this all liststypes are now set to `atomic`, `set` or `map` with a `MapKey`, the way I selected which type to use is as follows:
* if a list is composed of go primitives(such as strings) then I use the `set` type, this does some deduplication but the places where we use this such as resource tags this would be unique values anyways
* if a list is composed of objects with a single key or single required key use a `map` type with the `mapKey` set to that value
* if the list is composed of objects with multiple required fields or all optional fields then set it to atomic
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


