### PR TITLE
[improvement][fix] Check control plane component health of control plane machine to decide on readiness

### DIFF
--- a/cloud/services/domains.go
+++ b/cloud/services/domains.go
@@ -15,9 +15,9 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
 	"github.com/go-logr/logr"
 	"github.com/linode/linodego/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/core/v1beta2"
 	kutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/collections"
 
 	"github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/clients"
@@ -328,12 +328,15 @@ func removeElement(stringList []string, elemToRemove string) []string {
 }
 
 func isCapiMachineReady(capiMachine *v1beta2.Machine) bool {
-	for _, condition := range capiMachine.Status.Conditions {
-		if condition.Type == v1beta2.ReadyCondition {
-			return condition.Status == metav1.ConditionTrue
-		}
-	}
-	return false
+	// Don't assume we have MachineHealthCheck conditions to check.
+	// Instead, use the CAPI upstream filter to check the machine does not have unhealthy control plane components.
+	// (See https://github.com/kubernetes-sigs/cluster-api/blob/v1.13.4/util/collections/machine_filters.go#L171-L174)
+	// This saves us from having to check the several conditions ourselves.
+	//
+	// NOTE: We assume etcd is not externally managed / don't configure that on the ControlPlane resource (KCP, RKE2ControlPlane, KThreesControlPlane).
+	// We might want to configure that in the future via LinodeCluster.Spec and check that field here.
+	return len(collections.FromMachines(capiMachine).
+		Filter(collections.HasUnhealthyControlPlaneComponents(true))) == 0
 }
 
 func processLinodeMachine(ctx context.Context, cscope *scope.ClusterScope, machine v1alpha2.LinodeMachine, dnsTTLSec int, subdomain string, firstMachine bool) ([]DNSOptions, error) {

--- a/cloud/services/domains.go
+++ b/cloud/services/domains.go
@@ -15,9 +15,12 @@ import (
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v12/pkg/dns"
 	"github.com/go-logr/logr"
 	"github.com/linode/linodego/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kcpv1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	"sigs.k8s.io/cluster-api/api/core/v1beta2"
 	kutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/clients"
@@ -327,16 +330,29 @@ func removeElement(stringList []string, elemToRemove string) []string {
 	return stringList
 }
 
-func isCapiMachineReady(capiMachine *v1beta2.Machine) bool {
+func isCapiMachineReady(ctx context.Context, capiMachine *v1beta2.Machine, k8sClient client.Client) (bool, error) {
+	ref := metav1.GetControllerOf(capiMachine)
+	if ref == nil || ref.Kind != "KubeadmControlPlane" {
+		// not owned by a KCP, fall back to just checking the Machine Ready condition
+		for _, condition := range capiMachine.Status.Conditions {
+			if condition.Type == v1beta2.ReadyCondition {
+				return condition.Status == metav1.ConditionTrue, nil
+			}
+		}
+		return false, nil
+	}
+	kcp := &kcpv1beta2.KubeadmControlPlane{}
+	if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: capiMachine.Namespace, Name: ref.Name}, kcp); err != nil {
+		return false, err
+	}
 	// Don't assume we have MachineHealthCheck conditions to check.
 	// Instead, use the CAPI upstream filter to check the machine does not have unhealthy control plane components.
 	// (See https://github.com/kubernetes-sigs/cluster-api/blob/v1.13.4/util/collections/machine_filters.go#L171-L174)
 	// This saves us from having to check the several conditions ourselves.
-	//
-	// NOTE: We assume etcd is not externally managed / don't configure that on the ControlPlane resource (KCP, RKE2ControlPlane, KThreesControlPlane).
-	// We might want to configure that in the future via LinodeCluster.Spec and check that field here.
+	// If etcd is not externally managed, check the etcd component health too.
+	isEtcdManagedExternally := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.IsDefined()
 	return len(collections.FromMachines(capiMachine).
-		Filter(collections.HasUnhealthyControlPlaneComponents(true))) == 0
+		Filter(collections.HasUnhealthyControlPlaneComponents(!isEtcdManagedExternally))) == 0, nil
 }
 
 func processLinodeMachine(ctx context.Context, cscope *scope.ClusterScope, machine v1alpha2.LinodeMachine, dnsTTLSec int, subdomain string, firstMachine bool) ([]DNSOptions, error) {
@@ -351,10 +367,15 @@ func processLinodeMachine(ctx context.Context, cscope *scope.ClusterScope, machi
 		return nil, nil
 	}
 
-	if !firstMachine && !isCapiMachineReady(capiMachine) {
+	logger := logr.FromContextOrDiscard(ctx)
+	isReady, err := isCapiMachineReady(ctx, capiMachine, cscope.Client)
+	if err != nil {
+		logger.Error(err, "failed to determine if linode machine is ready, will not requeue")
+		return nil, nil //nolint:nilnil requeueing will not fix it
+	}
+	if !firstMachine && !isReady {
 		// always process the first linodeMachine, and add its IP to the DNS entries.
 		// For other linodeMachine, only process them if the CAPI machine is ready
-		logger := logr.FromContextOrDiscard(ctx)
 		logger.Info("skipping DNS entry creation for LinodeMachine as the CAPI machine is not ready", "LinodeMachine", machine.Name)
 		// If not ready, return an error so we can requeue and try again later.
 		return nil, util.ErrReconcileAgain

--- a/cloud/services/domains.go
+++ b/cloud/services/domains.go
@@ -270,8 +270,8 @@ func EnsureAkamaiDNSEntries(ctx context.Context, cscope *scope.ClusterScope, ope
 	})
 }
 
-func createAkamaiEntry(ctx context.Context, client clients.AkamClient, dnsEntry DNSOptions, fqdn, rootDomain string) error {
-	return client.CreateRecord(
+func createAkamaiEntry(ctx context.Context, akamClient clients.AkamClient, dnsEntry DNSOptions, fqdn, rootDomain string) error {
+	return akamClient.CreateRecord(
 		ctx,
 		dns.CreateRecordRequest{
 			Record: &dns.RecordBody{
@@ -371,7 +371,7 @@ func processLinodeMachine(ctx context.Context, cscope *scope.ClusterScope, machi
 	isReady, err := isCapiMachineReady(ctx, capiMachine, cscope.Client)
 	if err != nil {
 		logger.Error(err, "failed to determine if linode machine is ready, will not requeue")
-		return nil, nil //nolint:nilnil requeueing will not fix it
+		return nil, nil
 	}
 	if !firstMachine && !isReady {
 		// always process the first linodeMachine, and add its IP to the DNS entries.

--- a/cloud/services/domains_test.go
+++ b/cloud/services/domains_test.go
@@ -335,7 +335,7 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 			if testcase.expectedError != nil {
 				require.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			if testcase.name == "Failure if Machine control plane components are unhealthy (etcd)" {
 				// set everything to healthy and make sure it succeeds
@@ -343,7 +343,7 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 					unhealthyStatus.Conditions[i].Status = metav1.ConditionTrue
 				}
 				mockAkamClient.EXPECT().CreateRecord(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-				assert.NoError(t, EnsureDNSEntries(t.Context(), testcase.clusterScope, "create"))
+				require.NoError(t, EnsureDNSEntries(t.Context(), testcase.clusterScope, "create"))
 			}
 		})
 	}

--- a/cloud/services/domains_test.go
+++ b/cloud/services/domains_test.go
@@ -13,12 +13,15 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
+	kcpv1beta2 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/cloud/scope"
 	"github.com/linode/cluster-api-provider-linode/mock"
+	"github.com/linode/cluster-api-provider-linode/util"
 )
 
 func TestAddIPToEdgeDNS(t *testing.T) {
@@ -94,7 +97,152 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
+			},
+		},
+		{
+			name: "Failure if Machine control plane components are unhealthy (etcd)",
+			clusterScope: &scope.ClusterScope{
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+						UID:  "test-uid",
+					},
+				},
+				LinodeCluster: &infrav1alpha2.LinodeCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster",
+						UID:  "test-uid",
+					},
+					Spec: infrav1alpha2.LinodeClusterSpec{
+						Network: infrav1alpha2.NetworkSpec{
+							LoadBalancerType:    "dns",
+							DNSRootDomain:       "akafn.com",
+							DNSUniqueIdentifier: "test-hash",
+							DNSProvider:         "akamai",
+						},
+					},
+				},
+				LinodeMachines: infrav1alpha2.LinodeMachineList{
+					Items: []infrav1alpha2.LinodeMachine{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-machine",
+								UID:  "test-uid",
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										APIVersion: clusterv1.GroupVersion.String(),
+										Kind:       "Machine",
+										Name:       "test-machine",
+										UID:        "test-uid",
+									},
+								},
+							},
+							Spec: infrav1alpha2.LinodeMachineSpec{
+								ProviderID: ptr.To("linode://123"),
+								InstanceID: ptr.To(123),
+							},
+							Status: infrav1alpha2.LinodeMachineStatus{
+								Addresses: []clusterv1.MachineAddress{
+									{
+										Type:    "ExternalIP",
+										Address: "10.10.10.10",
+									},
+									{
+										Type:    "ExternalIP",
+										Address: "fd00::",
+									},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-machine",
+								UID:  "test-uid",
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										APIVersion: clusterv1.GroupVersion.String(),
+										Kind:       "Machine",
+										Name:       "test-machine",
+										UID:        "test-uid",
+									},
+								},
+							},
+							Spec: infrav1alpha2.LinodeMachineSpec{
+								ProviderID: ptr.To("linode://123"),
+								InstanceID: ptr.To(123),
+							},
+							Status: infrav1alpha2.LinodeMachineStatus{
+								Addresses: []clusterv1.MachineAddress{
+									{
+										Type:    "ExternalIP",
+										Address: "10.10.10.10",
+									},
+									{
+										Type:    "ExternalIP",
+										Address: "fd00::",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expects: func(mockClient *mock.MockAkamClient) {
+				mockClient.EXPECT().GetRecord(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("Not Found")).AnyTimes()
+			},
+			expectedError: util.ErrReconcileAgain,
+			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
+				machineOwnerReferences := []metav1.OwnerReference{{
+					APIVersion: kcpv1beta2.GroupVersion.String(),
+					Kind:       "KubeadmControlPlane",
+					Name:       "test-cluster-cp",
+					UID:        "test-kcp-uid",
+					Controller: ptr.To(true),
+				}}
+				machineStatus := &clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   kcpv1beta2.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   kcpv1beta2.KubeadmControlPlaneMachineControllerManagerPodHealthyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   kcpv1beta2.KubeadmControlPlaneMachineSchedulerPodHealthyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   kcpv1beta2.KubeadmControlPlaneMachineEtcdPodHealthyCondition,
+							Status: metav1.ConditionTrue,
+						},
+						{
+							Type:   kcpv1beta2.KubeadmControlPlaneMachineEtcdMemberHealthyCondition,
+							Status: metav1.ConditionFalse,
+						},
+						{
+							Type:   clusterv1.ReadyCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				}
+				mockCAPIMachine(mockK8sClient, machineOwnerReferences, machineStatus)
+				kcp := &kcpv1beta2.KubeadmControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster-cp",
+						UID:  "test-kcp-uid",
+					},
+					Spec: kcpv1beta2.KubeadmControlPlaneSpec{
+						KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+							ClusterConfiguration: bootstrapv1.ClusterConfiguration{
+								Etcd: bootstrapv1.Etcd{},
+							},
+						},
+					},
+				}
+				mockK8sClient.EXPECT().Get(gomock.Any(), client.ObjectKey{Namespace: "default", Name: "test-cluster-cp"}, kcp).Return(nil).AnyTimes()
 			},
 		},
 		{
@@ -161,7 +309,7 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("create record failed"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 	}
@@ -274,7 +422,7 @@ func TestRemoveIPFromEdgeDNS(t *testing.T) {
 			expectedError: nil,
 			expectedList:  []string{"10.10.10.10", "10.10.10.12"},
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -343,7 +491,7 @@ func TestRemoveIPFromEdgeDNS(t *testing.T) {
 			expectedError: fmt.Errorf("API Down"),
 			expectedList:  []string{"10.10.10.10", "10.10.10.12"},
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 	}
@@ -649,7 +797,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -727,7 +875,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -799,7 +947,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("failed to create domain record of type A"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -878,7 +1026,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -949,7 +1097,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("api error"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1019,7 +1167,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1089,7 +1237,7 @@ func TestAddIPToDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("domain lkedevs.net not found in list of domains owned by this account"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 	}
@@ -1337,7 +1485,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1416,7 +1564,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("failed to delete record"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1461,7 +1609,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 			},
 			expectedError: nil,
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1526,7 +1674,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("cannot get the domain from the api"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1596,7 +1744,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("domain lkedevs.net not found in list of domains owned by this account"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 		{
@@ -1667,7 +1815,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 			},
 			expectedError: fmt.Errorf("api error"),
 			expectK8sClient: func(mockK8sClient *mock.MockK8sClient) {
-				mockCAPIMachine(mockK8sClient)
+				mockCAPIMachine(mockK8sClient, nil, nil)
 			},
 		},
 	}
@@ -1701,7 +1849,7 @@ func TestDeleteIPFromDNS(t *testing.T) {
 }
 
 // mockCAPIMachine sets up the k8s client mock to return a CAPI machine for GetOwnerMachine
-func mockCAPIMachine(mockK8sClient *mock.MockK8sClient) {
+func mockCAPIMachine(mockK8sClient *mock.MockK8sClient, ownerRefs []metav1.OwnerReference, machineStatus *clusterv1.MachineStatus) {
 	mockK8sClient.EXPECT().Scheme().Return(nil).AnyTimes()
 	// Mock the Get call for GetOwnerMachine to return a CAPI machine
 	mockK8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -1713,6 +1861,10 @@ func mockCAPIMachine(mockK8sClient *mock.MockK8sClient) {
 				machine.Namespace = "default"
 				machine.DeletionTimestamp = nil
 				machine.UID = "test-uid"
+				machine.OwnerReferences = ownerRefs
+				if machineStatus != nil {
+					machine.SetConditions(machineStatus.Conditions)
+				}
 			}
 			return nil
 		}).AnyTimes()

--- a/cloud/services/domains_test.go
+++ b/cloud/services/domains_test.go
@@ -24,6 +24,35 @@ import (
 	"github.com/linode/cluster-api-provider-linode/util"
 )
 
+var unhealthyStatus = &clusterv1.MachineStatus{
+	Conditions: []metav1.Condition{
+		{
+			Type:   kcpv1beta2.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   kcpv1beta2.KubeadmControlPlaneMachineControllerManagerPodHealthyCondition,
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   kcpv1beta2.KubeadmControlPlaneMachineSchedulerPodHealthyCondition,
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   kcpv1beta2.KubeadmControlPlaneMachineEtcdPodHealthyCondition,
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   kcpv1beta2.KubeadmControlPlaneMachineEtcdMemberHealthyCondition,
+			Status: metav1.ConditionFalse,
+		},
+		{
+			Type:   clusterv1.ReadyCondition,
+			Status: metav1.ConditionTrue,
+		},
+	},
+}
+
 func TestAddIPToEdgeDNS(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -200,34 +229,7 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 					UID:        "test-kcp-uid",
 					Controller: ptr.To(true),
 				}}
-				machineStatus := &clusterv1.MachineStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   kcpv1beta2.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
-							Status: metav1.ConditionTrue,
-						},
-						{
-							Type:   kcpv1beta2.KubeadmControlPlaneMachineControllerManagerPodHealthyCondition,
-							Status: metav1.ConditionTrue,
-						},
-						{
-							Type:   kcpv1beta2.KubeadmControlPlaneMachineSchedulerPodHealthyCondition,
-							Status: metav1.ConditionTrue,
-						},
-						{
-							Type:   kcpv1beta2.KubeadmControlPlaneMachineEtcdPodHealthyCondition,
-							Status: metav1.ConditionTrue,
-						},
-						{
-							Type:   kcpv1beta2.KubeadmControlPlaneMachineEtcdMemberHealthyCondition,
-							Status: metav1.ConditionFalse,
-						},
-						{
-							Type:   clusterv1.ReadyCondition,
-							Status: metav1.ConditionTrue,
-						},
-					},
-				}
+				machineStatus := unhealthyStatus
 				mockCAPIMachine(mockK8sClient, machineOwnerReferences, machineStatus)
 				kcp := &kcpv1beta2.KubeadmControlPlane{
 					ObjectMeta: metav1.ObjectMeta{
@@ -321,9 +323,9 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			MockAkamClient := mock.NewMockAkamClient(ctrl)
-			testcase.clusterScope.AkamaiDomainsClient = MockAkamClient
-			testcase.expects(MockAkamClient)
+			mockAkamClient := mock.NewMockAkamClient(ctrl)
+			testcase.clusterScope.AkamaiDomainsClient = mockAkamClient
+			testcase.expects(mockAkamClient)
 
 			MockK8sClient := mock.NewMockK8sClient(ctrl)
 			testcase.clusterScope.Client = MockK8sClient
@@ -334,6 +336,14 @@ func TestAddIPToEdgeDNS(t *testing.T) {
 				require.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {
 				assert.NoError(t, err)
+			}
+			if testcase.name == "Failure if Machine control plane components are unhealthy (etcd)" {
+				// set everything to healthy and make sure it succeeds
+				for i := range unhealthyStatus.Conditions {
+					unhealthyStatus.Conditions[i].Status = metav1.ConditionTrue
+				}
+				mockAkamClient.EXPECT().CreateRecord(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+				assert.NoError(t, EnsureDNSEntries(t.Context(), testcase.clusterScope, "create"))
 			}
 		})
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplanes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
   - addresssets

--- a/go.mod
+++ b/go.mod
@@ -152,6 +152,7 @@ require (
 	gopkg.in/ini.v1 v1.67.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
+	k8s.io/cluster-bootstrap v0.34.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/internal/controller/linodecluster_controller.go
+++ b/internal/controller/linodecluster_controller.go
@@ -72,6 +72,8 @@ type LinodeClusterReconciler struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodeclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=linodeclusters/finalizers,verbs=update
 
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,verbs=get;list;watch
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -62,8 +62,6 @@ const (
 	ConditionPreflightLinodeFirewallReady       = "PreflightLinodeFirewallReady"
 	ConditionPreflightMetadataSupportConfigured = "PreflightMetadataSupportConfigured"
 	ConditionPreflightCreated                   = "PreflightCreated"
-	ConditionPreflightRootDiskResizing          = "PreflightRootDiskResizing"
-	ConditionPreflightRootDiskResized           = "PreflightRootDiskResized"
 	ConditionPreflightAdditionalDisksCreated    = "PreflightAdditionalDisksCreated"
 	ConditionPreflightConfigured                = "PreflightConfigured"
 	ConditionPreflightBootTriggered             = "PreflightBootTriggered"


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
This checks the (control plane) machine's control plane component conditions (apiserver, scheduler, controller-manager, etcd) for readiness similar to KCP via CAPI's `HasUnhealthyControlPlaneComponents` filter instead of relying on the Machine Ready condition or MachineHealthChecks:
https://github.com/kubernetes-sigs/cluster-api/blob/v1.13.4/controlplane/kubeadm/internal/control_plane.go#L333-L338

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests


