### PR TITLE
[CI][deps] bump k8s and CAPI-related deps for tests, new vpcless dual-stack kubeadm flavor

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -32,7 +32,7 @@ if os.getenv("USE_CAPI_OPERATOR", "false") == "true":
         flags=[
           "--create-namespace",
           "--wait",
-          "--version=0.14.0",
+          "--version=0.27.0",
         ],
         resource_deps=["capi-operator-repo", "cert-manager"],
         labels=["CAPI"],
@@ -108,7 +108,7 @@ else:
     local_resource(
         'capi-controller-manager',
         cmd="EXP_CLUSTER_RESOURCE_SET=true CLUSTER_TOPOLOGY=true EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true clusterctl init --addon helm --core cluster-api:${capi_version} --bootstrap kubeadm:${capi_version},k3s:${k3s_version},rke2:${rke2_version} --control-plane kubeadm:${capi_version},k3s:${k3s_version},rke2:${rke2_version} --config ./hack/clusterctl.yaml",
-        env={'capi_version': os.getenv("CAPI_VERSION", "v1.11.1"), 'k3s_version': os.getenv("K3S_VERSION", "v0.3.0"), 'rke2_version': os.getenv("RKE2_VERSION", "v0.20.1")},
+        env={'capi_version': os.getenv("CAPI_VERSION", "v1.13.3"), 'k3s_version': os.getenv("K3S_VERSION", "v0.4.0"), 'rke2_version': os.getenv("RKE2_VERSION", "v0.25.0")},
     )
 
 capl_resources = [

--- a/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
@@ -34,7 +34,7 @@ spec:
               - name: CLUSTERCTL_CONFIG
                 value: (env('CLUSTERCTL_CONFIG'))
               - name: KUBERNETES_VERSION
-                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
             content: |
               set -e
               clusterctl generate cluster $CLUSTER -n $NAMESPACE \

--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -36,7 +36,7 @@ spec:
               - name: CLUSTERCTL_CONFIG
                 value: (env('CLUSTERCTL_CONFIG'))
               - name: KUBERNETES_VERSION
-                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
             content: |
               set -e
               clusterctl generate cluster $CLUSTER -n $NAMESPACE \

--- a/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-flatcar-vpcless-capl-cluster/chainsaw-test.yaml
@@ -92,7 +92,7 @@ spec:
               - name: CLUSTERCTL_CONFIG
                 value: (env('CLUSTERCTL_CONFIG'))
               - name: KUBERNETES_VERSION
-                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
             content: |
               set -e
               export FLATCAR_IMAGE_NAME=$(cat image-id)

--- a/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-full-capl-cluster/chainsaw-test.yaml
@@ -45,7 +45,7 @@ spec:
               - name: ETCD_BACKUP_SCHEDULE
                 value: '* * * * *'
               - name: KUBERNETES_VERSION
-                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
             content: |
               set -e
               if [ -z "$SSE_KEY" ]; then

--- a/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
@@ -33,7 +33,7 @@ spec:
               - name: CLUSTERCTL_CONFIG
                 value: (env('CLUSTERCTL_CONFIG'))
               - name: KUBERNETES_VERSION
-                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
             content: |
               set -e
               clusterctl generate cluster $CLUSTER -n $NAMESPACE \

--- a/e2e/cluster-pause/chainsaw-test.yaml
+++ b/e2e/cluster-pause/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
               - name: CLUSTERCTL_CONFIG
                 value: (env('CLUSTERCTL_CONFIG'))
               - name: KUBERNETES_VERSION
-                value: (env('KUBERNETES_VERSION') || 'v1.33.4')
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
             content: |
               set -e
               clusterctl generate cluster "$CLUSTER" -n "$NAMESPACE" \

--- a/templates/flavors/kubeadm/dual-stack-vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/dual-stack-vpcless/kustomization.yaml
@@ -1,0 +1,97 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../vpcless
+
+patches:
+  - target:
+      group: infrastructure.cluster.x-k8s.io
+      version: v1alpha2
+      kind: LinodeCluster
+    patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+      kind: LinodeCluster
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        nodeBalancerFirewallRef: null
+  - target:
+      group: cluster.x-k8s.io
+      version: v1beta2
+      kind: Cluster
+    patch: |-
+      apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      metadata:
+        name: ${CLUSTER_NAME}
+      spec:
+        clusterNetwork:
+          pods:
+            cidrBlocks:
+              - 10.192.0.0/10
+              - fd02::/80
+          services:
+            cidrBlocks:
+              - 10.96.0.0/12
+              - fd03::/108
+  - target:
+      group: controlplane.cluster.x-k8s.io
+      version: v1beta2
+      kind: KubeadmControlPlane
+    patch: |-
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+      kind: KubeadmControlPlane
+      metadata:
+        name: ${CLUSTER_NAME}-cp
+      spec:
+        kubeadmConfigSpec:
+          clusterConfiguration:
+            controllerManager:
+              extraArgs:
+                - name: "node-cidr-mask-size-ipv6"
+                  value: "96"
+  - target:
+      kind: HelmChartProxy
+      name: .*-cilium
+    patch: |-
+      - op: replace
+        path: /spec/valuesTemplate
+        value: |
+          bgpControlPlane:
+            enabled: true
+          routingMode: native
+          devices:
+            - eth0
+            - eth1
+          nodePort:
+            addresses:
+              - 0.0.0.0/0
+              - ::/0
+            directRoutingDevice: eth0
+          kubeProxyReplacement: true
+          ipv4NativeRoutingCIDR: 0.0.0.0/0
+          ipv6NativeRoutingCIDR: ::/0
+          tunnelProtocol: ""
+          enableIPv4Masquerade: true
+          enableIPv6Masquerade: false
+          policyAuditMode: ${FW_AUDIT_ONLY:=true}
+          hostFirewall:
+            enabled: true
+          extraConfig:
+            allow-localhost: policy
+          k8sServiceHost: {{ .InfraCluster.spec.controlPlaneEndpoint.host }}
+          k8sServicePort: {{ .InfraCluster.spec.controlPlaneEndpoint.port }}
+          ipam:
+            mode: kubernetes
+          ipv4:
+            enabled: true
+          ipv6:
+            enabled: true
+          k8s:
+            requireIPv4PodCIDR: true
+            requireIPv6PodCIDR: true
+          hubble:
+            relay:
+              enabled: true
+            ui:
+              enabled: true


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
- We want to make sure we're testing on the latest stable releases. 
- This also adds a new flavor we specifically want to use for the CCM in https://github.com/linode/linode-cloud-controller-manager/pull/590 where I'm trying to bump to the latest CAPL but dual-stack for versions past CAPL v0.9.5 include a VPC now which breaks the ipv6 tests we have for the CCM. (The CCM explicitly says in the configuration docs: `VPC IPv6 backend addresses are not supported.`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


