### PR TITLE
[improvement] shorten resource names for templates and tests for easier compatibility with Linode API label length limits

### DIFF
--- a/docs/src/topics/disks/data-disks.md
+++ b/docs/src/topics/disks/data-disks.md
@@ -63,7 +63,7 @@ spec:
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
-  name: "${CLUSTER_NAME}-control-plane"
+  name: "${CLUSTER_NAME}-cp"
 spec:
     diskSetup:
       filesystems:

--- a/docs/src/topics/vpc.md
+++ b/docs/src/topics/vpc.md
@@ -27,7 +27,7 @@ _Example template where the VPC interface is not the primary interface_
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: LinodeMachineTemplate
 metadata:
-  name: test-cluster-md-0
+  name: test-cluster
   namespace: default
 spec:
   template:

--- a/e2e/admission-webhooks/validating/chainsaw-test.yaml
+++ b/e2e/admission-webhooks/validating/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'validating-webhooks', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'validating-webhooks', random('[0-9a-z]{5}')]))
     - name: name
       # Format a generic resource name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'k3s-cluster', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'k3s', random('[0-9a-z]{7}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'k3s', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'k3s', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -3,7 +3,7 @@ apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
   creationTimestamp: null
-  name: default-capl-cluster
+  name: default-cluster
   # Labels to allow the test to be triggered based on selector flag
   labels:
     all:
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'default-cluster', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'default', random('[0-9a-z]{7}')]))
     - name: cluster
       # Format the cluster name
       # linode firewall has limit of max 32 chars, so we truncate the cluster name to 29 chars

--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'default', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'default', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       # linode firewall has limit of max 32 chars, so we truncate the cluster name to 29 chars

--- a/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'flatcar-cluster', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'flatcar', random('[0-9a-z]{7}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'flatcar', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'flatcar', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # Identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'full', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'full', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # Identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'kdmf-tst', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'full', random('[0-9a-z]{7}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'rke2', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'rke2', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodecluster-controller/firewall-integration/chainsaw-test.yaml
+++ b/e2e/linodecluster-controller/firewall-integration/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'firewall-integration', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'firewall-integration', random('[0-9a-z]{5}')]))
     - name: firewall
       # Format the firewall name into a valid Kubernetes object name
       value: (trim((truncate(($run), `63`)), '-'))

--- a/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
+++ b/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'min-cluster', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'min-cluster', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodefirewall-controller/linodefirewall-addressset/chainsaw-test.yaml
+++ b/e2e/linodefirewall-controller/linodefirewall-addressset/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'addrset-firewall', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'addrset-firewall', random('[0-9a-z]{5}')]))
     - name: firewall
       # Format the firewall name into a valid Kubernetes object name
       value: (trim((truncate(($run), `63`)), '-'))

--- a/e2e/linodefirewall-controller/linodefirewall-firewall-rule/chainsaw-test.yaml
+++ b/e2e/linodefirewall-controller/linodefirewall-firewall-rule/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'fwrule-firewall', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'fwrule-firewall', random('[0-9a-z]{5}')]))
     - name: firewall
       # Format the firewall name into a valid Kubernetes object name
       value: (trim((truncate(($run), `63`)), '-'))

--- a/e2e/linodefirewall-controller/minimal-linodefirewall/chainsaw-test.yaml
+++ b/e2e/linodefirewall-controller/minimal-linodefirewall/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'min-firewall', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'min-firewall', random('[0-9a-z]{5}')]))
     - name: firewall
       # Format the firewall name into a valid Kubernetes object name
       value: (trim((truncate(($run), `63`)), '-'))

--- a/e2e/linodemachine-controller/cluster-object-store/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['cluster-obj', random('[0-9a-z]{7}')]))
+      value: (join('-', ['cluster-obj', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodemachine-controller/linodecluster-vpcref-integration/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/linodecluster-vpcref-integration/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'lc-vpc', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'lc-vpc', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodemachine-controller/linodemachine-vpcref-integration/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/linodemachine-vpcref-integration/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'lm-vpc', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'lm-vpc', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodemachine-controller/metadata-gzip-compression/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/metadata-gzip-compression/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'metadata-gzip', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'metadata-gzip', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodemachine-controller/minimal-linodemachine/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/minimal-linodemachine/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'min-lm', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'min-lm', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodemachinetemplate-controller/lmt-tags/chainsaw-test.yaml
+++ b/e2e/linodemachinetemplate-controller/lmt-tags/chainsaw-test.yaml
@@ -10,7 +10,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'cluster-obj-store', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'obj-store', random('[0-9a-z]{7}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodemachinetemplate-controller/lmt-tags/chainsaw-test.yaml
+++ b/e2e/linodemachinetemplate-controller/lmt-tags/chainsaw-test.yaml
@@ -10,7 +10,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'obj-store', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'obj-store', random('[0-9a-z]{5}')]))
     - name: cluster
       # Format the cluster name
       value: (trim((truncate(($run), `29`)), '-'))

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'force-delete-obj', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'force-delete-obj', random('[0-9a-z]{5}')]))
     - name: bucket
       # Format the bucket name into a valid Kubernetes object name
       # TODO: This is over-truncated to account for the Kubernetes access key Secret

