### PR TITLE
feat: return auth error

### DIFF
--- a/internal/controller/linodecluster_controller.go
+++ b/internal/controller/linodecluster_controller.go
@@ -207,7 +207,7 @@ func (r *LinodeClusterReconciler) reconcile(
 
 	if err := addMachineToLB(ctx, clusterScope); err != nil {
 		logger.Error(err, "Failed to add Linode machine to loadbalancer option")
-		return retryIfTransient(err, logger)
+		return retryIfTransient(err)
 	}
 
 	return res, nil

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -670,8 +670,10 @@ var _ = Describe("create", Label("machine", "create"), func() {
 			reconciler.ReconcileTimeout = time.Nanosecond
 
 			res, err := reconciler.reconcileCreate(ctx, logger, &mScope)
-			Expect(res.RequeueAfter).To(Equal(rutil.DefaultMachineControllerRetryDelay))
-			Expect(err).NotTo(HaveOccurred())
+			// Error is returned so controller-runtime handles requeue with exponential backoff
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("time is up"))
+			Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 			Expect(linodeMachine.GetCondition(ConditionPreflightMetadataSupportConfigured).Status).To(Equal(metav1.ConditionTrue))
 			Expect(linodeMachine.GetCondition(ConditionPreflightCreated).Status).To(Equal(metav1.ConditionFalse))

--- a/internal/controller/linodeobjectstoragebucket_controller.go
+++ b/internal/controller/linodeobjectstoragebucket_controller.go
@@ -140,7 +140,7 @@ func (r *LinodeObjectStorageBucketReconciler) reconcile(ctx context.Context, bSc
 	// Handle deleted buckets
 	if !bScope.Bucket.DeletionTimestamp.IsZero() {
 		if err := r.reconcileDelete(ctx, bScope); err != nil {
-			return retryIfTransient(err, bScope.Logger)
+			return retryIfTransient(err)
 		}
 		return res, nil
 	}

--- a/internal/controller/linodeobjectstoragebucket_controller_test.go
+++ b/internal/controller/linodeobjectstoragebucket_controller_test.go
@@ -266,8 +266,8 @@ var _ = Describe("lifecycle", Ordered, Label("bucket", "lifecycle"), func() {
 				OneOf(
 					Path(Result("cannot purge bucket", func(ctx context.Context, mck Mock) {
 						_, err := reconciler.reconcile(ctx, &bScope)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(mck.Logs()).To(ContainSubstring("failed to purge all objects"))
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("failed to purge all objects"))
 					})),
 				),
 			),

--- a/util/errors.go
+++ b/util/errors.go
@@ -33,5 +33,5 @@ var (
 	DeleteError     = "DeleteError"
 	UpdateError     = "UpdateError"
 	UnknownError    = "UnknownError"
-	CredentialError = "CredentialError"
+	CredentialError = "CredentialError" // #nosec G101 -- false positive
 )

--- a/util/errors.go
+++ b/util/errors.go
@@ -29,8 +29,9 @@ var (
 
 // List of failure reasons to use in the status fields of our resources
 var (
-	CreateError  = "CreateError"
-	DeleteError  = "DeleteError"
-	UpdateError  = "UpdateError"
-	UnknownError = "UnknownError"
+	CreateError     = "CreateError"
+	DeleteError     = "DeleteError"
+	UpdateError     = "UpdateError"
+	UnknownError    = "UnknownError"
+	CredentialError = "CredentialError"
 )

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -61,6 +61,24 @@ func IsRetryableError(err error) bool {
 		linodego.ErrorFromError) || errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
+// IsAuthenticationError determines if the error is an authentication or authorization error (401/403)
+// These errors are terminal and should not be retried without user intervention
+func IsAuthenticationError(err error) bool {
+	return linodego.ErrHasStatus(err, http.StatusUnauthorized, http.StatusForbidden)
+}
+
+// IsTerminalError determines if the error is terminal and should not be retried.
+// Terminal errors include bad requests (400), authentication errors (401/403), and not found (404)
+func IsTerminalError(err error) bool {
+	return linodego.ErrHasStatus(
+		err,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	)
+}
+
 // GetInstanceID determines the instance ID from the ProviderID
 func GetInstanceID(providerID *string) (int, error) {
 	if providerID == nil {

--- a/util/helpers_test.go
+++ b/util/helpers_test.go
@@ -121,6 +121,138 @@ func TestIsRetryableError(t *testing.T) {
 	}
 }
 
+func TestIsAuthenticationError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{{
+		name: "unauthorized error (401)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusUnauthorized,
+			Message:  "Invalid Token",
+		},
+		want: true,
+	}, {
+		name: "forbidden error (403)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusForbidden,
+			Message:  "Forbidden",
+		},
+		want: true,
+	}, {
+		name: "bad request error (400)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusBadRequest,
+			Message:  "bad request",
+		},
+		want: false,
+	}, {
+		name: "not found error (404)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusNotFound,
+			Message:  "not found",
+		},
+		want: false,
+	}, {
+		name: "internal server error (500)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusInternalServerError,
+			Message:  "internal error",
+		},
+		want: false,
+	}, {
+		name: "non-Linode error",
+		err:  errors.New("random error"),
+		want: false,
+	}}
+	for _, tt := range tests {
+		testcase := tt
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			if testcase.want != IsAuthenticationError(testcase.err) {
+				t.Errorf("IsAuthenticationError() = %v, want %v", IsAuthenticationError(testcase.err), testcase.want)
+			}
+		})
+	}
+}
+
+func TestIsTerminalError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{{
+		name: "bad request error (400)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusBadRequest,
+			Message:  "bad request",
+		},
+		want: true,
+	}, {
+		name: "unauthorized error (401)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusUnauthorized,
+			Message:  "Invalid Token",
+		},
+		want: true,
+	}, {
+		name: "forbidden error (403)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusForbidden,
+			Message:  "Forbidden",
+		},
+		want: true,
+	}, {
+		name: "not found error (404)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusNotFound,
+			Message:  "not found",
+		},
+		want: true,
+	}, {
+		name: "internal server error (500)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusInternalServerError,
+			Message:  "internal error",
+		},
+		want: false,
+	}, {
+		name: "too many requests (429)",
+		err: &linodego.Error{
+			Response: nil,
+			Code:     http.StatusTooManyRequests,
+			Message:  "rate limited",
+		},
+		want: false,
+	}, {
+		name: "non-Linode error",
+		err:  errors.New("random error"),
+		want: false,
+	}}
+	for _, tt := range tests {
+		testcase := tt
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			if testcase.want != IsTerminalError(testcase.err) {
+				t.Errorf("IsTerminalError() = %v, want %v", IsTerminalError(testcase.err), testcase.want)
+			}
+		})
+	}
+}
+
 func TestGetInstanceID(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

If the controller encounters an auth error (token invalid), the error stays silent to the user.

log error example:
```
2026-01-08T14:14:06Z	ERROR	LinodeMachineReconciler	unknown Linode API error	{"controller": "linodemachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "LinodeMachine", "LinodeMachine": {"name":"test-workload-cp-cjhrp","namespace":"default"}, "namespace": "default", "name": "test-workload-cp-cjhrp", "reconcileID": "7822f2fb-8d6e-439c-b7b5-133587bdfa73", "name": "default/test-workload-cp-cjhrp", "LinodeMachine": "test-workload-cp-cjhrp", "LinodeCluster": "test-workload", "error": "[401] Invalid Token"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


