### PR TITLE
[docs] Update etcd-backup-restore docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -179,7 +179,7 @@ Cluster templates in `templates/flavors/` define different configurations (VPC v
 
 ### Backup & Storage
 - `OBJ_BUCKET_REGION`: Object storage region for etcd backups (e.g., `us-ord`)
-- `ETCDBR_IMAGE`: Custom etcd backup/restore controller image
+- `ETCDBR_IMAGE`: Optional override for the etcd backup/restore controller image (defaults to the official gardener `etcdbrctl` image)
 - `SSE_KEY`: Server-side encryption key for object storage
 
 ### E2E Testing

--- a/docs/src/topics/etcd.md
+++ b/docs/src/topics/etcd.md
@@ -27,16 +27,13 @@ Users can also enable SSE (Server-side encryption) by passing a SSE AES-256 Key 
 [here](https://github.com/linode/cluster-api-provider-linode/blob/main/templates/addons/etcd-backup-restore/etcd-backup-restore.yaml)
 on the pod can be controlled during the provisioning process.
 
-```admonish warning
-This is currently under development and will be available for use once the upstream [PR](https://github.com/gardener/etcd-backup-restore/pull/719) is merged and an official image is made available
-```
-
 For eg:
 ```sh
 export CLUSTER_NAME=test
 export OBJ_BUCKET_REGION=us-ord
-export ETCDBR_IMAGE=docker.io/username/your-custom-image:version
 export SSE_KEY=cdQdZ3PrKgm5vmqxeqwQCuAWJ7pPVyHg
+# Optional: override the default official etcd-backup-restore image
+# export ETCDBR_IMAGE=europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl:v0.36.3
 clusterctl generate cluster $CLUSTER_NAME \
   --kubernetes-version v1.33.4 \
   --infrastructure linode-linode \

--- a/envrc.example
+++ b/envrc.example
@@ -12,7 +12,7 @@ export LINODE_MACHINE_TYPE="" # g6-standard-2
 
 # To set up etcd backup and restore
 export OBJ_BUCKET_REGION="" # us-ord
-export ETCDBR_IMAGE="" # docker.io/amoldeodhar/etcdbrctl:a7fc188f71977deabce6e4b2284e145d78000c30
+export ETCDBR_IMAGE="" # optional override; defaults to official europe-docker.pkg.dev/gardener-project/releases/gardener/etcdbrctl:v0.36.3
 export SSE_KEY="" # cdQdZ3PrKgm5vmqxeqwQCuAWJ7pPVyHg
 
 # To add SSH key to the CAPL cluster nodes


### PR DESCRIPTION
Update `etcd-backup-restore` docs to reflect the official gardener `etcdbrctl` image as the default and `ETCDBR_IMAGE` environment variable as an optional override.