### PR TITLE
[test][fix] new dual-stack vpcless flavor e2e test, fix template NativeRoutingCIDR cidrs to actually match podCidrs

### DIFF
--- a/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/k3s-capl-cluster/chainsaw-test.yaml
@@ -6,9 +6,7 @@ metadata:
   name: k3s-capl-cluster
   # Labels to allow the test to be triggered based on selector flag
   labels:
-#    all:
     k3s:
-#    flavors:
 spec:
   bindings:
     # A short identifier for the E2E test run

--- a/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-capl-cluster/chainsaw-test.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     all:
     kubeadm:
-    flavors:
 spec:
   bindings:
     # A short identifier for the E2E test run

--- a/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-capi-resources.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-capi-resources.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+  namespace: capl-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: caaph-controller-manager
+  namespace: caaph-system
+status:
+  availableReplicas: 1

--- a/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-child-cluster-daemonsets.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-child-cluster-daemonsets.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ccm-linode
+  namespace: kube-system
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+  numberAvailable: 1
+  numberMisscheduled: 0
+  numberReady: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cilium
+  namespace: kube-system
+status:
+  currentNumberScheduled: 2
+  desiredNumberScheduled: 2
+  numberAvailable: 2
+  numberMisscheduled: 0
+  numberReady: 2
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-linode-node
+  namespace: kube-system
+status:
+  currentNumberScheduled: 2
+  desiredNumberScheduled: 2
+  numberAvailable: 2
+  numberMisscheduled: 0
+  numberReady: 2

--- a/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-child-cluster-deployments.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-child-cluster-deployments.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+status:
+  availableReplicas: 2
+  readyReplicas: 2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  namespace: kube-system
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+status:
+  availableReplicas: 2
+  readyReplicas: 2

--- a/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-child-cluster-resources.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/assert-child-cluster-resources.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  region: (env('LINODE_REGION'))
+  type: g6-standard-2
+status:
+  ready: true
+  instanceState: running
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  clusterName: ($cluster)
+status:
+  initialization:
+    bootstrapDataSecretCreated: true
+    infrastructureProvisioned: true
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  clusterName: ($cluster)
+  replicas: 1
+status:
+  readyReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+status:
+  readyReplicas: 1
+  availableReplicas: 1
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmReleaseProxy
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+  - type: ClusterAvailable
+    status: "True"
+  - type: HelmReleaseReady
+    status: "True"
+  status: deployed

