### PR TITLE
[test] add object store fallback e2e

### DIFF
--- a/e2e/linodemachine-controller/cluster-object-store-fallback/assert-capi-resources.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/assert-capi-resources.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+  namespace: capl-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+status:
+  availableReplicas: 1

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/assert-key-and-secret.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/assert-key-and-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeObjectStorageKey
+metadata:
+  name: ($key)
+status:
+  ready: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ($key_secret)
+data:
+  (bucket != null): true
+  (endpoint != null): true
+  (access != null): true
+  (secret != null): true

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/assert-linodemachine.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/assert-linodemachine.yaml
@@ -1,0 +1,22 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  region: us-sea
+  type: g6-nanode-1
+status:
+  ready: true
+  instanceState: running
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  clusterName: ($cluster)
+status:
+  initialization:
+    infrastructureProvisioned: true

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/chainsaw-test.yaml
@@ -1,0 +1,133 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: cluster-object-store-fallback
+  labels:
+    all:
+    linodemachine:
+spec:
+  bindings:
+    - name: run
+      value: (join('-', ['cluster-obj-fallback', random('[0-9a-z]{5}')]))
+    - name: cluster
+      value: (trim((truncate(($run), `29`)), '-'))
+    - name: key
+      value: (trim((truncate((join('-', [($cluster)])), `52`)), '-'))
+    - name: key_secret
+      value: (concat(($key), '-obj-key'))
+    - name: primary_secret
+      value: (concat(($cluster), '-primary-obj-key'))
+  template: true
+  steps:
+    - name: Check if CAPI provider resources exist
+      try:
+        - assert:
+            file: assert-capi-resources.yaml
+    - name: Create bucket
+      try:
+        - script:
+            env:
+              - name: URI
+                value: object-storage/buckets
+              - name: BUCKET_LABEL
+                value: ($key)
+            content: |
+              set -e
+
+              curl -s \
+                -X POST \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "{\"label\":\"$BUCKET_LABEL\",\"region\":\"us-sea\"}" \
+                "https://api.linode.com/v4beta/$URI"
+            check:
+              ($error): ~
+    - name: Create LinodeObjectStorageKey
+      try:
+        - apply:
+            file: create-linodeobjectstoragekey.yaml
+        - assert:
+            file: assert-key-and-secret.yaml
+    - name: Create invalid primary Object Storage credentials
+      try:
+        - apply:
+            file: create-invalid-primary-secret.yaml
+    - name: Create Cluster resource
+      try:
+        - apply:
+            file: create-cluster.yaml
+    - name: Generate dummy cloud-config data
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+            content: |
+              set -eu
+              LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 102400 > chonk.txt
+              kubectl -n "$NAMESPACE" create secret generic chonk-secret --from-file=chonk.txt
+            check:
+              ($error): ~
+    - name: Create LinodeMachine
+      try:
+        - apply:
+            file: create-linodemachine.yaml
+        - assert:
+            file: assert-linodemachine.yaml
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachineTemplate
+        - describe:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+            kind: KubeadmControlPlane
+    - name: Delete Cluster resource
+      try:
+        - delete:
+            ref:
+              apiVersion: cluster.x-k8s.io/v1beta2
+              kind: Cluster
+              name: ($cluster)
+        - error:
+            file: check-linodemachine-deletion.yaml
+    - name: Delete LinodeObjectStorageKey
+      try:
+        - script:
+            env:
+              - name: OBJ_KEY
+                value: ($key)
+            content: |
+              set -e
+
+              export KEY_ID=$(kubectl -n $NAMESPACE get lobjkey $OBJ_KEY -ojson | jq '.status.accessKeyRef')
+
+              curl -s \
+                -X DELETE \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                "https://api.linode.com/v4beta/object-storage/keys/$KEY_ID"
+            check:
+              ($error): ~
+    - name: Delete bucket
+      try:
+        - script:
+            env:
+              - name: BUCKET_LABEL
+                value: ($key)
+            content: |
+              set -e
+
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X DELETE \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                "https://api.linode.com/v4beta/object-storage/buckets/us-sea/$BUCKET_LABEL")
+
+              case "$STATUS" in
+                2*) ;;
+                *)
+                  echo "bucket deletion failed with HTTP status $STATUS"
+                  exit 1
+                  ;;
+              esac
+            check:
+              ($error): ~

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/chainsaw-test.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/chainsaw-test.yaml
@@ -35,7 +35,7 @@ spec:
             content: |
               set -e
 
-              curl -s \
+              curl -fsS \
                 -X POST \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
                 -H "Content-Type: application/json" \
@@ -100,9 +100,9 @@ spec:
             content: |
               set -e
 
-              export KEY_ID=$(kubectl -n $NAMESPACE get lobjkey $OBJ_KEY -ojson | jq '.status.accessKeyRef')
+              export KEY_ID=$(kubectl -n "$NAMESPACE" get lobjkey "$OBJ_KEY" -ojson | jq -er '.status.accessKeyRef')
 
-              curl -s \
+              curl -fsS \
                 -X DELETE \
                 -H "Authorization: Bearer $LINODE_TOKEN" \
                 "https://api.linode.com/v4beta/object-storage/keys/$KEY_ID"

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/check-linodemachine-deletion.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/check-linodemachine-deletion.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/create-cluster.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/create-cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ($cluster)
+spec:
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: ($cluster)
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: LinodeCluster
+    name: ($cluster)
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeCluster
+metadata:
+  name: ($cluster)
+spec:
+  region: us-sea
+  objectStore:
+    credentialsRef:
+      name: ($primary_secret)
+    secondaryCredentialsRef:
+      name: ($key_secret)

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/create-invalid-primary-secret.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/create-invalid-primary-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ($primary_secret)
+type: Opaque
+stringData:
+  # Deliberately incomplete credentials make the primary attempt fail before
+  # any Object Store request; the configured secondary is then used.
+  bucket: (concat(($cluster), '-primary-does-not-exist'))

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/create-linodemachine.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/create-linodemachine.yaml
@@ -1,0 +1,35 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ($cluster)
+spec:
+  kubeadmConfigSpec:
+    files:
+      - path: /chonk.txt
+        contentFrom:
+          secret:
+            key: chonk.txt
+            name: chonk-secret
+    clusterConfiguration:
+      controllerManager:
+        extraArgs:
+          - name: cloud-provider
+            value: external
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: LinodeMachineTemplate
+        name: ($cluster)
+  replicas: 1
+  version: 1.33.4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachineTemplate
+metadata:
+  name: ($cluster)
+spec:
+  template:
+    spec:
+      region: us-sea
+      type: g6-nanode-1

--- a/e2e/linodemachine-controller/cluster-object-store-fallback/create-linodeobjectstoragekey.yaml
+++ b/e2e/linodemachine-controller/cluster-object-store-fallback/create-linodeobjectstoragekey.yaml
@@ -1,0 +1,16 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeObjectStorageKey
+metadata:
+  name: ($key)
+spec:
+  bucketAccess:
+    - bucketName: ($key)
+      permissions: read_write
+      region: us-sea
+  generatedSecret:
+    name: ($key_secret)
+    format:
+      bucket: '{{ .BucketName }}'
+      endpoint: '{{ .S3Endpoint }}'
+      access: '{{ .AccessKey }}'
+      secret: '{{ .SecretKey }}'


### PR DESCRIPTION
## Summary
- add a live Chainsaw test for Object Store fallback credentials
- `cluster-object-store` uses one valid Object Store Secret as `credentialsRef`
- `cluster-object-store-fallback` uses an incomplete primary Secret as `credentialsRef` and the valid generated Secret as `secondaryCredentialsRef`
- both tests use the same kubeadm bootstrap flow and oversized bootstrap payload; the fallback test verifies the machine becomes ready and the bucket can be deleted after cleanup
