### PR TITLE
[improvement] Harden quick e2e Linode API curl checks with polling

### DIFF
--- a/e2e/linodecluster-controller/firewall-integration/chainsaw-test.yaml
+++ b/e2e/linodecluster-controller/firewall-integration/chainsaw-test.yaml
@@ -45,15 +45,31 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Create Cluster resource
       try:
         - apply:
@@ -88,35 +104,40 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              
-              # Check if nodebalancer exists and get its ID
-              NB_RESPONSE=$(curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI")
-              
-              NB_COUNT=$(echo $NB_RESPONSE | jq '.results | length')
-              if [ "$NB_COUNT" -ne 1 ]; then
-                echo "Nodebalancer not found or multiple found"
-                exit 1
-              fi
-              
-              NB_ID=$(echo $NB_RESPONSE | jq -r '.data[0].id')
-              
-              # Check if firewall is configured for the nodebalancer
-              FW_RESPONSE=$(curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FIREWALL_LABEL" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI/$NB_ID/firewalls")
-              
-              FW_COUNT=$(echo $FW_RESPONSE | jq '.results')
-              if [ "$FW_COUNT" -eq 0 ]; then
-                echo "No firewall found for the nodebalancer"
-                exit 1
-              fi
-              
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                NB_RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$NB_RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  NB_ID=$(echo "$NB_RESPONSE" | jq -r '.data[0].id')
+                  FW_RESPONSE=$(curl -s \
+                    -H "Authorization: Bearer $LINODE_TOKEN" \
+                    -H "X-Filter: $FIREWALL_LABEL" \
+                    -H "Content-Type: application/json" \
+                    "https://$TARGET_API/$TARGET_API_VERSION/$URI/$NB_ID/firewalls")
+
+                  if echo "$FW_RESPONSE" | jq -e '.results > 0' >/dev/null; then
+                    break
+                  fi
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$NB_RESPONSE"
+                  echo "${FW_RESPONSE:-}"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
+
               echo "Nodebalancer exists and has the correct firewall configuration"
               exit 0
             check:
@@ -144,15 +165,31 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0
     - name: Check if the nodebalancer is deleted
       try:
         - script:
@@ -167,13 +204,29 @@ spec:
                 value: (to_string({"label":($nodebalancer)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0
     

--- a/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
+++ b/e2e/linodecluster-controller/minimal-linodecluster/chainsaw-test.yaml
@@ -57,15 +57,31 @@ spec:
                 value: (to_string({"label":($nodebalancer)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete Cluster resource
       try:
         - delete:
@@ -89,12 +105,28 @@ spec:
                 value: (to_string({"label":($nodebalancer)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodefirewall-controller/linodefirewall-addressset/chainsaw-test.yaml
+++ b/e2e/linodefirewall-controller/linodefirewall-addressset/chainsaw-test.yaml
@@ -46,15 +46,31 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete Firewall and AddressSet
       try:
         - delete:
@@ -77,12 +93,28 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodefirewall-controller/linodefirewall-firewall-rule/chainsaw-test.yaml
+++ b/e2e/linodefirewall-controller/linodefirewall-firewall-rule/chainsaw-test.yaml
@@ -46,15 +46,31 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete Firewall and FirewallRule
       try:
         - delete:
@@ -77,12 +93,28 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodefirewall-controller/minimal-linodefirewall/chainsaw-test.yaml
+++ b/e2e/linodefirewall-controller/minimal-linodefirewall/chainsaw-test.yaml
@@ -40,15 +40,31 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete Firewall
       try:
         - delete:
@@ -66,12 +82,28 @@ spec:
                 value: (to_string({"label":($firewall)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/networking/firewalls"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/networking/firewalls")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodemachine-controller/cluster-object-store/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
                 -H "Authorization: Bearer $LINODE_TOKEN" \
                 -H "Content-Type: application/json" \
                 -d "{\"label\":\"$BUCKET_LABEL\",\"region\":\"us-sea\"}" \
-                "https://api.linode.com/v4/$URI"
+                "https://api.linode.com/v4beta/$URI"
             check:
               ($error): ~
     - name: Create LinodeObjectStorageKey
@@ -119,7 +119,7 @@ spec:
               curl -s \
                 -X DELETE \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
-                "https://api.linode.com/v4/$URI/$KEY_ID"
+                "https://api.linode.com/v4beta/$URI/$KEY_ID"
             check:
               ($error): ~
     - name: Delete bucket
@@ -136,6 +136,6 @@ spec:
               curl -s \
                 -X DELETE \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
-                "https://api.linode.com/v4/$URI/$BUCKET_LABEL"
+                "https://api.linode.com/v4beta/$URI/$BUCKET_LABEL"
             check:
               ($error): ~

--- a/e2e/linodemachine-controller/linodecluster-vpcref-integration/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/linodecluster-vpcref-integration/chainsaw-test.yaml
@@ -70,15 +70,31 @@ spec:
                 value: (to_string({"tags":($cluster)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
         - script:
             env:
               - name: TARGET_API
@@ -91,19 +107,31 @@ spec:
                 value: (to_string({"label":($vpc)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.data[0].subnets[0].linodes[0].interfaces[0].active == true' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                data:
-                  - subnets:
-                      - linodes:
-                          - interfaces:
-                              - active: true
     - name: Delete the Cluster & LinodeVPC resource
       try:
         - delete:
@@ -132,15 +160,31 @@ spec:
                 value: (to_string({"tags":($cluster)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0
         - script:
             env:
               - name: TARGET_API
@@ -153,12 +197,28 @@ spec:
                 value: (to_string({"label":($vpc)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodemachine-controller/linodemachine-vpcref-integration/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/linodemachine-vpcref-integration/chainsaw-test.yaml
@@ -78,15 +78,31 @@ spec:
                 value: (to_string({"tags":($cluster)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
         - script:
             env:
               - name: TARGET_API
@@ -99,19 +115,31 @@ spec:
                 value: (to_string({"label":($vpc)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.data[0].subnets[0].linodes[0].interfaces[0].active == true' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                data:
-                  - subnets:
-                      - linodes:
-                          - interfaces:
-                              - active: true
     - name: Delete the Cluster & LinodeVPC resource
       try:
         - delete:
@@ -140,15 +168,31 @@ spec:
                 value: (to_string({"tags":($cluster)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0
         - script:
             env:
               - name: TARGET_API
@@ -161,12 +205,28 @@ spec:
                 value: (to_string({"label":($vpc)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodemachine-controller/minimal-linodemachine/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/minimal-linodemachine/chainsaw-test.yaml
@@ -66,15 +66,31 @@ spec:
                 value: (to_string({"tags":($cluster)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete Cluster resource
       try:
         - delete:
@@ -98,12 +114,28 @@ spec:
                 value: (to_string({"tags":($cluster)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://$TARGET_API/$TARGET_API_VERSION/$URI")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -19,6 +19,8 @@ spec:
       value: (trim((truncate(($run), `52`)), '-'))
     - name: access_secret
       value: (join('-', [($bucket), 'obj-key']))
+    - name: region
+      value: us-sea
   template: true
   steps:
     - name: Check if CAPI provider resources exist
@@ -47,6 +49,8 @@ spec:
             env:
               - name: BUCKET
                 value: ($bucket)
+              - name: REGION
+                value: ($region)
             content: |
               set -e
               MAX_RETRIES=12
@@ -57,7 +61,7 @@ spec:
                 RESPONSE=$(curl -s \
                   -H "Authorization: Bearer $LINODE_TOKEN" \
                   -H "Content-Type: application/json" \
-                  "https://api.linode.com/v4beta/object-storage/buckets/us-sea-1/$BUCKET")
+                  "https://api.linode.com/v4beta/object-storage/buckets/$REGION/$BUCKET")
 
                 if echo "$RESPONSE" | jq -e --arg bucket "$BUCKET" '.label == $bucket' >/dev/null; then
                   break
@@ -124,6 +128,8 @@ spec:
             env:
               - name: BUCKET
                 value: ($bucket)
+              - name: REGION
+                value: ($region)
             content: |
               set -e
               MAX_RETRIES=12
@@ -134,7 +140,7 @@ spec:
                 STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
                   -H "Authorization: Bearer $LINODE_TOKEN" \
                   -H "Content-Type: application/json" \
-                  "https://api.linode.com/v4beta/object-storage/buckets/us-sea-1/$BUCKET")
+                  "https://api.linode.com/v4beta/object-storage/buckets/$REGION/$BUCKET")
 
                 if [ "$STATUS" = "404" ]; then
                   echo "$STATUS"

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -80,7 +80,7 @@ spec:
               - name: URI
                 value: object-storage/keys
               - name: OBJ_KEY
-                value: ($access_secret)
+                value: ($bucket)
             content: |
               set -e
 

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -49,14 +49,30 @@ spec:
                 value: ($bucket)
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/object-storage/buckets/us-sea-1/$BUCKET"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/object-storage/buckets/us-sea-1/$BUCKET")
+
+                if echo "$RESPONSE" | jq -e --arg bucket "$BUCKET" '.label == $bucket' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                label: ($bucket)
     - name: Ensure the access key was created
       try:
         - script:
@@ -69,11 +85,28 @@ spec:
               set -e
 
               export KEY_ID=$(kubectl -n $NAMESPACE get lobjkey $OBJ_KEY -ojson | jq '.status.accessKeyRef')
-              
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/$URI/$KEY_ID"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/$URI/$KEY_ID")
+
+                if echo "$RESPONSE" | jq -e '.id' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
     - name: Delete LinodeObjectStorageBucket
@@ -93,10 +126,28 @@ spec:
                 value: ($bucket)
             content: |
               set -e
-              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/object-storage/buckets/us-sea-1/$BUCKET")
-              echo "$STATUS"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/object-storage/buckets/us-sea-1/$BUCKET")
+
+                if [ "$STATUS" = "404" ]; then
+                  echo "$STATUS"
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$STATUS"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               (contains($stdout, '404')): true

--- a/e2e/linodeobjectstoragekey-controller/custom-secret/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragekey-controller/custom-secret/chainsaw-test.yaml
@@ -42,7 +42,7 @@ spec:
                 -H "Authorization: Bearer $LINODE_TOKEN" \
                 -H "Content-Type: application/json" \
                 -d "{\"label\":\"$BUCKET_LABEL\",\"region\":\"us-sea\"}" \
-                "https://api.linode.com/v4/$URI"
+                "https://api.linode.com/v4beta/$URI"
             check:
               ($error): ~
     - name: Create LinodeObjectStorageKey
@@ -71,11 +71,28 @@ spec:
               set -e
 
               export KEY_ID=$(kubectl -n $NAMESPACE get lobjkey $OBJ_KEY -ojson | jq '.status.accessKeyRef')
-              
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/$URI/$KEY_ID"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/$URI/$KEY_ID")
+
+                if echo "$RESPONSE" | jq -e '.id' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
     - name: Delete LinodeObjectStorageKey
@@ -103,6 +120,6 @@ spec:
               curl -s \
                 -X DELETE \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
-                "https://api.linode.com/v4/$URI/$BUCKET_LABEL"
+                "https://api.linode.com/v4beta/$URI/$BUCKET_LABEL"
             check:
               ($error): ~

--- a/e2e/linodeobjectstoragekey-controller/minimal-linodeobjectstoragekey/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragekey-controller/minimal-linodeobjectstoragekey/chainsaw-test.yaml
@@ -41,7 +41,7 @@ spec:
                 -H "Authorization: Bearer $LINODE_TOKEN" \
                 -H "Content-Type: application/json" \
                 -d "{\"label\":\"$BUCKET_LABEL\",\"region\":\"us-sea\"}" \
-                "https://api.linode.com/v4/$URI"
+                "https://api.linode.com/v4beta/$URI"
             check:
               ($error): ~
     - name: Create LinodeObjectStorageKey
@@ -69,11 +69,28 @@ spec:
               set -e
 
               export KEY_ID=$(kubectl -n $NAMESPACE get lobjkey $OBJ_KEY -ojson | jq '.status.accessKeyRef')
-              
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/$URI/$KEY_ID"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/$URI/$KEY_ID")
+
+                if echo "$RESPONSE" | jq -e '.id' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
     - name: Delete LinodeObjectStorageKey
@@ -101,6 +118,6 @@ spec:
               curl -s \
                 -X DELETE \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
-                "https://api.linode.com/v4/$URI/$BUCKET_LABEL"
+                "https://api.linode.com/v4beta/$URI/$BUCKET_LABEL"
             check:
               ($error): ~

--- a/e2e/linodeplacementgroup-controller/minimal-linodeplacementgroup/chainsaw-test.yaml
+++ b/e2e/linodeplacementgroup-controller/minimal-linodeplacementgroup/chainsaw-test.yaml
@@ -40,15 +40,31 @@ spec:
                 value: (to_string({"label":($placementgroup)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/placement/groups"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/placement/groups")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete PlacementGroup
       try:
         - delete:
@@ -66,12 +82,28 @@ spec:
                 value: (to_string({"label":($placementgroup)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/placement/groups"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/placement/groups")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/e2e/linodevpc-controller/minimal-linodevpc/chainsaw-test.yaml
+++ b/e2e/linodevpc-controller/minimal-linodevpc/chainsaw-test.yaml
@@ -40,15 +40,31 @@ spec:
                 value: (to_string({"label":($vpc)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/vpcs"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/vpcs")
+
+                if echo "$RESPONSE" | jq -e '.results == 1' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 1
     - name: Delete VPC
       try:
         - delete:
@@ -66,12 +82,28 @@ spec:
                 value: (to_string({"label":($vpc)}))
             content: |
               set -e
-              curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "X-Filter: $FILTER" \
-                -H "Content-Type: application/json" \
-                "https://api.linode.com/v4/nodebalancers"
+              MAX_RETRIES=12
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                RESPONSE=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "X-Filter: $FILTER" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/vpcs")
+
+                if echo "$RESPONSE" | jq -e '.results == 0' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
             check:
               ($error): ~
-              (json_parse($stdout)):
-                results: 0

--- a/renovate.json5
+++ b/renovate.json5
@@ -70,6 +70,47 @@
       ]
     },
     {
+      "groupName": "github actions ci",
+      "groupSlug": "github-actions-ci",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "dorny/paths-filter",
+        "jetify-com/devbox-install-action",
+        "codecov/codecov-action",
+      ]
+    },
+    {
+      "groupName": "github actions docker",
+      "groupSlug": "github-actions-docker",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "docker/setup-qemu-action",
+        "docker/setup-buildx-action",
+        "docker/metadata-action",
+        "docker/login-action",
+        "docker/build-push-action",
+      ]
+    },
+    {
+      "groupName": "github actions pages",
+      "groupSlug": "github-actions-pages",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/configure-pages",
+        "actions/upload-pages-artifact",
+        "actions/deploy-pages",
+      ]
+    },
+    {
+      "groupName": "github actions release",
+      "groupSlug": "github-actions-release",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "release-drafter/release-drafter",
+        "softprops/action-gh-release",
+      ]
+    },
+    {
       "groupName": "akamai-major",
       "groupSlug": "akamai-go",
       "matchDatasources": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -77,6 +77,7 @@
         "dorny/paths-filter",
         "jetify-com/devbox-install-action",
         "codecov/codecov-action",
+        "actions/upload-artifact",
       ]
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -81,6 +81,26 @@
       ]
     },
     {
+      "groupName": "github actions core",
+      "groupSlug": "github-actions-core",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "actions/checkout",
+        "actions/setup-go",
+        "step-security/harden-runner",
+      ]
+    },
+    {
+      "groupName": "github actions tooling",
+      "groupSlug": "github-actions-tooling",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": [
+        "ScribeMD/docker-cache",
+        "gaurav-nelson/github-action-markdown-link-check",
+        "golangci/golangci-lint-action",
+      ]
+    },
+    {
       "groupName": "github actions docker",
       "groupSlug": "github-actions-docker",
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Why

Some of the quick Chainsaw e2e tests appear to fail because the Kubernetes resource reaches `status.ready=true` before the corresponding Linode API read/list endpoint reflects the new object consistently. In practice, the failing pattern is an immediate one-shot `curl` assertion against the provider API returning no result or incomplete linkage right after the controller reports readiness.

This change makes those checks more reliable by adding bounded polling directly inside the existing Chainsaw `script` steps.

## What changed

- add minimal polling loops to the affected provider-facing `curl` checks in the quick suite
- keep shell strictness at `set -e`
- move the affected checks to `https://api.linode.com/v4beta/...`
- fix the VPC delete validation to query the VPC endpoint instead of the nodebalancer endpoint

## Scope

This is intentionally a minimal test hardening change.

- no controller logic changes
- no shared helper scripts
- no Chainsaw abstraction/refactor
- polling is localized to the flaky provider API checks so CI can validate whether this removes the read-after-write race

## Validation

Local validation completed:

- targeted YAML parsing passed
- direct quick-suite execution reached the real Tilt/kind bootstrap path once Go was made available on `PATH`

CI on this draft PR should give the real signal on whether the polling reduces the random quick-test failures.
