### PR TITLE
[fix] clusterctl move annotation handling (Backport #1063 #1074)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -28,6 +28,9 @@ kubeadm-full:
 kubeadm-flatcar:
  - templates/flavors/kubeadm/flatcar/*
 
+cluster-pause:
+  - e2e/cluster-pause/*
+
 #k3s:
 #  - templates/flavors/k3s/default/*
 #  - e2e/capl-cluster-flavors/k3s-capl-cluster/*

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -24,6 +24,7 @@ on:
         required: true
         options:
           - quick
+          - cluster-pause
           - flavors
           - k3s
           - rke2

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -101,6 +101,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             storage.googleapis.com:443
             registry.k8s.io:443
             *.pkg.dev:443

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -63,6 +63,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             storage.googleapis.com:443
             registry.k8s.io:443
             *.pkg.dev:443

--- a/.github/workflows/go-analyze.yml
+++ b/.github/workflows/go-analyze.yml
@@ -53,6 +53,7 @@ jobs:
             *.githubusercontent.com:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             vuln.go.dev:443
             storage.googleapis.com:443
             golangci-lint.run:443

--- a/.github/workflows/pull_request_ci.yaml
+++ b/.github/workflows/pull_request_ci.yaml
@@ -104,6 +104,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             gcr.io:443
             storage.googleapis.com:443
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ generate-code: controller-gen gowrap ## Generate code containing DeepCopy, DeepC
 
 .PHONY: generate-mock
 generate-mock: mockgen ## Generate mocks for the Linode API client.
-	$(MOCKGEN) -source=./clients/clients.go -destination ./mock/client.go -package mock
+	GOROOT=$$(go env GOROOT) $(MOCKGEN) -source=./clients/clients.go -destination ./mock/client.go -package mock
 
 .PHONY: generate-flavors ## Generate template flavors.
 generate-flavors: $(KUSTOMIZE)

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ docs:
 
 .PHONY: test
 test: generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use ${ENVTEST_K8S_VERSION#v} --bin-dir $(CACHE_BIN) -p path)" go test -race -timeout 60s `go list ./... | grep -v ./mock$$`  -coverprofile cover.out.tmp
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use ${ENVTEST_K8S_VERSION#v} --bin-dir $(CACHE_BIN) -p path)" go test -timeout 60s `go list ./... | grep -v ./mock$$` -coverpkg=./... -coverprofile cover.out.tmp
 	grep -v "zz_generated.*" cover.out.tmp > cover.out
 	rm cover.out.tmp
 

--- a/Makefile
+++ b/Makefile
@@ -381,6 +381,7 @@ GOWRAP_VERSION           ?= v1.4.0
 S5CMD_VERSION            ?= v2.2.2
 CONVERSION_GEN_VERSION   ?= v0.32.2
 GOLANGCI_LINT_VERSION    ?= v2.1.5
+ENVTEST_VERSION          ?= release-0.22
 
 .PHONY: tools
 tools: $(KUSTOMIZE) $(CTLPTL) $(CLUSTERCTL) $(KUBECTL) $(CONTROLLER_GEN) $(CONVERSION_GEN) $(TILT) $(KIND) $(CHAINSAW) $(ENVTEST) $(HUSKY) $(NILAWAY) $(GOVULNC) $(MOCKGEN) $(GOWRAP)
@@ -452,7 +453,7 @@ $(CHAINSAW): $(CACHE_BIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(CACHE_BIN)
-	GOBIN=$(CACHE_BIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
+	GOBIN=$(CACHE_BIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .phony: golangci-lint
 golangci-lint: $(GOLANGCI_LINT)

--- a/api/v1alpha2/linodecluster_types.go
+++ b/api/v1alpha2/linodecluster_types.go
@@ -127,11 +127,35 @@ func (lc *LinodeCluster) GetConditions() []metav1.Condition {
 			lc.Status.Conditions[i].Reason = DefaultConditionReason
 		}
 	}
+
 	return lc.Status.Conditions
 }
 
 func (lc *LinodeCluster) SetConditions(conditions []metav1.Condition) {
 	lc.Status.Conditions = conditions
+}
+
+func (lc *LinodeCluster) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range lc.Status.Conditions {
+		if lc.Status.Conditions[i].Type == cond.Type {
+			lc.Status.Conditions[i] = cond
+			return
+		}
+	}
+	lc.Status.Conditions = append(lc.Status.Conditions, cond)
+}
+
+func (lc *LinodeCluster) GetCondition(condType string) *metav1.Condition {
+	for i := range lc.Status.Conditions {
+		if lc.Status.Conditions[i].Type == condType {
+			return &lc.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
 // We need V1Beta2Conditions helpers to be able to use the conditions package from cluster-api

--- a/api/v1alpha2/linodefirewall_types.go
+++ b/api/v1alpha2/linodefirewall_types.go
@@ -157,11 +157,35 @@ func (lfw *LinodeFirewall) GetConditions() []metav1.Condition {
 			lfw.Status.Conditions[i].Reason = DefaultConditionReason
 		}
 	}
+
 	return lfw.Status.Conditions
 }
 
 func (lfw *LinodeFirewall) SetConditions(conditions []metav1.Condition) {
 	lfw.Status.Conditions = conditions
+}
+
+func (lfw *LinodeFirewall) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range lfw.Status.Conditions {
+		if lfw.Status.Conditions[i].Type == cond.Type {
+			lfw.Status.Conditions[i] = cond
+			return
+		}
+	}
+	lfw.Status.Conditions = append(lfw.Status.Conditions, cond)
+}
+
+func (lfw *LinodeFirewall) GetCondition(condType string) *metav1.Condition {
+	for i := range lfw.Status.Conditions {
+		if lfw.Status.Conditions[i].Type == condType {
+			return &lfw.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
 // We need V1Beta2Conditions helpers to be able to use the conditions package from cluster-api

--- a/api/v1alpha2/linodemachine_types.go
+++ b/api/v1alpha2/linodemachine_types.go
@@ -558,11 +558,35 @@ func (lm *LinodeMachine) GetConditions() []metav1.Condition {
 			lm.Status.Conditions[i].Reason = DefaultConditionReason
 		}
 	}
+
 	return lm.Status.Conditions
 }
 
 func (lm *LinodeMachine) SetConditions(conditions []metav1.Condition) {
 	lm.Status.Conditions = conditions
+}
+
+func (lm *LinodeMachine) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range lm.Status.Conditions {
+		if lm.Status.Conditions[i].Type == cond.Type {
+			lm.Status.Conditions[i] = cond
+			return
+		}
+	}
+	lm.Status.Conditions = append(lm.Status.Conditions, cond)
+}
+
+func (lm *LinodeMachine) GetCondition(condType string) *metav1.Condition {
+	for i := range lm.Status.Conditions {
+		if lm.Status.Conditions[i].Type == condType {
+			return &lm.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
 func (lm *LinodeMachine) GetV1Beta2Conditions() []metav1.Condition {

--- a/api/v1alpha2/linodeplacementgroup_types.go
+++ b/api/v1alpha2/linodeplacementgroup_types.go
@@ -140,11 +140,35 @@ func (lpg *LinodePlacementGroup) GetConditions() []metav1.Condition {
 			lpg.Status.Conditions[i].Reason = DefaultConditionReason
 		}
 	}
+
 	return lpg.Status.Conditions
 }
 
 func (lpg *LinodePlacementGroup) SetConditions(conditions []metav1.Condition) {
 	lpg.Status.Conditions = conditions
+}
+
+func (lpg *LinodePlacementGroup) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range lpg.Status.Conditions {
+		if lpg.Status.Conditions[i].Type == cond.Type {
+			lpg.Status.Conditions[i] = cond
+			return
+		}
+	}
+	lpg.Status.Conditions = append(lpg.Status.Conditions, cond)
+}
+
+func (lpg *LinodePlacementGroup) GetCondition(condType string) *metav1.Condition {
+	for i := range lpg.Status.Conditions {
+		if lpg.Status.Conditions[i].Type == condType {
+			return &lpg.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
 func (lpg *LinodePlacementGroup) GetV1Beta2Conditions() []metav1.Condition {

--- a/api/v1alpha2/linodevpc_types.go
+++ b/api/v1alpha2/linodevpc_types.go
@@ -215,11 +215,35 @@ func (lv *LinodeVPC) GetConditions() []metav1.Condition {
 			lv.Status.Conditions[i].Reason = DefaultConditionReason
 		}
 	}
+
 	return lv.Status.Conditions
 }
 
 func (lv *LinodeVPC) SetConditions(conditions []metav1.Condition) {
 	lv.Status.Conditions = conditions
+}
+
+func (lv *LinodeVPC) SetCondition(cond metav1.Condition) {
+	if cond.LastTransitionTime.IsZero() {
+		cond.LastTransitionTime = metav1.Now()
+	}
+	for i := range lv.Status.Conditions {
+		if lv.Status.Conditions[i].Type == cond.Type {
+			lv.Status.Conditions[i] = cond
+			return
+		}
+	}
+	lv.Status.Conditions = append(lv.Status.Conditions, cond)
+}
+
+func (lv *LinodeVPC) GetCondition(condType string) *metav1.Condition {
+	for i := range lv.Status.Conditions {
+		if lv.Status.Conditions[i].Type == condType {
+			return &lv.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }
 
 func (lv *LinodeVPC) GetV1Beta2Conditions() []metav1.Condition {

--- a/e2e/cluster-pause/assert-capi-resources.yaml
+++ b/e2e/cluster-pause/assert-capi-resources.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+  namespace: capl-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caaph-controller-manager
+  namespace: caaph-system
+status:
+  availableReplicas: 1

--- a/e2e/cluster-pause/assert-child-cluster-daemonsets.yaml
+++ b/e2e/cluster-pause/assert-child-cluster-daemonsets.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ccm-linode
+  namespace: kube-system
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+status:
+  currentNumberScheduled: 2
+  desiredNumberScheduled: 2
+  numberAvailable: 2
+  numberMisscheduled: 0
+  numberReady: 2
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-linode-node
+  namespace: kube-system
+status:
+  currentNumberScheduled: 2
+  desiredNumberScheduled: 2
+  numberAvailable: 2
+  numberMisscheduled: 0
+  numberReady: 2

--- a/e2e/cluster-pause/assert-child-cluster-deployments.yaml
+++ b/e2e/cluster-pause/assert-child-cluster-deployments.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+status:
+  availableReplicas: 2
+  readyReplicas: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  namespace: kube-system
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+status:
+  availableReplicas: 2
+  readyReplicas: 2

--- a/e2e/cluster-pause/assert-child-cluster-resources.yaml
+++ b/e2e/cluster-pause/assert-child-cluster-resources.yaml
@@ -1,0 +1,59 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  region: (env('LINODE_REGION'))
+  type: g6-standard-2
+status:
+  ready: true
+  instanceState: running
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  clusterName: ($cluster)
+status:
+  initialization:
+    bootstrapDataSecretCreated: true
+    infrastructureProvisioned: true
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  clusterName: ($cluster)
+  replicas: 1
+status:
+  readyReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+status:
+  readyReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmReleaseProxy
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+  - type: ClusterAvailable
+    status: "True"
+  - type: HelmReleaseReady
+    status: "True"
+  status: deployed

--- a/e2e/cluster-pause/chainsaw-test.yaml
+++ b/e2e/cluster-pause/chainsaw-test.yaml
@@ -1,0 +1,466 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: cluster-pause
+  labels:
+    all:
+    cluster-pause:
+spec:
+  bindings:
+    - name: run
+      value: (join('-', ['e2e', 'pause', random('[0-9a-z]{5}')]))
+    - name: cluster
+      value: (trim((truncate(($run), `29`)), '-'))
+  template: true
+  steps:
+    - name: Check if CAPI provider resources exist
+      try:
+        - assert:
+            file: assert-capi-resources.yaml
+    - name: Generate cluster using clusterctl
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: CLUSTERCTL_CONFIG
+                value: (env('CLUSTERCTL_CONFIG'))
+              - name: KUBERNETES_VERSION
+                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+            content: |
+              set -e
+              clusterctl generate cluster "$CLUSTER" -n "$NAMESPACE" \
+                --kubernetes-version "${KUBERNETES_VERSION}" \
+                --infrastructure local-linode:v0.0.0 \
+                --control-plane-machine-count 1 --worker-machine-count 1 \
+                --config "${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml}" > cluster-pause.yaml
+            check:
+              ($error == null): true
+    - name: Apply generated cluster yaml
+      try:
+        - apply:
+            file: cluster-pause.yaml
+        - assert:
+            file: assert-child-cluster-resources.yaml
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachine
+        - describe:
+            apiVersion: cluster.x-k8s.io/v1beta2
+            kind: Machine
+        - describe:
+            apiVersion: cluster.x-k8s.io/v1beta2
+            kind: MachineDeployment
+        - describe:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: KubeadmControlPlane
+        - describe:
+            apiVersion: addons.cluster.x-k8s.io/v1alpha1
+            kind: HelmReleaseProxy
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Check if the Linodes are created
+      try:
+        - script:
+            env:
+              - name: TARGET_API
+                value: api.linode.com
+              - name: TARGET_API_VERSION
+                value: v4beta
+              - name: URI
+                value: linode/instances
+              - name: FILTER
+                value: (to_string({"tags":($cluster)}))
+            content: |
+              set -e
+              curl -s \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "X-Filter: $FILTER" \
+                -H "Content-Type: application/json" \
+                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+            check:
+              ($error): ~
+              (json_parse($stdout)):
+                results: 2
+    - name: Get child cluster kubeconfig
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -e
+              clusterctl get kubeconfig "$CLUSTER" -n "$NAMESPACE" > cluster-pause-kubeconfig.yaml
+            check:
+              ($error == null): true
+    - clusters:
+        cluster-pause:
+          kubeconfig: ./cluster-pause-kubeconfig.yaml
+      name: Check child cluster resources
+      try:
+        - assert:
+            cluster: cluster-pause
+            file: assert-child-cluster-deployments.yaml
+        - assert:
+            cluster: cluster-pause
+            file: assert-child-cluster-daemonsets.yaml
+      catch:
+        - describe:
+            cluster: cluster-pause
+            apiVersion: apps/v1
+            kind: Deployment
+            namespace: kube-system
+        - describe:
+            cluster: cluster-pause
+            apiVersion: apps/v1
+            kind: DaemonSet
+            namespace: kube-system
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Pause owner cluster
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -e
+              kubectl patch cluster "$CLUSTER" -n "$NAMESPACE" --type=merge -p '{"spec":{"paused":true}}'
+            check:
+              ($error == null): true
+      catch:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Verify CAPL resources are paused
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -euo pipefail
+
+              wait_for_count() {
+                local resource=$1
+                local selector=$2
+                local expected=$3
+                local count=""
+
+                for _ in $(seq 1 30); do
+                  count=$(kubectl get "$resource" -n "$NAMESPACE" -l "$selector" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+                  if [[ "$count" == "$expected" ]]; then
+                    return 0
+                  fi
+                  sleep 10
+                done
+
+                echo "expected $expected $resource resources for selector $selector, got ${count:-0}"
+                kubectl get "$resource" -n "$NAMESPACE" -l "$selector" -o wide || true
+                return 1
+              }
+
+              wait_for_pause_named() {
+                local resource=$1
+                local name=$2
+                local expected=$3
+                kubectl wait -n "$NAMESPACE" --for="jsonpath={.status.conditions[?(@.type==\"Paused\")].status}=${expected}" --timeout=10m "$resource/$name"
+              }
+
+              wait_for_pause_selector() {
+                local resource=$1
+                local selector=$2
+                local expected=$3
+                kubectl wait -n "$NAMESPACE" --for="jsonpath={.status.conditions[?(@.type==\"Paused\")].status}=${expected}" --timeout=10m "$resource" -l "$selector"
+              }
+
+              selector="cluster.x-k8s.io/cluster-name=$CLUSTER"
+
+              wait_for_count linodevpc "$selector" 1
+              wait_for_count linodefirewall "$selector" 2
+              wait_for_count linodemachine "$selector" 2
+
+              wait_for_pause_named cluster "$CLUSTER" True
+              wait_for_pause_named linodecluster "$CLUSTER" True
+              wait_for_pause_named linodevpc "$CLUSTER" True
+              wait_for_pause_named linodefirewall "$CLUSTER" True
+              wait_for_pause_named linodefirewall "${CLUSTER}-nb" True
+              wait_for_pause_selector linodemachine "$selector" True
+            check:
+              ($error == null): true
+      catch:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Unpause owner cluster
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -e
+              kubectl patch cluster "$CLUSTER" -n "$NAMESPACE" --type=merge -p '{"spec":{"paused":false}}'
+            check:
+              ($error == null): true
+      catch:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Verify CAPL resources are unpaused
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -euo pipefail
+
+              wait_for_count() {
+                local resource=$1
+                local selector=$2
+                local expected=$3
+                local count=""
+
+                for _ in $(seq 1 30); do
+                  count=$(kubectl get "$resource" -n "$NAMESPACE" -l "$selector" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+                  if [[ "$count" == "$expected" ]]; then
+                    return 0
+                  fi
+                  sleep 10
+                done
+
+                echo "expected $expected $resource resources for selector $selector, got ${count:-0}"
+                kubectl get "$resource" -n "$NAMESPACE" -l "$selector" -o wide || true
+                return 1
+              }
+
+              wait_for_pause_named() {
+                local resource=$1
+                local name=$2
+                local expected=$3
+                kubectl wait -n "$NAMESPACE" --for="jsonpath={.status.conditions[?(@.type==\"Paused\")].status}=${expected}" --timeout=10m "$resource/$name"
+              }
+
+              wait_for_pause_selector() {
+                local resource=$1
+                local selector=$2
+                local expected=$3
+                kubectl wait -n "$NAMESPACE" --for="jsonpath={.status.conditions[?(@.type==\"Paused\")].status}=${expected}" --timeout=10m "$resource" -l "$selector"
+              }
+
+              selector="cluster.x-k8s.io/cluster-name=$CLUSTER"
+
+              wait_for_count linodevpc "$selector" 1
+              wait_for_count linodefirewall "$selector" 2
+              wait_for_count linodemachine "$selector" 2
+
+              wait_for_pause_named cluster "$CLUSTER" False
+              wait_for_pause_named linodecluster "$CLUSTER" False
+              wait_for_pause_named linodevpc "$CLUSTER" False
+              wait_for_pause_named linodefirewall "$CLUSTER" False
+              wait_for_pause_named linodefirewall "${CLUSTER}-nb" False
+              wait_for_pause_selector linodemachine "$selector" False
+            check:
+              ($error == null): true
+      catch:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Delete child cluster
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: SKIP_DELETE
+                value: (env('SKIP_CUSTOM_DELETE'))
+            content: |
+              set -e
+              if [[ -n "$SKIP_DELETE" ]]; then
+                echo "Skipping deletion of child cluster"
+                exit 0
+              fi
+              kubectl delete cluster "$CLUSTER" -n "$NAMESPACE" --timeout=120s || { echo "deletion failed!"; exit 1; }
+            check:
+              ($error == null): true
+              (contains($stdout, 'deletion failed')): false
+      catch:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Check if the Linodes are deleted
+      try:
+        - script:
+            env:
+              - name: TARGET_API
+                value: api.linode.com
+              - name: TARGET_API_VERSION
+                value: v4beta
+              - name: URI
+                value: linode/instances
+              - name: FILTER
+                value: (to_string({"tags":($cluster)}))
+              - name: SKIP_DELETE
+                value: (env('SKIP_CUSTOM_DELETE'))
+            content: |
+              set -e
+              if [[ -n "$SKIP_DELETE" ]]; then
+                echo '{"results":0}'
+                exit 0
+              fi
+              curl -s \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "X-Filter: $FILTER" \
+                -H "Content-Type: application/json" \
+                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+            check:
+              ($error): ~
+              (json_parse($stdout)):
+                results: 0
+      catch:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set +e
+              kubectl describe cluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodecluster "$CLUSTER" -n "$NAMESPACE"
+              kubectl describe linodevpc -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodefirewall -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              kubectl describe linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER"
+              clusterctl describe cluster "$CLUSTER" -n "$NAMESPACE" --show-conditions all || true
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 100
+    - name: Delete generated child cluster manifest yaml
+      try:
+        - script:
+            content: |
+              rm -f cluster-pause.yaml
+              rm -f cluster-pause-kubeconfig.yaml
+            check:
+              ($error == null): true

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -92,11 +92,10 @@ spec:
               - name: BUCKET
                 value: ($bucket)
             content: |
-              set -e
-              curl -s \
+              curl -s -w "\n%{http_code}" \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
                 -H "Content-Type: application/json" \
                 "https://api.linode.com/v4/object-storage/buckets/us-sea-1/$BUCKET"
             check:
-              ($stdout): |-
-                {"errors": [{"reason": "Not found"}]}
+              ($error): ~
+              (ends_with(trim($stdout), '404')): true

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -98,4 +98,4 @@ spec:
                 "https://api.linode.com/v4/object-storage/buckets/us-sea-1/$BUCKET"
             check:
               ($error): ~
-              (ends_with(trim($stdout), '404')): true
+              (ends_with(trim($stdout, '\n'), '404')): true

--- a/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
+++ b/e2e/linodeobjectstoragebucket-controller/force-delete-linodeobjectstoragebucket/chainsaw-test.yaml
@@ -98,4 +98,4 @@ spec:
                 "https://api.linode.com/v4/object-storage/buckets/us-sea-1/$BUCKET"
             check:
               ($error): ~
-              (ends_with(trim($stdout, '\n'), '404')): true
+              (ends_with($stdout, '404')): true

--- a/internal/controller/linodecluster_controller.go
+++ b/internal/controller/linodecluster_controller.go
@@ -74,17 +74,11 @@ type LinodeClusterReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 
-func (r *LinodeClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LinodeClusterReconciler) Reconcile(ctx context.Context, linodeCluster *infrav1alpha2.LinodeCluster) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
 
-	logger := ctrl.LoggerFrom(ctx).WithName("LinodeClusterReconciler").WithValues("name", req.String())
-	linodeCluster := &infrav1alpha2.LinodeCluster{}
-	if err := r.TracedClient().Get(ctx, req.NamespacedName, linodeCluster); err != nil {
-		logger.Info("Failed to fetch Linode cluster", "error", err.Error())
-
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
+	logger := ctrl.LoggerFrom(ctx).WithName("LinodeClusterReconciler").WithValues("name", linodeCluster.Name, "namespace", linodeCluster.Namespace)
 
 	cluster, err := kutil.GetOwnerCluster(ctx, r.TracedClient(), linodeCluster.ObjectMeta)
 	if err != nil {
@@ -544,7 +538,7 @@ func (r *LinodeClusterReconciler) SetupWithManager(mgr ctrl.Manager, options crc
 		Watches(
 			&infrav1alpha2.LinodeMachine{},
 			handler.EnqueueRequestsFromMapFunc(linodeMachineToLinodeCluster(r.TracedClient(), mgr.GetLogger())),
-		).Complete(wrappedruntimereconciler.NewRuntimeReconcilerWithTracing(r, wrappedruntimereconciler.DefaultDecorator()))
+		).Complete(reconciler.AsReconcilerWithTracing(r.TracedClient(), r))
 	if err != nil {
 		return fmt.Errorf("failed to build controller: %w", err)
 	}

--- a/internal/controller/linodecluster_controller.go
+++ b/internal/controller/linodecluster_controller.go
@@ -533,7 +533,7 @@ func (r *LinodeClusterReconciler) SetupWithManager(mgr ctrl.Manager, options crc
 		For(&infrav1alpha2.LinodeCluster{}).
 		WithOptions(options).
 		// we care about reconciling on metadata updates for LinodeClusters because the OwnerRef for the Cluster is needed
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(

--- a/internal/controller/linodecluster_controller_test.go
+++ b/internal/controller/linodecluster_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -289,9 +288,7 @@ var _ = Describe("cluster-lifecycle", Ordered, Label("cluster", "cluster-lifecyc
 				}),
 				Result("no capl cluster error", func(ctx context.Context, mck Mock) {
 					reconciler.Client = k8sClient
-					_, err := reconciler.Reconcile(ctx, reconcile.Request{
-						NamespacedName: client.ObjectKeyFromObject(cScope.LinodeCluster),
-					})
+					_, err := reconciler.Reconcile(ctx, cScope.LinodeCluster)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(linodeCluster.Status.Ready).To(BeFalseBecause("failed to get Cluster/no-capl-cluster: clusters.cluster.x-k8s.io \"no-capl-cluster\" not found"))
 				}),
@@ -373,7 +370,7 @@ var _ = Describe("pause handling", Label("cluster", "pause"), func() {
 			DnsClientConfig:    scope.ClientConfig{Token: "test-token"},
 		}
 
-		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(linodeCluster)})
+		_, err := reconciler.Reconcile(ctx, linodeCluster)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeCluster), linodeCluster)).To(Succeed())

--- a/internal/controller/linodecluster_controller_test.go
+++ b/internal/controller/linodecluster_controller_test.go
@@ -25,11 +25,14 @@ import (
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
@@ -334,6 +337,92 @@ var _ = Describe("cluster-lifecycle", Ordered, Label("cluster", "cluster-lifecyc
 			),
 		),
 	)
+})
+
+var _ = Describe("pause handling", Label("cluster", "pause"), func() {
+	It("sets paused condition for LinodeCluster when owner Cluster is paused", func(ctx SpecContext) {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-cluster-owner",
+				Namespace: defaultNamespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		linodeCluster := &infrav1alpha2.LinodeCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-cluster-infra",
+				Namespace: defaultNamespace,
+			},
+			Spec: infrav1alpha2.LinodeClusterSpec{
+				Region: "us-ord",
+				ControlPlaneEndpoint: clusterv1.APIEndpoint{
+					Port: 6443,
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		Expect(controllerutil.SetControllerReference(cluster, linodeCluster, scheme.Scheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, linodeCluster)).To(Succeed())
+
+		reconciler := &LinodeClusterReconciler{
+			Client:             k8sClient,
+			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
+			DnsClientConfig:    scope.ClientConfig{Token: "test-token"},
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(linodeCluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeCluster), linodeCluster)).To(Succeed())
+		pausedCondition := linodeCluster.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(controllerutil.ContainsFinalizer(linodeCluster, infrav1alpha2.ClusterFinalizer)).To(BeFalse())
+	})
+
+	It("sets and clears paused condition from the upstream pause annotation path", func(ctx SpecContext) {
+		linodeCluster := &infrav1alpha2.LinodeCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-cluster-annotation",
+				Namespace: defaultNamespace,
+				Annotations: map[string]string{
+					clusterv1.PausedAnnotation: "",
+				},
+			},
+			Spec: infrav1alpha2.LinodeClusterSpec{
+				Region: "us-ord",
+				ControlPlaneEndpoint: clusterv1.APIEndpoint{
+					Port: 6443,
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, linodeCluster)).To(Succeed())
+
+		isPaused, _, err := paused.EnsurePausedCondition(ctx, k8sClient, nil, linodeCluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeTrue())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeCluster), linodeCluster)).To(Succeed())
+		pausedCondition := linodeCluster.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+
+		delete(linodeCluster.Annotations, clusterv1.PausedAnnotation)
+		Expect(k8sClient.Update(ctx, linodeCluster)).To(Succeed())
+
+		isPaused, _, err = paused.EnsurePausedCondition(ctx, k8sClient, nil, linodeCluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeFalse())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeCluster), linodeCluster)).To(Succeed())
+		pausedCondition = linodeCluster.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
+	})
 })
 
 var _ = Describe("cluster-lifecycle-dns", Ordered, Label("cluster", "cluster-lifecycle-dns"), func() {

--- a/internal/controller/linodefirewall_controller.go
+++ b/internal/controller/linodefirewall_controller.go
@@ -114,7 +114,7 @@ func (r *LinodeFirewallReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, fmt.Errorf("failed to create cluster scope: %w", err)
 	}
 
-	// Only check pause if not deleting or if cluster still exists
+	// Only check pause if not deleting or if cluster still exists.
 	if linodeFirewall.DeletionTimestamp.IsZero() || cluster != nil {
 		isPaused, _, err := paused.EnsurePausedCondition(ctx, fwScope.Client, fwScope.Cluster, fwScope.LinodeFirewall)
 		if err != nil {
@@ -289,8 +289,11 @@ func (r *LinodeFirewallReconciler) SetupWithManager(mgr ctrl.Manager, options cr
 		WithOptions(options).
 		WithEventFilter(
 			predicate.And(
-				predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
-				predicate.GenerationChangedPredicate{},
+				predicates.ResourceHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
+				predicate.Or(
+					predicate.GenerationChangedPredicate{},
+					predicate.AnnotationChangedPredicate{},
+				),
 				predicate.Funcs{UpdateFunc: func(e event.UpdateEvent) bool {
 					oldObject, okOld := e.ObjectOld.(*infrav1alpha2.LinodeFirewall)
 					newObject, okNew := e.ObjectNew.(*infrav1alpha2.LinodeFirewall)

--- a/internal/controller/linodefirewall_controller_helpers.go
+++ b/internal/controller/linodefirewall_controller_helpers.go
@@ -55,7 +55,7 @@ func findObjectsForObject(logger logr.Logger, tracedClient client.Client) handle
 				logger.Info("LinodeFirewall(s) not found for %s")
 
 				return nil
-			case err != nil:
+			default:
 				logger.Error(err, "Failed to get LinodeFirewalls")
 
 				return nil

--- a/internal/controller/linodefirewall_controller_test.go
+++ b/internal/controller/linodefirewall_controller_test.go
@@ -29,7 +29,10 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -306,4 +309,85 @@ var _ = Describe("lifecycle", Ordered, Label("firewalls", "lifecycle"), func() {
 			),
 		),
 	)
+})
+
+var _ = Describe("pause handling", Label("firewalls", "pause"), func() {
+	It("sets paused condition for LinodeFirewall when owner Cluster is paused", func(ctx SpecContext) {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-firewall-cluster",
+				Namespace: defaultNamespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		firewall := &infrav1alpha2.LinodeFirewall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-firewall-object",
+				Namespace: defaultNamespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: cluster.Name,
+				},
+			},
+			Spec: infrav1alpha2.LinodeFirewallSpec{
+				Enabled: true,
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		Expect(k8sClient.Create(ctx, firewall)).To(Succeed())
+
+		reconciler := &LinodeFirewallReconciler{
+			Client:             k8sClient,
+			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(firewall)})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(firewall), firewall)).To(Succeed())
+		pausedCondition := firewall.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(controllerutil.ContainsFinalizer(firewall, infrav1alpha2.FirewallFinalizer)).To(BeFalse())
+	})
+
+	It("sets and clears paused condition from the upstream pause annotation path", func(ctx SpecContext) {
+		firewall := &infrav1alpha2.LinodeFirewall{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-firewall-annotation",
+				Namespace: defaultNamespace,
+				Annotations: map[string]string{
+					clusterv1.PausedAnnotation: "",
+				},
+			},
+			Spec: infrav1alpha2.LinodeFirewallSpec{
+				Enabled: true,
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, firewall)).To(Succeed())
+
+		isPaused, _, err := paused.EnsurePausedCondition(ctx, k8sClient, nil, firewall)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeTrue())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(firewall), firewall)).To(Succeed())
+		pausedCondition := firewall.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+
+		delete(firewall.Annotations, clusterv1.PausedAnnotation)
+		Expect(k8sClient.Update(ctx, firewall)).To(Succeed())
+
+		isPaused, _, err = paused.EnsurePausedCondition(ctx, k8sClient, nil, firewall)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeFalse())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(firewall), firewall)).To(Succeed())
+		pausedCondition = firewall.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
+	})
 })

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -945,7 +945,7 @@ func (r *LinodeMachineReconciler) SetupWithManager(mgr ctrl.Manager, options crc
 		).
 		// we care about reconciling on metadata updates for LinodeMachines because the OwnerRef for the Machine is needed
 		WithEventFilter(predicate.And(
-			predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
+			predicates.ResourceHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
 			predicate.Funcs{UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject, okOld := e.ObjectOld.(*infrav1alpha2.LinodeMachine)
 				newObject, okNew := e.ObjectNew.(*infrav1alpha2.LinodeMachine)

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -30,14 +30,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -1091,6 +1095,126 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				{Type: clusterv1.MachineInternalIP, Address: "192.168.0.2"},
 			}))
 		})
+	})
+})
+
+var _ = Describe("pause handling", Label("machine", "pause"), func() {
+	It("sets paused condition for LinodeMachine when owner Cluster is paused", func(ctx SpecContext) {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-machine-cluster",
+				Namespace: defaultNamespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+				InfrastructureRef: &corev1.ObjectReference{
+					Kind:       "LinodeCluster",
+					Name:       "pause-machine-linodecluster",
+					APIVersion: infrav1alpha2.GroupVersion.String(),
+				},
+			},
+		}
+		linodeCluster := &infrav1alpha2.LinodeCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-machine-linodecluster",
+				Namespace: defaultNamespace,
+			},
+			Spec: infrav1alpha2.LinodeClusterSpec{
+				Region: "us-ord",
+				ControlPlaneEndpoint: clusterv1.APIEndpoint{
+					Port: 6443,
+				},
+			},
+		}
+		machine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-machine-owner",
+				Namespace: defaultNamespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: cluster.Name,
+				},
+			},
+			Spec: clusterv1.MachineSpec{
+				ClusterName: cluster.Name,
+				Bootstrap: clusterv1.Bootstrap{
+					DataSecretName: ptr.To("pause-machine-bootstrap"),
+				},
+				InfrastructureRef: corev1.ObjectReference{
+					Kind:       "LinodeMachine",
+					Name:       "pause-machine-infra",
+					APIVersion: infrav1alpha2.GroupVersion.String(),
+				},
+			},
+		}
+		linodeMachine := &infrav1alpha2.LinodeMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-machine-infra",
+				Namespace: defaultNamespace,
+			},
+			Spec: infrav1alpha2.LinodeMachineSpec{
+				Region: "us-ord",
+				Type:   "g6-standard-1",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		Expect(k8sClient.Create(ctx, linodeCluster)).To(Succeed())
+		Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+		Expect(controllerutil.SetControllerReference(machine, linodeMachine, scheme.Scheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, linodeMachine)).To(Succeed())
+
+		reconciler := &LinodeMachineReconciler{
+			Client:             k8sClient,
+			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
+		}
+
+		_, err := reconciler.Reconcile(ctrl.LoggerInto(ctx, ctrl.Log), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(linodeMachine)})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeMachine), linodeMachine)).To(Succeed())
+		pausedCondition := linodeMachine.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(controllerutil.ContainsFinalizer(linodeMachine, infrav1alpha2.MachineFinalizer)).To(BeFalse())
+	})
+
+	It("sets and clears paused condition from the upstream pause annotation path", func(ctx SpecContext) {
+		linodeMachine := &infrav1alpha2.LinodeMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-machine-annotation",
+				Namespace: defaultNamespace,
+				Annotations: map[string]string{
+					clusterv1.PausedAnnotation: "",
+				},
+			},
+			Spec: infrav1alpha2.LinodeMachineSpec{
+				Region: "us-ord",
+				Type:   "g6-standard-1",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, linodeMachine)).To(Succeed())
+
+		isPaused, _, err := paused.EnsurePausedCondition(ctx, k8sClient, nil, linodeMachine)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeTrue())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeMachine), linodeMachine)).To(Succeed())
+		pausedCondition := linodeMachine.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+
+		delete(linodeMachine.Annotations, clusterv1.PausedAnnotation)
+		Expect(k8sClient.Update(ctx, linodeMachine)).To(Succeed())
+
+		isPaused, _, err = paused.EnsurePausedCondition(ctx, k8sClient, nil, linodeMachine)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeFalse())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(linodeMachine), linodeMachine)).To(Succeed())
+		pausedCondition = linodeMachine.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
 	})
 })
 

--- a/internal/controller/linodeobjectstoragebucket_controller.go
+++ b/internal/controller/linodeobjectstoragebucket_controller.go
@@ -44,7 +44,6 @@ import (
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	"github.com/linode/cluster-api-provider-linode/cloud/services"
 	wrappedruntimeclient "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimeclient"
-	wrappedruntimereconciler "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimereconciler"
 	"github.com/linode/cluster-api-provider-linode/util"
 	"github.com/linode/cluster-api-provider-linode/util/reconciler"
 )
@@ -76,20 +75,11 @@ type LinodeObjectStorageBucketReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.0/pkg/reconcile
-func (r *LinodeObjectStorageBucketReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LinodeObjectStorageBucketReconciler) Reconcile(ctx context.Context, objectStorageBucket *infrav1alpha2.LinodeObjectStorageBucket) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
 
-	logger := r.Logger.WithValues("name", req.String())
-
-	objectStorageBucket := &infrav1alpha2.LinodeObjectStorageBucket{}
-	if err := r.TracedClient().Get(ctx, req.NamespacedName, objectStorageBucket); err != nil {
-		if err = client.IgnoreNotFound(err); err != nil {
-			logger.Error(err, "Failed to fetch LinodeObjectStorageBucket", "name", req.String())
-		}
-
-		return ctrl.Result{}, err
-	}
+	logger := r.Logger.WithValues("name", objectStorageBucket.Name, "namespace", objectStorageBucket.Namespace)
 
 	if _, ok := objectStorageBucket.Labels[clusterv1.ClusterNameLabel]; ok {
 		cluster, err := kutil.GetClusterFromMetadata(ctx, r.TracedClient(), objectStorageBucket.ObjectMeta)
@@ -254,7 +244,7 @@ func (r *LinodeObjectStorageBucketReconciler) SetupWithManager(mgr ctrl.Manager,
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(linodeObjectStorageBucketMapper),
 			builder.WithPredicates(predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), mgr.GetLogger())),
-		).Complete(wrappedruntimereconciler.NewRuntimeReconcilerWithTracing(r, wrappedruntimereconciler.DefaultDecorator()))
+		).Complete(reconciler.AsReconcilerWithTracing(r.TracedClient(), r))
 	if err != nil {
 		return fmt.Errorf("failed to build controller: %w", err)
 	}

--- a/internal/controller/linodeobjectstoragebucket_controller_test.go
+++ b/internal/controller/linodeobjectstoragebucket_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	"github.com/linode/cluster-api-provider-linode/mock"
 	"github.com/linode/cluster-api-provider-linode/util"
+	rec "github.com/linode/cluster-api-provider-linode/util/reconciler"
 
 	. "github.com/linode/cluster-api-provider-linode/mock/mocktest"
 	. "github.com/onsi/ginkgo/v2"
@@ -329,7 +330,7 @@ var _ = Describe("errors", Label("bucket", "errors"), func() {
 				}),
 				Result("no error", func(ctx context.Context, mck Mock) {
 					reconciler.Client = mck.K8sClient
-					_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					_, err := rec.AsReconcilerWithTracing(mck.K8sClient, &reconciler).Reconcile(ctx, reconcile.Request{
 						NamespacedName: client.ObjectKeyFromObject(bScope.Bucket),
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -342,18 +343,17 @@ var _ = Describe("errors", Label("bucket", "errors"), func() {
 				Result("error", func(ctx context.Context, mck Mock) {
 					reconciler.Client = mck.K8sClient
 					reconciler.Logger = bScope.Logger
-					_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					_, err := rec.AsReconcilerWithTracing(mck.K8sClient, &reconciler).Reconcile(ctx, reconcile.Request{
 						NamespacedName: client.ObjectKeyFromObject(bScope.Bucket),
 					})
 					Expect(err.Error()).To(ContainSubstring("non-404 error"))
-					Expect(mck.Logs()).To(ContainSubstring("Failed to fetch LinodeObjectStorageBucket"))
 				}),
 			),
 		),
 		Result("scope params is missing args", func(ctx context.Context, mck Mock) {
 			reconciler.Client = mck.K8sClient
 			reconciler.Logger = bScope.Logger
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			_, err := rec.AsReconcilerWithTracing(mck.K8sClient, &reconciler).Reconcile(ctx, reconcile.Request{
 				NamespacedName: client.ObjectKeyFromObject(bScope.Bucket),
 			})
 			Expect(err.Error()).To(ContainSubstring("failed to create object storage bucket scope"))

--- a/internal/controller/linodeobjectstoragekey_controller.go
+++ b/internal/controller/linodeobjectstoragekey_controller.go
@@ -45,7 +45,6 @@ import (
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	"github.com/linode/cluster-api-provider-linode/cloud/services"
 	wrappedruntimeclient "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimeclient"
-	wrappedruntimereconciler "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimereconciler"
 	"github.com/linode/cluster-api-provider-linode/util"
 	"github.com/linode/cluster-api-provider-linode/util/reconciler"
 )
@@ -76,22 +75,13 @@ type LinodeObjectStorageKeyReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.2/pkg/reconcile
-func (r *LinodeObjectStorageKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LinodeObjectStorageKeyReconciler) Reconcile(ctx context.Context, objectStorageKey *infrav1alpha2.LinodeObjectStorageKey) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
 
-	logger := r.Logger.WithValues("name", req.String())
+	logger := r.Logger.WithValues("name", objectStorageKey.Name, "namespace", objectStorageKey.Namespace)
 
 	tracedClient := r.TracedClient()
-
-	objectStorageKey := &infrav1alpha2.LinodeObjectStorageKey{}
-	if err := tracedClient.Get(ctx, req.NamespacedName, objectStorageKey); err != nil {
-		if err = client.IgnoreNotFound(err); err != nil {
-			logger.Error(err, "Failed to fetch LinodeObjectStorageKey", "name", req.String())
-		}
-
-		return ctrl.Result{}, err
-	}
 
 	if _, ok := objectStorageKey.Labels[clusterv1.ClusterNameLabel]; ok {
 		cluster, err := kutil.GetClusterFromMetadata(ctx, r.TracedClient(), objectStorageKey.ObjectMeta)
@@ -334,7 +324,7 @@ func (r *LinodeObjectStorageKeyReconciler) SetupWithManager(mgr ctrl.Manager, op
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(linodeObjectStorageKeyMapper),
 			builder.WithPredicates(predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), mgr.GetLogger())),
-		).Complete(wrappedruntimereconciler.NewRuntimeReconcilerWithTracing(r, wrappedruntimereconciler.DefaultDecorator()))
+		).Complete(reconciler.AsReconcilerWithTracing(r.TracedClient(), r))
 	if err != nil {
 		return fmt.Errorf("failed to build controller: %w", err)
 	}

--- a/internal/controller/linodeobjectstoragekey_controller_test.go
+++ b/internal/controller/linodeobjectstoragekey_controller_test.go
@@ -39,6 +39,7 @@ import (
 	infrav1 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	"github.com/linode/cluster-api-provider-linode/mock"
+	utilreconciler "github.com/linode/cluster-api-provider-linode/util/reconciler"
 
 	. "github.com/linode/cluster-api-provider-linode/mock/mocktest"
 	. "github.com/onsi/ginkgo/v2"
@@ -460,7 +461,7 @@ var _ = Describe("errors", Label("key", "key-errors"), func() {
 				}),
 				Result("no error", func(ctx context.Context, mck Mock) {
 					reconciler.Client = mck.K8sClient
-					_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					_, err := utilreconciler.AsReconcilerWithTracing(mck.K8sClient, &reconciler).Reconcile(ctx, reconcile.Request{
 						NamespacedName: client.ObjectKeyFromObject(keyScope.Key),
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -473,18 +474,17 @@ var _ = Describe("errors", Label("key", "key-errors"), func() {
 				Result("error", func(ctx context.Context, mck Mock) {
 					reconciler.Client = mck.K8sClient
 					reconciler.Logger = keyScope.Logger
-					_, err := reconciler.Reconcile(ctx, reconcile.Request{
+					_, err := utilreconciler.AsReconcilerWithTracing(mck.K8sClient, &reconciler).Reconcile(ctx, reconcile.Request{
 						NamespacedName: client.ObjectKeyFromObject(keyScope.Key),
 					})
 					Expect(err.Error()).To(ContainSubstring("non-404 error"))
-					Expect(mck.Logs()).To(ContainSubstring("Failed to fetch LinodeObjectStorageKey"))
 				}),
 			),
 		),
 		Result("scope params is missing args", func(ctx context.Context, mck Mock) {
 			reconciler.Client = mck.K8sClient
 			reconciler.Logger = keyScope.Logger
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			_, err := utilreconciler.AsReconcilerWithTracing(mck.K8sClient, &reconciler).Reconcile(ctx, reconcile.Request{
 				NamespacedName: client.ObjectKeyFromObject(keyScope.Key),
 			})
 			Expect(err.Error()).To(ContainSubstring("failed to create object storage key scope"))

--- a/internal/controller/linodeplacementgroup_controller.go
+++ b/internal/controller/linodeplacementgroup_controller.go
@@ -119,7 +119,7 @@ func (r *LinodePlacementGroupReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, fmt.Errorf("failed to create Placement Group scope: %w", err)
 	}
 
-	// Only check pause if not deleting or if cluster still exists
+	// Only check pause if not deleting or if cluster still exists.
 	if linodeplacementgroup.DeletionTimestamp.IsZero() || cluster != nil {
 		isPaused, _, err := paused.EnsurePausedCondition(ctx, pgScope.Client, pgScope.Cluster, pgScope.LinodePlacementGroup)
 		if err != nil {
@@ -376,8 +376,11 @@ func (r *LinodePlacementGroupReconciler) SetupWithManager(mgr ctrl.Manager, opti
 		For(&infrav1alpha2.LinodePlacementGroup{}).
 		WithOptions(options).
 		WithEventFilter(predicate.And(
-			predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
-			predicate.GenerationChangedPredicate{},
+			predicates.ResourceHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.AnnotationChangedPredicate{},
+			),
 			predicate.Funcs{UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject, okOld := e.ObjectOld.(*infrav1alpha2.LinodePlacementGroup)
 				newObject, okNew := e.ObjectNew.(*infrav1alpha2.LinodePlacementGroup)

--- a/internal/controller/linodeplacementgroup_controller.go
+++ b/internal/controller/linodeplacementgroup_controller.go
@@ -46,7 +46,6 @@ import (
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	wrappedruntimeclient "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimeclient"
-	wrappedruntimereconciler "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimereconciler"
 	"github.com/linode/cluster-api-provider-linode/util"
 	"github.com/linode/cluster-api-provider-linode/util/reconciler"
 )
@@ -70,20 +69,12 @@ type LinodePlacementGroupReconciler struct {
 // move the current state of the Placement Group closer to the desired state.
 //
 
-func (r *LinodePlacementGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LinodePlacementGroupReconciler) Reconcile(ctx context.Context, linodeplacementgroup *infrav1alpha2.LinodePlacementGroup) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
 
-	log := ctrl.LoggerFrom(ctx).WithName("LinodePlacementGroupReconciler").WithValues("name", req.String())
+	log := ctrl.LoggerFrom(ctx).WithName("LinodePlacementGroupReconciler").WithValues("name", linodeplacementgroup.Name, "namespace", linodeplacementgroup.Namespace)
 
-	linodeplacementgroup := &infrav1alpha2.LinodePlacementGroup{}
-	if err := r.TracedClient().Get(ctx, req.NamespacedName, linodeplacementgroup); err != nil {
-		if err = client.IgnoreNotFound(err); err != nil {
-			log.Error(err, "Failed to fetch LinodePlacementGroup")
-		}
-
-		return ctrl.Result{}, err
-	}
 	var cluster *clusterv1.Cluster
 	var err error
 	if _, ok := linodeplacementgroup.Labels[clusterv1.ClusterNameLabel]; ok {
@@ -395,7 +386,7 @@ func (r *LinodePlacementGroupReconciler) SetupWithManager(mgr ctrl.Manager, opti
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(linodePlacementGroupMapper),
 			builder.WithPredicates(predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), mgr.GetLogger())),
-		).Complete(wrappedruntimereconciler.NewRuntimeReconcilerWithTracing(r, wrappedruntimereconciler.DefaultDecorator()))
+		).Complete(reconciler.AsReconcilerWithTracing(r.TracedClient(), r))
 	if err != nil {
 		return fmt.Errorf("failed to build controller: %w", err)
 	}

--- a/internal/controller/linodeplacementgroup_controller_test.go
+++ b/internal/controller/linodeplacementgroup_controller_test.go
@@ -25,8 +25,12 @@ import (
 	"go.uber.org/mock/gomock"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -225,4 +229,89 @@ var _ = Describe("lifecycle", Ordered, Label("placementgroup", "lifecycle"), fun
 			),
 		),
 	)
+})
+
+var _ = Describe("pause handling", Label("placementgroup", "pause"), func() {
+	It("sets paused condition for LinodePlacementGroup when owner Cluster is paused", func(ctx SpecContext) {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-pg-cluster",
+				Namespace: defaultNamespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		placementGroup := &infrav1alpha2.LinodePlacementGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-pg-object",
+				Namespace: defaultNamespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: cluster.Name,
+				},
+			},
+			Spec: infrav1alpha2.LinodePlacementGroupSpec{
+				Region:               "us-ord",
+				PlacementGroupType:   "anti_affinity:local",
+				PlacementGroupPolicy: "strict",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		Expect(k8sClient.Create(ctx, placementGroup)).To(Succeed())
+
+		reconciler := &LinodePlacementGroupReconciler{
+			Client:             k8sClient,
+			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(placementGroup)})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(placementGroup), placementGroup)).To(Succeed())
+		pausedCondition := placementGroup.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(controllerutil.ContainsFinalizer(placementGroup, infrav1alpha2.PlacementGroupFinalizer)).To(BeFalse())
+	})
+
+	It("sets and clears paused condition from the upstream pause annotation path", func(ctx SpecContext) {
+		placementGroup := &infrav1alpha2.LinodePlacementGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-pg-annotation",
+				Namespace: defaultNamespace,
+				Annotations: map[string]string{
+					clusterv1.PausedAnnotation: "",
+				},
+			},
+			Spec: infrav1alpha2.LinodePlacementGroupSpec{
+				Region:               "us-ord",
+				PlacementGroupType:   "anti_affinity:local",
+				PlacementGroupPolicy: "strict",
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, placementGroup)).To(Succeed())
+
+		isPaused, _, err := paused.EnsurePausedCondition(ctx, k8sClient, nil, placementGroup)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeTrue())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(placementGroup), placementGroup)).To(Succeed())
+		pausedCondition := placementGroup.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+
+		delete(placementGroup.Annotations, clusterv1.PausedAnnotation)
+		Expect(k8sClient.Update(ctx, placementGroup)).To(Succeed())
+
+		isPaused, _, err = paused.EnsurePausedCondition(ctx, k8sClient, nil, placementGroup)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeFalse())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(placementGroup), placementGroup)).To(Succeed())
+		pausedCondition = placementGroup.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
+	})
 })

--- a/internal/controller/linodeplacementgroup_controller_test.go
+++ b/internal/controller/linodeplacementgroup_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -265,7 +264,7 @@ var _ = Describe("pause handling", Label("placementgroup", "pause"), func() {
 			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
 		}
 
-		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(placementGroup)})
+		_, err := reconciler.Reconcile(ctx, placementGroup)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(placementGroup), placementGroup)).To(Succeed())

--- a/internal/controller/linodevpc_controller.go
+++ b/internal/controller/linodevpc_controller.go
@@ -124,7 +124,7 @@ func (r *LinodeVPCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("failed to create VPC scope: %w", err)
 	}
 
-	// Only check pause if not deleting or if cluster still exists
+	// Only check pause if not deleting or if cluster still exists.
 	if linodeVPC.DeletionTimestamp.IsZero() || cluster != nil {
 		isPaused, _, err := paused.EnsurePausedCondition(ctx, vpcScope.Client, vpcScope.Cluster, vpcScope.LinodeVPC)
 		if err != nil {
@@ -496,8 +496,11 @@ func (r *LinodeVPCReconciler) SetupWithManager(mgr ctrl.Manager, options crcontr
 		For(&infrav1alpha2.LinodeVPC{}).
 		WithOptions(options).
 		WithEventFilter(predicate.And(
-			predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
-			predicate.GenerationChangedPredicate{},
+			predicates.ResourceHasFilterLabel(mgr.GetScheme(), mgr.GetLogger(), r.WatchFilterValue),
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.AnnotationChangedPredicate{},
+			),
 			predicate.Funcs{UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject, okOld := e.ObjectOld.(*infrav1alpha2.LinodeVPC)
 				newObject, okNew := e.ObjectNew.(*infrav1alpha2.LinodeVPC)

--- a/internal/controller/linodevpc_controller.go
+++ b/internal/controller/linodevpc_controller.go
@@ -47,7 +47,6 @@ import (
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	wrappedruntimeclient "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimeclient"
-	wrappedruntimereconciler "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimereconciler"
 	"github.com/linode/cluster-api-provider-linode/util"
 	"github.com/linode/cluster-api-provider-linode/util/reconciler"
 )
@@ -78,18 +77,11 @@ type LinodeVPCReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.0/pkg/reconcile
 //
 
-func (r *LinodeVPCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *LinodeVPCReconciler) Reconcile(ctx context.Context, linodeVPC *infrav1alpha2.LinodeVPC) (ctrl.Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, reconciler.DefaultedLoopTimeout(r.ReconcileTimeout))
 	defer cancel()
 
-	log := ctrl.LoggerFrom(ctx).WithName("LinodeVPCReconciler").WithValues("name", req.String())
-	linodeVPC := &infrav1alpha2.LinodeVPC{}
-	if err := r.TracedClient().Get(ctx, req.NamespacedName, linodeVPC); err != nil {
-		if err = client.IgnoreNotFound(err); err != nil {
-			log.Error(err, "Failed to fetch LinodeVPC")
-		}
-		return ctrl.Result{}, err
-	}
+	log := ctrl.LoggerFrom(ctx).WithName("LinodeVPCReconciler").WithValues("name", linodeVPC.Name, "namespace", linodeVPC.Namespace)
 
 	var cluster *clusterv1.Cluster
 	var err error
@@ -515,7 +507,7 @@ func (r *LinodeVPCReconciler) SetupWithManager(mgr ctrl.Manager, options crcontr
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(linodeVPCMapper),
 			builder.WithPredicates(predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), mgr.GetLogger())),
-		).Complete(wrappedruntimereconciler.NewRuntimeReconcilerWithTracing(r, wrappedruntimereconciler.DefaultDecorator()))
+		).Complete(reconciler.AsReconcilerWithTracing(r.TracedClient(), r))
 	if err != nil {
 		return fmt.Errorf("failed to build controller: %w", err)
 	}

--- a/internal/controller/linodevpc_controller_test.go
+++ b/internal/controller/linodevpc_controller_test.go
@@ -29,7 +29,10 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -294,6 +297,93 @@ var _ = Describe("lifecycle", Ordered, Label("vpc", "lifecycle"), func() {
 			),
 		),
 	)
+})
+
+var _ = Describe("pause handling", Label("vpc", "pause"), func() {
+	It("sets paused condition for LinodeVPC when owner Cluster is paused", func(ctx SpecContext) {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-vpc-cluster",
+				Namespace: defaultNamespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		vpc := &infrav1alpha2.LinodeVPC{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-vpc-object",
+				Namespace: defaultNamespace,
+				Labels: map[string]string{
+					clusterv1.ClusterNameLabel: cluster.Name,
+				},
+			},
+			Spec: infrav1alpha2.LinodeVPCSpec{
+				Region: "us-ord",
+				Subnets: []infrav1alpha2.VPCSubnetCreateOptions{
+					{Label: "subnet1", IPv4: "10.2.0.0/24"},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+
+		reconciler := &LinodeVPCReconciler{
+			Client:             k8sClient,
+			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vpc)})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(vpc), vpc)).To(Succeed())
+		pausedCondition := vpc.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(controllerutil.ContainsFinalizer(vpc, infrav1alpha2.VPCFinalizer)).To(BeFalse())
+	})
+
+	It("sets and clears paused condition from the upstream pause annotation path", func(ctx SpecContext) {
+		vpc := &infrav1alpha2.LinodeVPC{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pause-vpc-annotation",
+				Namespace: defaultNamespace,
+				Annotations: map[string]string{
+					clusterv1.PausedAnnotation: "",
+				},
+			},
+			Spec: infrav1alpha2.LinodeVPCSpec{
+				Region: "us-ord",
+				Subnets: []infrav1alpha2.VPCSubnetCreateOptions{
+					{Label: "subnet1", IPv4: "10.2.0.0/24"},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, vpc)).To(Succeed())
+
+		isPaused, _, err := paused.EnsurePausedCondition(ctx, k8sClient, nil, vpc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeTrue())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(vpc), vpc)).To(Succeed())
+		pausedCondition := vpc.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionTrue))
+
+		delete(vpc.Annotations, clusterv1.PausedAnnotation)
+		Expect(k8sClient.Update(ctx, vpc)).To(Succeed())
+
+		isPaused, _, err = paused.EnsurePausedCondition(ctx, k8sClient, nil, vpc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isPaused).To(BeFalse())
+
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(vpc), vpc)).To(Succeed())
+		pausedCondition = vpc.GetCondition(clusterv1.PausedV1Beta2Condition)
+		Expect(pausedCondition).NotTo(BeNil())
+		Expect(pausedCondition.Status).To(Equal(metav1.ConditionFalse))
+	})
 })
 
 var _ = Describe("retained VPC", Label("vpc", "lifecycle"), func() {

--- a/internal/controller/linodevpc_controller_test.go
+++ b/internal/controller/linodevpc_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/paused"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
@@ -334,7 +333,7 @@ var _ = Describe("pause handling", Label("vpc", "pause"), func() {
 			LinodeClientConfig: scope.ClientConfig{Token: "test-token"},
 		}
 
-		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vpc)})
+		_, err := reconciler.Reconcile(ctx, vpc)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(vpc), vpc)).To(Succeed())

--- a/util/reconciler/typedreconciler.go
+++ b/util/reconciler/typedreconciler.go
@@ -1,0 +1,39 @@
+package reconciler
+
+import (
+	"context"
+
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	o11yreconciler "github.com/linode/cluster-api-provider-linode/observability/wrappers/runtimereconciler"
+)
+
+func AsReconcilerWithTracing[object client.Object](k8sClient client.Client, rec reconcile.ObjectReconciler[object]) reconcile.Reconciler {
+	capiReconciler := &capiReconcilerAdapter[object]{
+		objReconciler: rec,
+		k8sClient:     k8sClient,
+	}
+
+	return o11yreconciler.NewRuntimeReconcilerWithTracing(
+		reconcile.AsReconciler(
+			k8sClient, capiReconciler),
+		o11yreconciler.DefaultDecorator())
+}
+
+type capiReconcilerAdapter[object client.Object] struct {
+	objReconciler reconcile.ObjectReconciler[object]
+	k8sClient     client.Client
+}
+
+func (a *capiReconcilerAdapter[object]) Reconcile(ctx context.Context, obj object) (reconcile.Result, error) {
+	// Skip normal reconciliation when clusterctl marks the object for deletion during a move.
+	// Reconciling here could recreate or mutate infrastructure while ownership is being handed off.
+	if annotations := obj.GetAnnotations(); annotations != nil {
+		if _, exists := annotations[clusterctlv1.DeleteForMoveAnnotation]; exists {
+			return reconcile.Result{}, nil
+		}
+	}
+	return a.objReconciler.Reconcile(ctx, obj)
+}


### PR DESCRIPTION
* fix: restore pause handling during pivot

* fix: bump Go toolchain to 1.25.9

* Add e2e test to assert cluster.spec.pause will set pause conditions on linode resource. Unpause as well when Cluster is unpaused.

* fix: watch pause annotation updates

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