--- a/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/chainsaw-test.yaml
@@ -1,0 +1,189 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: dualstack-capl-cluster
+  labels:
+    all:
+    kubeadm-dualstack:
+    flavors:
+spec:
+  catch:
+    - script:
+        env:
+          - name: TARGET_API
+            value: api.linode.com
+          - name: TARGET_API_VERSION
+            value: v4
+          - name: URI
+            value: images
+          - name: LINODE_REGION
+            value: (env('LINODE_REGION'))
+        content: |
+          set -e
+          # Get the latest version on Alpha channel.
+          # NOTE: This can be changed to Beta or Stable when Akamai support will come on these channels.
+          IMAGE_ID=$(cat image-id)
+          curl --request DELETE \
+            --url "https://${TARGET_API}/${TARGET_API_VERSION}/${URI}/${IMAGE_ID}" \
+            --header "Authorization: Bearer ${LINODE_TOKEN}" \
+            --header "accept: application/json"
+  bindings:
+    # A short identifier for the E2E test run
+    - name: run
+      value: (join('-', ['e2e', 'dualstack', random('[0-9a-z]{5}')]))
+    - name: cluster
+      # Format the cluster name
+      value: (trim((truncate(($run), `29`)), '-'))
+  template: true
+  steps:
+    - name: Check if CAPI provider resources exist
+      try:
+        - assert:
+            file: assert-capi-resources.yaml
+    - name: Generate cluster using clusterctl
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: CLUSTERCTL_CONFIG
+                value: (env('CLUSTERCTL_CONFIG'))
+              - name: KUBERNETES_VERSION
+                value: (env('KUBERNETES_VERSION') || 'v1.36.2')
+            content: |
+              set -e
+              export FLATCAR_IMAGE_NAME=$(cat image-id)
+              clusterctl generate cluster $CLUSTER -n $NAMESPACE \
+              --kubernetes-version ${KUBERNETES_VERSION} \
+              --infrastructure local-linode:v0.0.0 \
+              --control-plane-machine-count 1 --worker-machine-count 1 \
+              --flavor kubeadm-dual-stack-vpcless \
+              --config ${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml} > dualstack-cluster.yaml
+            check:
+              ($error == null): true
+    - name: Apply generated cluster yaml
+      try:
+        - apply:
+            file: dualstack-cluster.yaml
+        - assert:
+            file: assert-child-cluster-resources.yaml
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachine
+        - describe:
+            apiVersion: cluster.x-k8s.io/v1beta2
+            kind: Machine
+        - describe:
+            apiVersion: cluster.x-k8s.io/v1beta2
+            kind: MachineDeployment
+        - describe:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: KubeadmControlPlane
+        - describe:
+            apiVersion: addons.cluster.x-k8s.io/v1alpha1
+            kind: HelmReleaseProxy
+    - name: Check if the linodes are created
+      try:
+        - script:
+            env:
+              - name: TARGET_API
+                value: api.linode.com
+              - name: TARGET_API_VERSION
+                value: v4beta
+              - name: URI
+                value: linode/instances
+              - name: FILTER
+                value: (to_string({"tags":($cluster)}))
+            content: |
+              set -e
+              curl -s \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "X-Filter: $FILTER" \
+                -H "Content-Type: application/json" \
+                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+            check:
+              ($error): ~
+              (json_parse($stdout)):
+                results: 2
+    - name: Get child cluster kubeconfig
+      try:
+        - script:
+            env:
+              - name: CLUSTER
+                value: ($cluster)
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: CLUSTERCTL_CONFIG
+                value: (env('CLUSTERCTL_CONFIG'))
+            content: |
+              set -e
+              clusterctl get kubeconfig $CLUSTER -n $NAMESPACE > dualstack-cluster-kubeconfig.yaml
+            check:
+              ($error == null): true
+    - clusters:
+        dualstack-cluster:
+          kubeconfig: ./dualstack-cluster-kubeconfig.yaml
+      name: Check child cluster resources
+      try:
+        - assert:
+            cluster: dualstack-cluster
+            file: assert-child-cluster-deployments.yaml
+        - assert:
+            cluster: dualstack-cluster
+            file: assert-child-cluster-daemonsets.yaml
+      catch:
+        - describe:
+            cluster: dualstack-cluster
+            apiVersion: apps/v1
+            kind: Deployment
+            namespace: kube-system
+        - describe:
+            cluster: dualstack-cluster
+            apiVersion: apps/v1
+            kind: DaemonSet
+            namespace: kube-system
+    - name: Delete child cluster
+      try:
+        - delete:
+            ref:
+              apiVersion: cluster.x-k8s.io/v1beta2
+              kind: Cluster
+              name: ($cluster)
+        - error:
+            file: check-child-cluster-deleted.yaml
+    - name: Check if the linodes are deleted
+      try:
+        - script:
+            env:
+              - name: TARGET_API
+                value: api.linode.com
+              - name: TARGET_API_VERSION
+                value: v4beta
+              - name: URI
+                value: linode/instances
+              - name: FILTER
+                value: (to_string({"tags":($cluster)}))
+            content: |
+              set -e
+              curl -s \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "X-Filter: $FILTER" \
+                -H "Content-Type: application/json" \
+                "https://$TARGET_API/$TARGET_API_VERSION/$URI"
+            check:
+              ($error): ~
+              (json_parse($stdout)):
+                results: 0
+    - name: Delete generated child cluster manifest yaml
+      try:
+        - script:
+            content: |
+              rm -f dualstack-cluster.yaml
+              rm -f dualstack-cluster-kubeconfig.yaml
+            check:
+              ($error == null): true

--- a/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/check-child-cluster-deleted.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dual-stack-vpcless/check-child-cluster-deleted.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)

--- a/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/rke2-capl-cluster/chainsaw-test.yaml
@@ -5,9 +5,7 @@ metadata:
   name: rke2-capl-cluster
   # Labels to allow the test to be triggered based on selector flag
   labels:
-#    all:
     rke2:
-#    flavors:
 spec:
   bindings:
     # A short identifier for the E2E test run

--- a/templates/flavors/kubeadm/dual-stack-vpcless/kustomization.yaml
+++ b/templates/flavors/kubeadm/dual-stack-vpcless/kustomization.yaml
@@ -69,8 +69,8 @@ patches:
               - ::/0
             directRoutingDevice: eth0
           kubeProxyReplacement: true
-          ipv4NativeRoutingCIDR: 0.0.0.0/0
-          ipv6NativeRoutingCIDR: ::/0
+          ipv4NativeRoutingCIDR: 10.192.0.0/10
+          ipv6NativeRoutingCIDR: fd02::/80
           tunnelProtocol: ""
           enableIPv4Masquerade: true
           enableIPv6Masquerade: false


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: Follow-up from #1094, adds a new e2e test based on the kubeadm-flatcar-vpcless-capl-cluster e2e test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: See https://github.com/linode/cluster-api-provider-linode/actions/runs/29368644408, our CI isn't running for this 

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests


