### PR TITLE
[improvement] Prioritize security Renovate PRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/linode/cluster-api-provider-linode
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 v12.3.0

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,11 @@
   ],
   "packageRules": [
     {
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "prPriority": 10,
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
     },


### PR DESCRIPTION
Allow security-related Renovate updates to bypass the normal schedule.
Set the highest PR priority so those fixes are raised immediately.