### PR TITLE
[fix] remove extra obj region validation that is incompatible with newer re…

### DIFF
--- a/internal/webhook/v1alpha2/linodeobjectstoragebucket_webhook.go
+++ b/internal/webhook/v1alpha2/linodeobjectstoragebucket_webhook.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/linode/linodego"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -109,7 +110,7 @@ func (v *LinodeObjectStorageBucketCustomValidator) validateLinodeObjectStorageBu
 	if skipAPIValidation {
 		return errs
 	}
-	if err := validateObjectStorageRegion(ctx, linodeClient, bucket.Spec.Region, field.NewPath("spec").Child("region")); err != nil {
+	if err := validateRegion(ctx, linodeClient, bucket.Spec.Region, field.NewPath("spec").Child("region"), linodego.CapabilityObjectStorage); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/webhook/v1alpha2/linodeobjectstoragebucket_webhook_test.go
+++ b/internal/webhook/v1alpha2/linodeobjectstoragebucket_webhook_test.go
@@ -93,24 +93,6 @@ func TestValidateLinodeObjectStorageBucketSpec(t *testing.T) {
 		),
 		OneOf(
 			Path(
-				Call("invalid region format in spec", func(ctx context.Context, mck Mock) {
-				}),
-				Result("error", func(ctx context.Context, mck Mock) {
-					bucket := bucket
-					bucket.Spec.Region = "123invalid"
-					assert.NotNil(t, objvalidator.validateLinodeObjectStorageBucketSpec(ctx, &bucket, mck.LinodeClient, false))
-				}),
-			),
-			Path(
-				Call("invalid region format in spec", func(ctx context.Context, mck Mock) {
-				}),
-				Result("error", func(ctx context.Context, mck Mock) {
-					bucket := bucket
-					bucket.Spec.Region = "invalid-2-2"
-					assert.NotNil(t, objvalidator.validateLinodeObjectStorageBucketSpec(ctx, &bucket, mck.LinodeClient, false))
-				}),
-			),
-			Path(
 				Call("region ID not present", func(ctx context.Context, mck Mock) {
 					mck.LinodeClient.EXPECT().GetRegion(gomock.Any(), gomock.Any()).Return(nil, errors.New("invalid region")).AnyTimes()
 				}),

--- a/internal/webhook/v1alpha2/webhook_helpers.go
+++ b/internal/webhook/v1alpha2/webhook_helpers.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"regexp"
 	"slices"
 	"time"
 
@@ -78,34 +77,6 @@ func validateLinodeType(ctx context.Context, linodegoclient clients.LinodeClient
 	}
 
 	return plan, nil
-}
-
-// validateObjectStorageRegion validates an Object Storage deployment's region ID via the following rules:
-//   - The Region ID is in the form: REGION_ID.
-//   - The region has Object Storage support.
-//
-// NOTE: This implementation intended to bypass the authentication requirement for the [Clusters List] and [Cluster
-// View] endpoints in the Linode API, thereby reusing a [github.com/linode/linodego.Client] (and its caching if enabled)
-// across many admission requests.
-//
-// [Clusters List]: https://www.linode.com/docs/api/object-storage/#clusters-list
-// [Cluster View]: https://www.linode.com/docs/api/object-storage/#cluster-view
-
-func validateObjectStorageRegion(ctx context.Context, linodegoclient clients.LinodeClient, id string, path *field.Path) *field.Error {
-	// TODO: instrument with tracing, might need refactor to preserve readibility
-
-	cexp := regexp.MustCompile("^(([[:lower:]]+-)*[[:lower:]]+)$")
-	cexp1 := regexp.MustCompile(`^(([[:lower:]]+-)*[[:lower:]]+)-\d+$`)
-	if !cexp.MatchString(id) && !cexp1.MatchString(id) {
-		return field.Invalid(path, id, "must be in form: region_id or region_id-ordinal")
-	}
-	var region string
-	if cexp.FindStringSubmatch(id) != nil {
-		region = cexp.FindStringSubmatch(id)[0]
-	} else {
-		region = cexp1.FindStringSubmatch(id)[1]
-	}
-	return validateRegion(ctx, linodegoclient, region, path, linodego.CapabilityObjectStorage)
 }
 
 func getCredentialDataFromRef(ctx context.Context, crClient clients.K8sClient, credentialsRef corev1.SecretReference, defaultNamespace string) ([]byte, error) {


### PR DESCRIPTION
…gions

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
Newer Linode regions occasionally include an ordinal, which breaks the assumption of our obj webhook that if an ordinal exists, we should strip it and pass it through as a region. For instance, `sg-sin-2` and `jp-tyo-3` are new valid regions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


