### PR TITLE
fix(ci): allow Docker CloudFront redirects on release/0.9

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -100,6 +100,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             storage.googleapis.com:443
             registry.k8s.io:443
             *.pkg.dev:443

--- a/.github/workflows/e2e-upgrade-test.yaml
+++ b/.github/workflows/e2e-upgrade-test.yaml
@@ -63,6 +63,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             storage.googleapis.com:443
             registry.k8s.io:443
             *.pkg.dev:443

--- a/.github/workflows/go-analyze.yml
+++ b/.github/workflows/go-analyze.yml
@@ -53,6 +53,7 @@ jobs:
             *.githubusercontent.com:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             vuln.go.dev:443
             storage.googleapis.com:443
             golangci-lint.run:443

--- a/.github/workflows/pull_request_ci.yaml
+++ b/.github/workflows/pull_request_ci.yaml
@@ -104,6 +104,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             gcr.io:443
             storage.googleapis.com:443
 


### PR DESCRIPTION
## Summary

- Allow Docker's CloudFront redirect endpoint in the release/0.9 Harden Runner egress policy.
