### PR TITLE
Group GitHub Actions dependency update PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -70,6 +70,47 @@
       ]
     },
     {
+      "groupName": "github actions ci",
+      "groupSlug": "github-actions-ci",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "dorny/paths-filter",
+        "jetify-com/devbox-install-action",
+        "codecov/codecov-action",
+      ]
+    },
+    {
+      "groupName": "github actions docker",
+      "groupSlug": "github-actions-docker",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "docker/setup-qemu-action",
+        "docker/setup-buildx-action",
+        "docker/metadata-action",
+        "docker/login-action",
+        "docker/build-push-action",
+      ]
+    },
+    {
+      "groupName": "github actions pages",
+      "groupSlug": "github-actions-pages",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/configure-pages",
+        "actions/upload-pages-artifact",
+        "actions/deploy-pages",
+      ]
+    },
+    {
+      "groupName": "github actions release",
+      "groupSlug": "github-actions-release",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "release-drafter/release-drafter",
+        "softprops/action-gh-release",
+      ]
+    },
+    {
       "groupName": "akamai-major",
       "groupSlug": "akamai-go",
       "matchDatasources": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -77,6 +77,7 @@
         "dorny/paths-filter",
         "jetify-com/devbox-install-action",
         "codecov/codecov-action",
+        "actions/upload-artifact",
       ]
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -81,6 +81,26 @@
       ]
     },
     {
+      "groupName": "github actions core",
+      "groupSlug": "github-actions-core",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/checkout",
+        "actions/setup-go",
+        "step-security/harden-runner",
+      ]
+    },
+    {
+      "groupName": "github actions tooling",
+      "groupSlug": "github-actions-tooling",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "ScribeMD/docker-cache",
+        "gaurav-nelson/github-action-markdown-link-check",
+        "golangci/golangci-lint-action",
+      ]
+    },
+    {
       "groupName": "github actions docker",
       "groupSlug": "github-actions-docker",
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
- add Renovate package rules to group related GitHub Actions updates
- keep Docker, Pages, release, and CI helper updates in separate buckets
- reduce pull request noise from one-action-per-PR updates

## Why
The pending GitHub Actions updates fall into a few clear workflow surfaces rather than one single category:
- CI helpers: paths filtering, devbox install, and codecov
- Docker publishing actions
- GitHub Pages deployment actions
- release automation actions

Grouping along those boundaries reduces Renovate noise while still keeping unrelated workflow changes separate. That makes the update PRs easier to review and easier to debug if one workflow surface breaks.

## Testing
- not run (Renovate config change only)