### PR TITLE
[improvement] use VPC_NETWORK_CIDR if set in templates instead of assuming 10.0.0.0/8, update admission webhook check for VPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 #####################################################################
 # top-level Makefile for cluster-api-provider-linode
 #####################################################################
+REGISTRY            ?= docker.io/linode
+IMAGE_NAME          ?= cluster-api-provider-linode
 VERSION             ?= $(shell git describe --always --tag --dirty=-dev)
 IMAGE_TAGS          ?= $(VERSION)
 WITH_GOFLAGS        ?= "GOFLAGS=\"-ldflags=-X github.com/linode/cluster-api-provider-linode/version.version=$(VERSION)\""

--- a/internal/webhook/v1alpha2/linodevpc_webhook.go
+++ b/internal/webhook/v1alpha2/linodevpc_webhook.go
@@ -46,11 +46,6 @@ var (
 	//
 	// [Valid IPv4 Ranges for a Subnet]: https://www.linode.com/docs/products/networking/vpc/guides/subnets/#valid-ipv4-ranges
 	LinodeVPCSubnetReserved = mustParseIPSet("192.168.128.0/17")
-
-	// IPv4 private address space as defined in [RFC 1918].
-	//
-	// [RFC 1918]: https://datatracker.ietf.org/doc/html/rfc1918
-	privateIPv4 = mustParseIPSet("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 )
 
 // mustParseIPSet parses the given IP CIDRs as a [go4.org/netipx.IPSet]. It is intended for use with hard-coded strings.
@@ -259,9 +254,6 @@ func validateSubnetIPv4CIDR(cidr string, path *field.Path) (*netipx.IPSet, *fiel
 	}
 	if netipx.ComparePrefix(prefix, prefix.Masked()) != 0 {
 		return nil, field.Invalid(path, cidr, errs[0].Error()) // #nosec G602: false positive
-	}
-	if !privateIPv4.ContainsPrefix(prefix) {
-		return nil, field.Invalid(path, cidr, errs[1].Error()) // #nosec G602: false positive
 	}
 	size, _ := netipx.PrefixIPNet(prefix).Mask.Size()
 	if size < minPrefix || size > maxPrefix {

--- a/templates/addons/cilium-network-policies/ciliumNetworkPolicies.yaml
+++ b/templates/addons/cilium-network-policies/ciliumNetworkPolicies.yaml
@@ -15,7 +15,7 @@ data:
         - fromEntities:
             - cluster
         - fromCIDR:
-            - 10.0.0.0/8
+            - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             - 192.168.128.0/17
     ---
     apiVersion: "cilium.io/v2"
@@ -29,7 +29,7 @@ data:
         - fromEntities:
             - cluster
         - fromCIDR:
-            - 10.0.0.0/8
+            - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
         - fromEntities:
             - all
           toPorts:

--- a/templates/flavors/k3s/default/kustomization.yaml
+++ b/templates/flavors/k3s/default/kustomization.yaml
@@ -47,7 +47,7 @@ patches:
         value: |
           routeController:
             vpcName: ${VPC_NAME:=${CLUSTER_NAME}}
-            clusterCIDR: 10.0.0.0/8
+            clusterCIDR: ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             configureCloudRoutes: true
           secretRef:
             name: "linode-token-region"

--- a/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/k3s/dns-loadbalancing/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
             protocol: "TCP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all tcp traffic within the vpc
           - action: ACCEPT
             label: intra-cluster-udp
@@ -47,14 +47,14 @@ patches:
             protocol: "UDP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all udp traffic within the vpc
           - action: ACCEPT
             label: intra-cluster-icmp
             protocol: "ICMP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all icmp traffic within the vpc
           - action: ACCEPT
             addresses:

--- a/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
@@ -41,7 +41,7 @@ patches:
             protocol: "TCP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all tcp traffic within the vpc
           - action: ACCEPT
             label: intra-cluster-udp
@@ -49,14 +49,14 @@ patches:
             protocol: "UDP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all udp traffic within the vpc
           - action: ACCEPT
             label: intra-cluster-icmp
             protocol: "ICMP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all icmp traffic within the vpc
           - action: ACCEPT
             addresses:

--- a/templates/flavors/kubeadm/konnectivity/kustomization.yaml
+++ b/templates/flavors/kubeadm/konnectivity/kustomization.yaml
@@ -82,7 +82,7 @@ patches:
               - fromEntities:
                   - cluster
               - fromCIDR:
-                  - 10.0.0.0/8
+                  - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
                   - 192.168.128.0/17
           ---
           apiVersion: "cilium.io/v2"
@@ -96,7 +96,7 @@ patches:
               - fromEntities:
                   - cluster
               - fromCIDR:
-                  - 10.0.0.0/8
+                  - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
               - fromEntities:
                   - all
                 toPorts:

--- a/templates/flavors/kubeadm/konnectivity/nb-firewall.yaml
+++ b/templates/flavors/kubeadm/konnectivity/nb-firewall.yaml
@@ -13,7 +13,7 @@ spec:
     - action: ACCEPT
       addresses:
         ipv4:
-          - 10.0.0.0/8
+          - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       description: accept all tcp traffic within the vpc
       label: intra-cluster-tcp
       ports: 1-65535
@@ -21,7 +21,7 @@ spec:
     - action: ACCEPT
       addresses:
         ipv4:
-          - 10.0.0.0/8
+          - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       description: accept all udp traffic within the vpc
       label: intra-cluster-udp
       ports: 1-65535
@@ -29,7 +29,7 @@ spec:
     - action: ACCEPT
       addresses:
         ipv4:
-          - 10.0.0.0/8
+          - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       description: accept all icmp traffic within the vpc
       label: intra-cluster-icmp
       protocol: ICMP

--- a/templates/flavors/kubeadm/vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/vpcless/kustomization.yaml
@@ -73,7 +73,7 @@ patches:
               - fromEntities:
                   - cluster
               - fromCIDR:
-                  - 10.0.0.0/8
+                  - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
                   - 192.168.128.0/17
           ---
           apiVersion: "cilium.io/v2"
@@ -87,7 +87,7 @@ patches:
               - fromEntities:
                   - cluster
               - fromCIDR:
-                  - 10.0.0.0/8
+                  - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
                   - 192.168.128.0/17
               - fromEntities:
                   - all

--- a/templates/flavors/rke2/default/kustomization.yaml
+++ b/templates/flavors/rke2/default/kustomization.yaml
@@ -49,7 +49,7 @@ patches:
         value: |
           routeController:
             vpcName: ${VPC_NAME:=${CLUSTER_NAME}}
-            clusterCIDR: 10.0.0.0/8
+            clusterCIDR: ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             configureCloudRoutes: true
           secretRef:
             name: "linode-token-region"

--- a/templates/flavors/rke2/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/rke2/dns-loadbalancing/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
             protocol: "TCP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all tcp traffic within the vpc
           - action: ACCEPT
             label: intra-cluster-udp
@@ -47,14 +47,14 @@ patches:
             protocol: "UDP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all udp traffic within the vpc
           - action: ACCEPT
             label: intra-cluster-icmp
             protocol: "ICMP"
             addresses:
               ipv4:
-                - "10.0.0.0/8"
+                - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
             description: accept all icmp traffic within the vpc
           - action: ACCEPT
             addresses:

--- a/templates/infra/linodeFirewall.yaml
+++ b/templates/infra/linodeFirewall.yaml
@@ -17,7 +17,7 @@ spec:
       protocol: "TCP"
       addresses:
         ipv4:
-          - "10.0.0.0/8"
+          - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       description: accept all tcp traffic within the vpc
     - action: ACCEPT
       label: intra-cluster-udp
@@ -25,14 +25,14 @@ spec:
       protocol: "UDP"
       addresses:
         ipv4:
-          - "10.0.0.0/8"
+          - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       description: accept all udp traffic within the vpc
     - action: ACCEPT
       label: intra-cluster-icmp
       protocol: "ICMP"
       addresses:
         ipv4:
-          - "10.0.0.0/8"
+          - ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       description: accept all icmp traffic within the vpc
     - action: ACCEPT
       addresses:

--- a/templates/infra/linodeVPC.yaml
+++ b/templates/infra/linodeVPC.yaml
@@ -10,5 +10,5 @@ spec:
     name: ${CLUSTER_NAME}-credentials
   region: ${LINODE_REGION}
   subnets:
-    - ipv4: 10.0.0.0/8
+    - ipv4: ${VPC_NETWORK_CIDR:=10.0.0.0/8}
       label: default


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This removes the "private IPs only" validating admission webhook check on VPC creation and fixes the templates to use the `VPC_NETWORK_CIDR` if set instead of assuming `10.0.0.0/8` (though that still is the default).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