--- a/e2e/linodeobjectstoragekey-controller/custom-secret/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragekey-controller/custom-secret/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'key-cust-secret', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'key-cust-secret', random('[0-9a-z]{5}')]))
     - name: key
       # Format the key name into a valid Kubernetes object name
       # TODO: This is over-truncated to account for the Kubernetes access key Secret

--- a/e2e/linodeobjectstoragekey-controller/deprecated-secret/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragekey-controller/deprecated-secret/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'deprecated-secret', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'deprecated-secret', random('[0-9a-z]{5}')]))
     - name: key
       # Format the key name into a valid Kubernetes object name
       # TODO: This is over-truncated to account for the Kubernetes access key Secret

--- a/e2e/linodeobjectstoragekey-controller/minimal-linodeobjectstoragekey/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragekey-controller/minimal-linodeobjectstoragekey/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'min-obj', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'min-obj', random('[0-9a-z]{5}')]))
     - name: key
       # Format the key name into a valid Kubernetes object name
       # TODO: This is over-truncated to account for the Kubernetes access key Secret

--- a/e2e/linodeplacementgroup-controller/minimal-linodeplacementgroup/chainsaw-test.yaml
+++ b/e2e/linodeplacementgroup-controller/minimal-linodeplacementgroup/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'min-placementgroup', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'min-placementgroup', random('[0-9a-z]{5}')]))
     - name: placementgroup
       # Format the placementgroup name into a valid Kubernetes object name
       value: (trim((truncate(($run), `63`)), '-'))

--- a/e2e/linodevpc-controller/minimal-linodevpc/chainsaw-test.yaml
+++ b/e2e/linodevpc-controller/minimal-linodevpc/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
   bindings:
     # A short identifier for the E2E test run
     - name: run
-      value: (join('-', ['e2e', 'min-vpc', random('[0-9a-z]{7}')]))
+      value: (join('-', ['e2e', 'min-vpc', random('[0-9a-z]{5}')]))
     - name: vpc
       # Format the VPC name into a valid Kubernetes object name
       value: (trim((truncate(($run), `63`)), '-'))

--- a/templates/addons/machine-health-check/machinehealthcheck.yaml
+++ b/templates/addons/machine-health-check/machinehealthcheck.yaml
@@ -18,7 +18,7 @@ spec:
   # Conditions to check on Nodes for matched Machines, if any condition is matched for the duration of its timeout, the Machine is considered unhealthy
   selector:
     matchLabels:
-      cluster.x-k8s.io/deployment-name: ${CLUSTER_NAME}-md-0
+      cluster.x-k8s.io/deployment-name: ${CLUSTER_NAME}
   unhealthyConditions:
     - type: Ready
       status: Unknown

--- a/templates/flavors/clusterclass-kubeadm/clusterClass.yaml
+++ b/templates/flavors/clusterclass-kubeadm/clusterClass.yaml
@@ -7,12 +7,12 @@ spec:
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: kubeadm-control-plane
+      name: kubeadm-cp
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
         kind: LinodeMachineTemplate
-        name: kubeadm-control-plane
+        name: kubeadm-cp
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2

--- a/templates/flavors/clusterclass-kubeadm/deleteTransformer.yaml
+++ b/templates/flavors/clusterclass-kubeadm/deleteTransformer.yaml
@@ -33,7 +33,7 @@ patch: |-
   apiVersion: controlplane.cluster.x-k8s.io/v1beta1
   kind: KubeadmControlPlane
   metadata:
-    name: ${CLUSTER_NAME}-control-plane
+    name: ${CLUSTER_NAME}-cp
 ---
 # delete machineDeployment from ../base
 apiVersion: builtin
@@ -45,7 +45,7 @@ patch: |-
   apiVersion: cluster.x-k8s.io/v1beta1
   kind: MachineDeployment
   metadata:
-    name: ${CLUSTER_NAME}-md-0
+    name: ${CLUSTER_NAME}
 ---
 # delete extra fields from kubeadmControlPlaneTemplate
 apiVersion: builtin

--- a/templates/flavors/clusterclass-kubeadm/kubeadmControlPlaneTemplate.yaml
+++ b/templates/flavors/clusterclass-kubeadm/kubeadmControlPlaneTemplate.yaml
@@ -1,7 +1,7 @@
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
-  name: kubeadm-control-plane
+  name: kubeadm-cp
 spec:
   template:
     spec:

--- a/templates/flavors/clusterclass-kubeadm/kustomization.yaml
+++ b/templates/flavors/clusterclass-kubeadm/kustomization.yaml
@@ -36,7 +36,7 @@ patches:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: kubeadm-control-plane
+        name: kubeadm-cp
 
   - target:
       group: bootstrap.cluster.x-k8s.io

--- a/templates/flavors/clusterclass-kubeadm/replacementTransformer.yaml
+++ b/templates/flavors/clusterclass-kubeadm/replacementTransformer.yaml
@@ -20,11 +20,11 @@ metadata:
 replacements:
   - source:
       kind: KubeadmControlPlane
-      name: ${CLUSTER_NAME}-control-plane
+      name: ${CLUSTER_NAME}-cp
       fieldPath: spec
     targets:
       - select:
           kind: KubeadmControlPlaneTemplate
-          name: kubeadm-control-plane
+          name: kubeadm-cp
         fieldPaths:
           - spec.template.spec

--- a/templates/flavors/k3s/cluster-autoscaler/kustomization.yaml
+++ b/templates/flavors/k3s/cluster-autoscaler/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}

--- a/templates/flavors/k3s/default/k3sConfigTemplate.yaml
+++ b/templates/flavors/k3s/default/k3sConfigTemplate.yaml
@@ -2,7 +2,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KThreesConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   template:
     spec:

--- a/templates/flavors/k3s/default/k3sControlPlane.yaml
+++ b/templates/flavors/k3s/default/k3sControlPlane.yaml
@@ -2,13 +2,13 @@
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KThreesControlPlane
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
+  name: ${CLUSTER_NAME}-cp
 spec:
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
-      name: ${CLUSTER_NAME}-control-plane
+      name: ${CLUSTER_NAME}-cp
   kthreesConfigSpec:
     files:
       - path: /etc/rancher/k3s/config.yaml.d/capi-config.yaml

--- a/templates/flavors/k3s/dual-stack/kustomization.yaml
+++ b/templates/flavors/k3s/dual-stack/kustomization.yaml
@@ -47,7 +47,7 @@ patches:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -62,7 +62,7 @@ patches:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
       spec:
         template:
           spec:
@@ -77,7 +77,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KThreesControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kthreesConfigSpec:
           serverConfig:

--- a/templates/flavors/k3s/full-vpcless/kustomization.yaml
+++ b/templates/flavors/k3s/full-vpcless/kustomization.yaml
@@ -83,7 +83,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KThreesControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kthreesConfigSpec:
           serverConfig:
@@ -139,7 +139,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}
@@ -202,12 +202,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -228,4 +228,4 @@ patches:
         objectStore:
           presignedURLDuration: "24h"
           credentialsRef:
-            name: ${CLUSTER_NAME}-object-store-obj-key
+            name: ${CLUSTER_NAME}-obj-key

--- a/templates/flavors/k3s/full/kustomization.yaml
+++ b/templates/flavors/k3s/full/kustomization.yaml
@@ -18,7 +18,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}
@@ -38,12 +38,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -64,4 +64,4 @@ patches:
         objectStore:
           presignedURLDuration: "24h"
           credentialsRef:
-            name: ${CLUSTER_NAME}-object-store-obj-key
+            name: ${CLUSTER_NAME}-obj-key

--- a/templates/flavors/kubeadm/cilium-bgp-lb/kustomization.yaml
+++ b/templates/flavors/kubeadm/cilium-bgp-lb/kustomization.yaml
@@ -61,7 +61,7 @@ transformers:
     replacements:
       - source:
           kind: KubeadmConfigTemplate
-          name: ${CLUSTER_NAME}-md-0
+          name: ${CLUSTER_NAME}
           fieldPath: .spec
         targets:
           - select:
@@ -73,7 +73,7 @@ transformers:
               create: true
       - source:
           kind: LinodeMachineTemplate
