### PR TITLE
[improvement] Fix DNS_UNIQUE_ID in templating so it's not required to be set for DNS flavor

### DIFF
--- a/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
@@ -19,7 +19,7 @@ patches:
         network:
           loadBalancerType: dns
           dnsRootDomain: ${DNS_ROOT_DOMAIN}
-          dnsUniqueIdentifier: ${DNS_UNIQUE_ID}
+          dnsUniqueIdentifier: ${DNS_UNIQUE_ID:-""}
           dnsProvider: ${DNS_PROVIDER:-"linode"}
           dnsSubDomainOverride: ${DNS_SUBDOMAIN_OVERRIDE:-""}
   - target:


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: We allow this field to be empty so CAPL can create a unique identifier automatically:
```
  dnsUniqueIdentifier	<string>
    dnsUniqueIdentifier is the unique identifier for the DNS. This let clusters
    with the same name have unique
    DNS record
    Ignored if the LoadBalancerType is set to anything other than dns
    If not set, CAPL will create a unique identifier for you
```
However if this var isn't set during template rendering we get an error:
```
(⎈|kind-tilt:N/A) ~/cluster-api-provider-linode   main  clusterctl generate cluster test-cluster --kubernetes-version v1.31.8 --infrastructure local-linode:v0.0.0 --flavor kubeadm-dns-loadbalancing> test-cluster.yaml
Error: value for variables [DNS_UNIQUE_ID] is not set. Please set the value using os environment variables or the clusterctl config file
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


