### PR TITLE
bugfix: ApiResponseRatelimitCounter response header handling

### DIFF
--- a/util/ratelimits.go
+++ b/util/ratelimits.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -46,15 +47,40 @@ func (c *PostRequestCounter) ApiResponseRatelimitCounter(resp *resty.Response) e
 		return nil
 	}
 
-	var err error
-	c.ReqRemaining, err = strconv.Atoi(resp.Header().Get("X-Ratelimit-Remaining"))
-	if err != nil {
-		return err
-	}
+	var (
+		err       error
+		logger    = logr.FromContextOrDiscard(resp.Request.Context())
+		now       = time.Now().Add(15 * time.Second).Unix()
+		epochTime int64
+		// Linode creation limits ref: https://techdocs.akamai.com/linode-api/reference/rate-limits#specific-operation-rate-limits
+		// Creating Linodes has a dedicated rate limit of 20 requests per 15 seconds.
+		instancesPostDefaultLimit = 20
+		reqRemaining              int
+		rateLimitRemainingHeader  = resp.Header().Get("X-Ratelimit-Remaining")
+		rateLimitResetHeader      = resp.Header().Get("X-Ratelimit-Reset")
+	)
 
-	epochTime, err := strconv.ParseInt(resp.Header().Get("X-Ratelimit-Reset"), 10, 64)
-	if err != nil {
-		return err
+	if rateLimitRemainingHeader == "" {
+		logger.Info("missing X-Ratelimit-Remaining header, using default value")
+		reqRemaining = instancesPostDefaultLimit - 1
+	} else {
+		reqRemaining, err = strconv.Atoi(rateLimitRemainingHeader)
+		if err != nil {
+			logger.Error(err, "Failed to parse X-Ratelimit-Remaining header, using default value")
+			reqRemaining = instancesPostDefaultLimit - 1
+		}
+	}
+	c.ReqRemaining = reqRemaining
+
+	if rateLimitResetHeader == "" {
+		logger.Info("missing X-Ratelimit-Reset header, using default value", "X-Ratelimit-Reset", now)
+		epochTime = now
+	} else {
+		epochTime, err = strconv.ParseInt(rateLimitResetHeader, 10, 64)
+		if err != nil {
+			logger.Error(err, "Failed to parse X-Ratelimit-Reset header, using default value")
+			epochTime = now
+		}
 	}
 	c.RefreshTime = time.Unix(epochTime, 0)
 	return nil

--- a/util/ratelimits_test.go
+++ b/util/ratelimits_test.go
@@ -149,7 +149,7 @@ func TestPostRequestCounter_ApiResponseRatelimitCounter(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "no headers in response",
+			name: "no headers in response, expect default values",
 			fields: &PostRequestCounter{
 				ReqRemaining: 4,
 				RefreshTime:  now,
@@ -159,8 +159,11 @@ func TestPostRequestCounter_ApiResponseRatelimitCounter(t *testing.T) {
 					Method: http.MethodPost,
 					URL:    "/v4/linode/instances",
 				},
+				RawResponse: &http.Response{
+					Header: http.Header{"X-Ratelimit-Remaining": []string{"19"}, "X-Ratelimit-Reset": []string{strconv.Itoa(int(time.Now().Add(15 * time.Second).Unix()))}},
+				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "missing one value in response header",
@@ -174,10 +177,10 @@ func TestPostRequestCounter_ApiResponseRatelimitCounter(t *testing.T) {
 					URL:    "/v4/linode/instances",
 				},
 				RawResponse: &http.Response{
-					Header: http.Header{"X-Ratelimit-Remaining": []string{"5"}},
+					Header: http.Header{"X-Ratelimit-Remaining": []string{"5"}, "X-Ratelimit-Reset": []string{strconv.Itoa(int(time.Now().Add(15 * time.Second).Unix()))}},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "correct headers in response",


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

Fixes an edge case bug in handling POST /linode/instances linodego calls where the Linode is successfully created and the api response is missing header(s). This causes the request to fail, with `ERROR	LinodeMachineReconciler	Failed to create Linode machine instance`. This is due to the `ApiResponseRatelimitCounter` method not checking if the `X-Ratelimit-Remaining` and `X-Ratelimit-Reset` headers have a non-empty value, which causes the strconv call to fail: `"[002] strconv.Atoi: parsing \"\": invalid syntax"`.

This PR modifies the logic to not return an error and instead to log the error in the case of one or both of the headers not being present in the response. I added default values for each of the headers.
Per https://techdocs.akamai.com/linode-api/reference/rate-limits#specific-operation-rate-limits `Creating Linodes has a dedicated rate limit of 20 requests per 15 seconds.`

`X-Ratelimit-Remaining`: 19 (max of 20 per 15 seconds, minus the one just created)
`X-Ratelimit-Reset`: 15 (seconds)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests



