### PR TITLE
[fix] don't retry if it's not a transient error

### DIFF
--- a/internal/controller/linodemachine_controller_helpers.go
+++ b/internal/controller/linodemachine_controller_helpers.go
@@ -83,8 +83,8 @@ func retryIfTransient(err error, logger logr.Logger) (ctrl.Result, error) {
 		}
 		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerRetryDelay)}, nil
 	}
-	logger.Error(err, "unknown Linode API error")
-	return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerRetryDelay)}, nil
+	logger.Error(err, "Linode API error is not retryable, not requeuing...")
+	return ctrl.Result{}, nil
 }
 
 func fillCreateConfig(ctx context.Context, createConfig *linodego.InstanceCreateOptions, machineScope *scope.MachineScope) error {

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -655,7 +655,7 @@ var _ = Describe("create", Label("machine", "create"), func() {
 				After(getImage).
 				DoAndReturn(func(_, _ any) (*linodego.Instance, error) {
 					time.Sleep(time.Microsecond)
-					return nil, errors.New("time is up")
+					return nil, linodego.NewError(linodego.Error{Code: http.StatusRequestTimeout, Message: "time is up"})
 				})
 			mockLinodeClient.EXPECT().
 				OnAfterResponse(gomock.Any()).
@@ -1939,7 +1939,7 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 						Expect(err).To(HaveOccurred())
 						Expect(mck.Logs()).To(ContainSubstring("Failed to parse instance ID from provider ID"))
 					})),
-					Path(Result("update requeues on get error", func(ctx context.Context, mck Mock) {
+					Path(Result("update requeues on retryable get error", func(ctx context.Context, mck Mock) {
 						linodeMachine.Spec.ProviderID = util.Pointer("linode://11111")
 						linodeMachine.Status.InstanceState = util.Pointer(linodego.InstanceOffline)
 						mck.LinodeClient.EXPECT().GetInstance(ctx, 11111).
@@ -1948,6 +1948,15 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 						Expect(err).NotTo(HaveOccurred())
 						Expect(res.RequeueAfter).To(BeNumerically(">=", rutil.DefaultMachineControllerRetryDelay))
 						Expect(res.RequeueAfter).To(BeNumerically("<=", rutil.DefaultMachineControllerRetryDelay+time.Duration(float64(rutil.DefaultMachineControllerRetryDelay)*rutil.RetryJitterFraction)))
+					})),
+					Path(Result("update does not requeue on nonretryable get error", func(ctx context.Context, mck Mock) {
+						linodeMachine.Spec.ProviderID = util.Pointer("linode://11111")
+						linodeMachine.Status.InstanceState = util.Pointer(linodego.InstanceOffline)
+						mck.LinodeClient.EXPECT().GetInstance(ctx, 11111).
+							Return(nil, &linodego.Error{Code: http.StatusNotFound})
+						res, err := reconciler.reconcile(ctx, mck.Logger(), mScope)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(res.IsZero()).To(BeTrue())
 					})),
 				),
 			),


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:
We weren't respecting not retrying on non-transient errors (e.g. 404):
```
2026-08-10T18:46:15Z	ERROR	LinodeMachineReconciler	unknown Linode API error	{"controller": "linodemachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "LinodeMachine", "LinodeMachine": {"name":"e2e-dns-lb-kjimd-cp-8442r","namespace":"chainsaw-factual-gopher"}, "namespace": "chainsaw-factual-gopher", "name": "e2e-dns-lb-kjimd-cp-8442r", "reconcileID": "e05dc1f6-fdfd-457c-b0b6-b6ece5a8e966", "name": "chainsaw-factual-gopher/e2e-dns-lb-kjimd-cp-8442r", "LinodeMachine": "e2e-dns-lb-kjimd-cp-8442r", "LinodeCluster": "e2e-dns-lb-kjimd", "error": "[404] Not found"}
```
This fixes the logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