-          name: ${CLUSTER_NAME}-md-0
+          name: ${CLUSTER_NAME}
           fieldPath: .spec
         targets:
           - select:
@@ -85,7 +85,7 @@ transformers:
               create: true
       - source:
           kind: MachineDeployment
-          name: ${CLUSTER_NAME}-md-0
+          name: ${CLUSTER_NAME}
           fieldPath: .spec.template
         targets:
           - select:

--- a/templates/flavors/kubeadm/cluster-autoscaler/kustomization.yaml
+++ b/templates/flavors/kubeadm/cluster-autoscaler/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}

--- a/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmConfigTemplate.yaml
@@ -2,7 +2,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   template:
     spec:

--- a/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
+++ b/templates/flavors/kubeadm/default/kubeadmControlPlane.yaml
@@ -2,14 +2,14 @@
 kind: KubeadmControlPlane
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
+  name: ${CLUSTER_NAME}-cp
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   machineTemplate:
     infrastructureRef:
       kind: LinodeMachineTemplate
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
-      name: ${CLUSTER_NAME}-control-plane
+      name: ${CLUSTER_NAME}-cp
   kubeadmConfigSpec:
     preKubeadmCommands:
       - curl -fsSL https://github.com/linode/cluster-api-provider-linode/raw/dd76b1f979696ef22ce093d420cdbd0051a1d725/scripts/pre-kubeadminit.sh | bash -s ${KUBERNETES_VERSION}

--- a/templates/flavors/kubeadm/dual-stack/kustomization.yaml
+++ b/templates/flavors/kubeadm/dual-stack/kustomization.yaml
@@ -47,7 +47,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kubeadmConfigSpec:
           clusterConfiguration:
@@ -62,7 +62,7 @@ patches:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -77,7 +77,7 @@ patches:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
       spec:
         template:
           spec:

--- a/templates/flavors/kubeadm/etcd-disk/kustomization.yaml
+++ b/templates/flavors/kubeadm/etcd-disk/kustomization.yaml
@@ -9,12 +9,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -30,7 +30,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kubeadmConfigSpec:
           diskSetup:

--- a/templates/flavors/kubeadm/flatcar/patch-flatcar.yaml
+++ b/templates/flavors/kubeadm/flatcar/patch-flatcar.yaml
@@ -2,7 +2,7 @@
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:
-  name: "${CLUSTER_NAME}-control-plane"
+  name: "${CLUSTER_NAME}-cp"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   kubeadmConfigSpec:
@@ -58,7 +58,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   template:
     spec:
@@ -109,7 +109,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: LinodeMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   template:
     spec:
@@ -122,7 +122,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: LinodeMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
+  name: ${CLUSTER_NAME}-cp
 spec:
   template:
     spec:

--- a/templates/flavors/kubeadm/full-vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/full-vpcless/kustomization.yaml
@@ -111,7 +111,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kubeadmConfigSpec:
           clusterConfiguration:
@@ -126,7 +126,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}
@@ -134,12 +134,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -155,7 +155,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kubeadmConfigSpec:
           diskSetup:
@@ -177,7 +177,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         remediationStrategy:
           maxRetry: 5
@@ -203,7 +203,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         remediationStrategy:
           maxRetry: 5
@@ -228,12 +228,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -254,4 +254,4 @@ patches:
         objectStore:
           presignedURLDuration: "24h"
           credentialsRef:
-            name: ${CLUSTER_NAME}-object-store-obj-key
+            name: ${CLUSTER_NAME}-obj-key

--- a/templates/flavors/kubeadm/full/kustomization.yaml
+++ b/templates/flavors/kubeadm/full/kustomization.yaml
@@ -14,12 +14,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -35,7 +35,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kubeadmConfigSpec:
           diskSetup:
@@ -69,7 +69,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}
@@ -81,7 +81,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         remediationStrategy:
           maxRetry: 5
@@ -91,12 +91,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -117,4 +117,4 @@ patches:
         objectStore:
           presignedURLDuration: "24h"
           credentialsRef:
-            name: ${CLUSTER_NAME}-object-store-obj-key
+            name: ${CLUSTER_NAME}-obj-key

--- a/templates/flavors/kubeadm/konnectivity/kustomization.yaml
+++ b/templates/flavors/kubeadm/konnectivity/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         kubeadmConfigSpec:
           preKubeadmCommands:

--- a/templates/flavors/kubeadm/self-healing/kustomization.yaml
+++ b/templates/flavors/kubeadm/self-healing/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         remediationStrategy:
           maxRetry: 5

