### PR TITLE
Group Renovate security update PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,7 @@
   "postUpdateOptions": ["gomodTidy"],
   "vulnerabilityAlerts": {
     "enabled": true,
+    "groupName": "security updates",
   },
   "osvVulnerabilityAlerts": true,
   "platformAutomerge": true,


### PR DESCRIPTION
## Summary
- add a shared Renovate vulnerability alert group name
- reduce one-PR-per-package security update noise

## Testing
- not run (Renovate config change only)