--- a/templates/flavors/rke2/cluster-autoscaler/kustomization.yaml
+++ b/templates/flavors/rke2/cluster-autoscaler/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}

--- a/templates/flavors/rke2/default/rke2ConfigTemplate.yaml
+++ b/templates/flavors/rke2/default/rke2ConfigTemplate.yaml
@@ -2,7 +2,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   template:
     spec:

--- a/templates/flavors/rke2/default/rke2ControlPlane.yaml
+++ b/templates/flavors/rke2/default/rke2ControlPlane.yaml
@@ -2,13 +2,13 @@
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
+  name: ${CLUSTER_NAME}-cp
 spec:
   version: ${KUBERNETES_VERSION}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: LinodeMachineTemplate
-    name: ${CLUSTER_NAME}-control-plane
+    name: ${CLUSTER_NAME}-cp
   registrationMethod: internal-only-ips
   rolloutStrategy:
     rollingUpdate:

--- a/templates/flavors/rke2/etcd-disk/kustomization.yaml
+++ b/templates/flavors/rke2/etcd-disk/kustomization.yaml
@@ -9,12 +9,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -30,7 +30,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: RKE2ControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         agentConfig:
           additionalUserData:

--- a/templates/flavors/rke2/full-vpcless/kustomization.yaml
+++ b/templates/flavors/rke2/full-vpcless/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}
@@ -38,12 +38,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -59,7 +59,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: RKE2ControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         agentConfig:
           additionalUserData:
@@ -85,12 +85,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -111,4 +111,4 @@ patches:
         objectStore:
           presignedURLDuration: "24h"
           credentialsRef:
-            name: ${CLUSTER_NAME}-object-store-obj-key
+            name: ${CLUSTER_NAME}-obj-key

--- a/templates/flavors/rke2/full/kustomization.yaml
+++ b/templates/flavors/rke2/full/kustomization.yaml
@@ -30,7 +30,7 @@ patches:
       apiVersion: cluster.x-k8s.io/v1beta1
       kind: MachineDeployment
       metadata:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         annotations:
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: ${WORKER_MACHINE_MIN:-"1"}
           cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: ${WORKER_MACHINE_MAX:-"10"}
@@ -38,12 +38,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -59,7 +59,7 @@ patches:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: RKE2ControlPlane
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         agentConfig:
           additionalUserData:
@@ -77,12 +77,12 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeMachineTemplate
-      name: .*-control-plane
+      name: .*-cp
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeMachineTemplate
       metadata:
-        name: ${CLUSTER_NAME}-control-plane
+        name: ${CLUSTER_NAME}-cp
       spec:
         template:
           spec:
@@ -103,4 +103,4 @@ patches:
         objectStore:
           presignedURLDuration: "24h"
           credentialsRef:
-            name: ${CLUSTER_NAME}-object-store-obj-key
+            name: ${CLUSTER_NAME}-obj-key

--- a/templates/infra/cluster.yaml
+++ b/templates/infra/cluster.yaml
@@ -13,7 +13,7 @@ spec:
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: REPLACEME
-    name: ${CLUSTER_NAME}-control-plane
+    name: ${CLUSTER_NAME}-cp
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: LinodeCluster

--- a/templates/infra/linodeMachineTemplate.yaml
+++ b/templates/infra/linodeMachineTemplate.yaml
@@ -2,7 +2,7 @@
 kind: LinodeMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 metadata:
-  name: ${CLUSTER_NAME}-control-plane
+  name: ${CLUSTER_NAME}-cp
 spec:
   template:
     spec:
@@ -29,7 +29,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: LinodeMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   template:
     spec:

--- a/templates/infra/machineDeployment.yaml
+++ b/templates/infra/machineDeployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: ${CLUSTER_NAME}-md-0
+  name: ${CLUSTER_NAME}
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}
@@ -14,10 +14,10 @@ spec:
       version: "${KUBERNETES_VERSION}"
       bootstrap:
         configRef:
-          name: ${CLUSTER_NAME}-md-0
+          name: ${CLUSTER_NAME}
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: REPLACEME
       infrastructureRef:
-        name: ${CLUSTER_NAME}-md-0
+        name: ${CLUSTER_NAME}
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
         kind: LinodeMachineTemplate


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: Shrinks the name of resources to more easily comply with the 32 character label limit for the linode API. This makes the following changes to the templates:
- shortens all instances of `"${CLUSTER_NAME}-control-plane"` to `"${CLUSTER_NAME}-cp"`
- removes `-md-0` from the worker node templates

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests


