### PR TITLE
feat: add check for customer account settings in linodemachinetemplate validating webhook

### DIFF
--- a/api/v1alpha2/linodemachinetemplate_types.go
+++ b/api/v1alpha2/linodemachinetemplate_types.go
@@ -55,6 +55,11 @@ type LinodeMachineTemplateResource struct {
 	Spec LinodeMachineSpec `json:"spec,omitempty,omitzero"`
 }
 
+const (
+	ErrLinodeInterfacesNotAllowed = "Linode Interfaces are not allowed on this account (interfaces_for_new_linodes=legacy_config_only)"
+	ErrLegacyInterfacesNotAllowed = "Legacy Configuration Profile interfaces are not allowed on this account (interfaces_for_new_linodes=linode_only)"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:resource:path=linodemachinetemplates,scope=Namespaced,categories=cluster-api,shortName=lmt

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -24,6 +24,7 @@ type LinodeClient interface {
 	LinodeFirewallClient
 	LinodeTokenClient
 	LinodeInterfacesClient
+	LinodeAccountSettingsClient
 
 	OnAfterResponse(m func(response *http.Response) error)
 }
@@ -131,6 +132,11 @@ type LinodeFirewallClient interface {
 type LinodeInterfacesClient interface {
 	ListInterfaces(ctx context.Context, linodeID int, opts *linodego.ListOptions) ([]linodego.LinodeInterface, error)
 	ListInterfaceFirewalls(ctx context.Context, linodeID int, interfaceID int, opts *linodego.ListOptions) ([]linodego.Firewall, error)
+}
+
+// LinodeAccountSettingsClient defines the methods that interact with account settings.
+type LinodeAccountSettingsClient interface {
+	GetAccountSettings(ctx context.Context) (*linodego.AccountSettings, error)
 }
 
 type K8sClient interface {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -94,6 +94,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha2-linodemachinetemplate
+  failurePolicy: Fail
+  name: validation.linodemachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    resources:
+    - linodemachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1alpha2-linodeobjectstoragebucket
   failurePolicy: Fail
   name: validation.linodeobjectstoragebucket.infrastructure.cluster.x-k8s.io

--- a/internal/webhook/v1alpha2/linodemachinetemplate_webhook.go
+++ b/internal/webhook/v1alpha2/linodemachinetemplate_webhook.go
@@ -17,21 +17,83 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
+	"github.com/linode/cluster-api-provider-linode/clients"
 )
 
 // log is for logging in this package.
-//
-//nolint:unused // Package logger variable is intended for future use in webhook implementation
 var linodemachinetemplatelog = logf.Log.WithName("linodemachinetemplate-resource")
+
+type linodeMachineTemplateValidator struct {
+	Client client.Client
+}
 
 // SetupLinodeMachineTemplateWebhookWithManager registers the webhook for LinodeMachineTemplate in the manager.
 func SetupLinodeMachineTemplateWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &infrav1alpha2.LinodeMachineTemplate{}).
+		WithValidator(&linodeMachineTemplateValidator{Client: mgr.GetClient()}).
 		Complete()
+}
+
+// +kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha2-linodemachinetemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=linodemachinetemplates,verbs=create,versions=v1alpha2,name=validation.linodemachinetemplate.infrastructure.cluster.x-k8s.io,admissionReviewVersions=v1
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *linodeMachineTemplateValidator) ValidateCreate(ctx context.Context, linodeMachineTemplate *infrav1alpha2.LinodeMachineTemplate) (admission.Warnings, error) {
+	spec := linodeMachineTemplate.Spec
+	linodemachinetemplatelog.Info("validate create", "name", linodeMachineTemplate.Name)
+
+	skipAPIValidation, linodeClient, err := setupClientWithCredentials(ctx, r.Client, spec.Template.Spec.CredentialsRef,
+		linodeMachineTemplate.Name, linodeMachineTemplate.GetNamespace(), linodemachinetemplatelog)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	var errs field.ErrorList
+	if !skipAPIValidation {
+		if templateErrs := r.validateLinodeMachineTemplateSpec(ctx, linodeClient, spec); templateErrs != nil {
+			errs = append(errs, templateErrs...)
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil, nil
+	}
+	return nil, apierrors.NewInvalid(
+		schema.GroupKind{Group: "infrastructure.cluster.x-k8s.io", Kind: "LinodeMachineTemplate"},
+		linodeMachineTemplate.Name, errs)
+}
+
+func (r *linodeMachineTemplateValidator) validateLinodeMachineTemplateSpec(ctx context.Context, linodeClient clients.LinodeClient, spec infrav1alpha2.LinodeMachineTemplateSpec) field.ErrorList {
+	var errs field.ErrorList
+	usesLegacy := len(spec.Template.Spec.Interfaces) > 0
+	usesLinode := len(spec.Template.Spec.LinodeInterfaces) > 0
+	path := field.NewPath("spec", "template", "spec")
+	if ferr, err := validateInterfaceAccountSettings(ctx, linodeClient, usesLegacy, usesLinode, path); err != nil {
+		return append(errs, field.InternalError(path, err))
+	} else if ferr != nil {
+		errs = append(errs, ferr)
+	}
+	return errs
+}
+
+func (r *linodeMachineTemplateValidator) ValidateUpdate(_ context.Context, _, newLinodeMachineTemplate *infrav1alpha2.LinodeMachineTemplate) (admission.Warnings, error) {
+	linodemachinetemplatelog.Info("validate update", "name", newLinodeMachineTemplate.Name)
+	return nil, nil
+}
+
+func (r *linodeMachineTemplateValidator) ValidateDelete(_ context.Context, linodeMachineTemplate *infrav1alpha2.LinodeMachineTemplate) (admission.Warnings, error) {
+	linodemachinetemplatelog.Info("validate delete", "name", linodeMachineTemplate.Name)
+	return nil, nil
 }
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/internal/webhook/v1alpha2/linodemachinetemplate_webhook_test.go
+++ b/internal/webhook/v1alpha2/linodemachinetemplate_webhook_test.go
@@ -17,38 +17,246 @@ limitations under the License.
 package v1alpha2
 
 import (
-	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
+	"context"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/linode/linodego/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
+	"github.com/linode/cluster-api-provider-linode/mock"
+
+	. "github.com/linode/cluster-api-provider-linode/mock/mocktest"
 )
 
-var _ = Describe("LinodeMachineTemplate Webhook", func() {
+func TestValidateLinodeMachineTemplateCreate(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockK8sClient := mock.NewMockK8sClient(ctrl)
+
 	var (
-		obj    *infrav1alpha2.LinodeMachineTemplate
-		oldObj *infrav1alpha2.LinodeMachineTemplate
+		// Template with no LinodeInterfaces — the account settings check is skipped entirely.
+		templateWithoutInterfaces = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+			Spec: infrav1alpha2.LinodeMachineTemplateSpec{
+				Template: infrav1alpha2.LinodeMachineTemplateResource{
+					Spec: infrav1alpha2.LinodeMachineSpec{
+						Region: "us-ord",
+						Type:   "g6-standard-1",
+					},
+				},
+			},
+		}
+		// Template with LinodeInterfaces and a credRef whose secret is not found.
+		// setupClientWithCredentials returns skipAPIValidation=true so the account
+		// settings check is also skipped.
+		templateWithInterfacesAndMissingCred = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+			Spec: infrav1alpha2.LinodeMachineTemplateSpec{
+				Template: infrav1alpha2.LinodeMachineTemplateResource{
+					Spec: infrav1alpha2.LinodeMachineSpec{
+						Region:           "us-ord",
+						Type:             "g6-standard-1",
+						LinodeInterfaces: []infrav1alpha2.LinodeInterfaceCreateOptions{{}},
+						CredentialsRef: &corev1.SecretReference{
+							Name:      "template-credentials",
+							Namespace: "example",
+						},
+					},
+				},
+			},
+		}
+		// Template with LinodeInterfaces and a resolved credRef — API validation runs using the mock linode client.
+		templateWithoutCred = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+			Spec: infrav1alpha2.LinodeMachineTemplateSpec{
+				Template: infrav1alpha2.LinodeMachineTemplateResource{
+					Spec: infrav1alpha2.LinodeMachineSpec{
+						Region:           "us-ord",
+						Type:             "g6-standard-1",
+						LinodeInterfaces: []infrav1alpha2.LinodeInterfaceCreateOptions{{}},
+						CredentialsRef: &corev1.SecretReference{
+							Name:      "example-creds",
+							Namespace: "example",
+						},
+					},
+				},
+			},
+		}
+		// Template with legacy Interfaces and a resolved credRef — API validation runs using the mock linode client.
+		templateWithLegacyInterfacesAndNoCred = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+			Spec: infrav1alpha2.LinodeMachineTemplateSpec{
+				Template: infrav1alpha2.LinodeMachineTemplateResource{
+					Spec: infrav1alpha2.LinodeMachineSpec{
+						Region: "us-ord",
+						Type:   "g6-standard-1",
+						Interfaces: []infrav1alpha2.InstanceConfigInterfaceCreateOptions{
+							{Purpose: "public"},
+						},
+						CredentialsRef: &corev1.SecretReference{
+							Name:      "example-creds",
+							Namespace: "example",
+						},
+					},
+				},
+			},
+		}
+		validator = &linodeMachineTemplateValidator{Client: mockK8sClient}
 	)
 
-	BeforeEach(func() {
-		obj = &infrav1alpha2.LinodeMachineTemplate{}
-		oldObj = &infrav1alpha2.LinodeMachineTemplate{}
-		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
-		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		// TODO (user): Add any setup logic common to all tests
-	})
+	NewSuite(t, mock.MockLinodeClient{}).Run(
+		OneOf(
+			// No interface fields → account settings check is skipped entirely.
+			Path(
+				Call("no interfaces set", func(ctx context.Context, mck Mock) {}),
+				Result("success", func(ctx context.Context, mck Mock) {
+					_, err := validator.ValidateCreate(ctx, &templateWithoutInterfaces)
+					require.NoError(t, err)
+				}),
+			),
+			// Credentials secret not found → skipAPIValidation=true → account settings check skipped.
+			Path(
+				Call("credentials secret not found", func(ctx context.Context, mck Mock) {
+					mockK8sClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(apierrors.NewNotFound(corev1.Resource("secrets"), "template-credentials")).AnyTimes()
+				}),
+				Result("success — API validation skipped", func(ctx context.Context, mck Mock) {
+					_, err := validator.ValidateCreate(ctx, &templateWithInterfacesAndMissingCred)
+					require.NoError(t, err)
+				}),
+			),
+			// Linode Interfaces set, account has LegacyConfigOnly → forbidden.
+			Path(
+				Call("LinodeInterfaces + LegacyConfigOnly", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LegacyConfigOnly,
+					}, nil)
+				}),
+				Result("forbidden error", func(ctx context.Context, mck Mock) {
+					errs := validator.validateLinodeMachineTemplateSpec(ctx, mck.LinodeClient, templateWithoutCred.Spec)
+					require.NotEmpty(t, errs)
+					assert.Contains(t, errs[0].Detail, "legacy_config_only")
+				}),
+			),
+			// Legacy interfaces set, account has LinodeOnly → forbidden.
+			Path(
+				Call("legacy interfaces + LinodeOnly", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LinodeOnly,
+					}, nil)
+				}),
+				Result("forbidden error", func(ctx context.Context, mck Mock) {
+					errs := validator.validateLinodeMachineTemplateSpec(ctx, mck.LinodeClient, templateWithLegacyInterfacesAndNoCred.Spec)
+					require.NotEmpty(t, errs)
+					assert.Contains(t, errs[0].Detail, "linode_only")
+				}),
+			),
+			// Linode Interfaces set, account allows both → permitted.
+			Path(
+				Call("LinodeInterfaces + LegacyConfigDefaultButLinodeAllowed", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LegacyConfigDefaultButLinodeAllowed,
+					}, nil)
+				}),
+				Result("success", func(ctx context.Context, mck Mock) {
+					errs := validator.validateLinodeMachineTemplateSpec(ctx, mck.LinodeClient, templateWithoutCred.Spec)
+					require.Empty(t, errs)
+				}),
+			),
+		),
+	)
+}
 
-	AfterEach(func() {
-		// TODO (user): Add any teardown logic common to all tests
-	})
+func TestValidateLinodeMachineTemplateUpdate(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	Context("When creating LinodeMachineTemplate under Conversion Webhook", func() {
-		// TODO (user): Add logic to convert the object to the desired version and verify the conversion
-		// Example:
-		// It("Should convert the object correctly", func() {
-		//     convertedObj := &infrav1alpha2.LinodeMachineTemplate{}
-		//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
-		//     Expect(convertedObj).ToNot(BeNil())
-		// })
-	})
+	mockK8sClient := mock.NewMockK8sClient(ctrl)
 
-})
+	var (
+		oldTemplate = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+		}
+		newTemplate = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+			Spec: infrav1alpha2.LinodeMachineTemplateSpec{
+				Template: infrav1alpha2.LinodeMachineTemplateResource{
+					Spec: infrav1alpha2.LinodeMachineSpec{
+						Region:           "us-ord",
+						LinodeInterfaces: []infrav1alpha2.LinodeInterfaceCreateOptions{{}},
+					},
+				},
+			},
+		}
+		validator = &linodeMachineTemplateValidator{Client: mockK8sClient}
+	)
+
+	NewSuite(t, mock.MockLinodeClient{}).Run(
+		OneOf(
+			Path(
+				Call("update", func(ctx context.Context, mck Mock) {}),
+				Result("success", func(ctx context.Context, mck Mock) {
+					_, err := validator.ValidateUpdate(ctx, &oldTemplate, &newTemplate)
+					assert.NoError(t, err)
+				}),
+			),
+		),
+	)
+}
+
+func TestValidateLinodeMachineTemplateDelete(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockK8sClient := mock.NewMockK8sClient(ctrl)
+
+	var (
+		template = infrav1alpha2.LinodeMachineTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "example",
+			},
+		}
+		validator = &linodeMachineTemplateValidator{Client: mockK8sClient}
+	)
+
+	NewSuite(t, mock.MockLinodeClient{}).Run(
+		OneOf(
+			Path(
+				Call("delete", func(ctx context.Context, mck Mock) {}),
+				Result("success", func(ctx context.Context, mck Mock) {
+					_, err := validator.ValidateDelete(ctx, &template)
+					assert.NoError(t, err)
+				}),
+			),
+		),
+	)
+}

--- a/internal/webhook/v1alpha2/webhook_helpers.go
+++ b/internal/webhook/v1alpha2/webhook_helpers.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	caplv1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
 	"github.com/linode/cluster-api-provider-linode/clients"
 	"github.com/linode/cluster-api-provider-linode/observability/wrappers/linodeclient"
 )
@@ -148,4 +149,33 @@ func setupClientWithCredentials(ctx context.Context, crClient clients.K8sClient,
 	// The caller should handle validation with the default client
 	logger.Error(err, "failed getting credentials from secret ref", "name", resourceName)
 	return false, linodeClient, nil
+}
+
+// validateInterfaceAccountSettings checks a customer's account settings to ensure that
+// the requested interface type is permitted.
+//   - usesLegacyInterfaces: true when the machine spec has Interfaces set
+//   - usesLinodeInterfaces: true when the machine spec has LinodeInterfaces set
+//
+// Returns a field.Error when the requested type is not allowed, or nil when everything is fine.
+func validateInterfaceAccountSettings(ctx context.Context, linodegoclient clients.LinodeClient, usesLegacyInterfaces, usesLinodeInterfaces bool, path *field.Path) (*field.Error, error) {
+	if !usesLegacyInterfaces && !usesLinodeInterfaces {
+		return nil, nil //nolint:nilnil // nil, nil is the intended "nothing to validate" state
+	}
+
+	accountSettings, err := linodegoclient.GetAccountSettings(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get customer account settings: %w", err)
+	}
+
+	setting := accountSettings.InterfacesForNewLinodes
+
+	if usesLinodeInterfaces && setting == linodego.LegacyConfigOnly {
+		return field.Forbidden(path.Child("linodeInterfaces"), caplv1alpha2.ErrLinodeInterfacesNotAllowed), nil
+	}
+
+	if usesLegacyInterfaces && setting == linodego.LinodeOnly {
+		return field.Forbidden(path.Child("legacyConfiguration"), caplv1alpha2.ErrLegacyInterfacesNotAllowed), nil
+	}
+
+	return nil, nil //nolint:nilnil // nil, nil is the intended "permitted, no error" state
 }

--- a/internal/webhook/v1alpha2/webhook_helpers_test.go
+++ b/internal/webhook/v1alpha2/webhook_helpers_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 Akamai Technologies, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/linode/linodego/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/linode/cluster-api-provider-linode/mock"
+
+	. "github.com/linode/cluster-api-provider-linode/mock/mocktest"
+)
+
+func TestValidateInterfaceAccountSettings(t *testing.T) {
+	t.Parallel()
+
+	path := field.NewPath("spec")
+
+	NewSuite(t, mock.MockLinodeClient{}).Run(
+		OneOf(
+			// Neither interface type set → no API call, no error.
+			Path(
+				Call("neither interface type set", func(ctx context.Context, mck Mock) {}),
+				Result("no error", func(ctx context.Context, mck Mock) {
+					ferr, err := validateInterfaceAccountSettings(ctx, mck.LinodeClient, false, false, path)
+					require.NoError(t, err)
+					assert.Nil(t, ferr)
+				}),
+			),
+			// Linode Interfaces requested, account only allows legacy → forbidden.
+			Path(
+				Call("LinodeInterfaces + LegacyConfigOnly", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LegacyConfigOnly,
+					}, nil)
+				}),
+				Result("forbidden", func(ctx context.Context, mck Mock) {
+					ferr, err := validateInterfaceAccountSettings(ctx, mck.LinodeClient, false, true, path)
+					require.NoError(t, err)
+					require.NotNil(t, ferr)
+					assert.Contains(t, ferr.Detail, "legacy_config_only")
+				}),
+			),
+			// Legacy interfaces requested, account only allows Linode → forbidden.
+			Path(
+				Call("legacy interfaces + LinodeOnly", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LinodeOnly,
+					}, nil)
+				}),
+				Result("forbidden", func(ctx context.Context, mck Mock) {
+					ferr, err := validateInterfaceAccountSettings(ctx, mck.LinodeClient, true, false, path)
+					require.NoError(t, err)
+					require.NotNil(t, ferr)
+					assert.Contains(t, ferr.Detail, "linode_only")
+				}),
+			),
+			// Linode Interfaces requested, account allows both → permitted.
+			Path(
+				Call("LinodeInterfaces + LegacyConfigDefaultButLinodeAllowed", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LegacyConfigDefaultButLinodeAllowed,
+					}, nil)
+				}),
+				Result("permitted", func(ctx context.Context, mck Mock) {
+					ferr, err := validateInterfaceAccountSettings(ctx, mck.LinodeClient, false, true, path)
+					require.NoError(t, err)
+					assert.Nil(t, ferr)
+				}),
+			),
+			// Legacy interfaces requested, account allows both → permitted.
+			Path(
+				Call("legacy interfaces + LinodeDefaultButLegacyConfigAllowed", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(&linodego.AccountSettings{
+						InterfacesForNewLinodes: linodego.LinodeDefaultButLegacyConfigAllowed,
+					}, nil)
+				}),
+				Result("permitted", func(ctx context.Context, mck Mock) {
+					ferr, err := validateInterfaceAccountSettings(ctx, mck.LinodeClient, true, false, path)
+					require.NoError(t, err)
+					assert.Nil(t, ferr)
+				}),
+			),
+			// GetAccountSettings returns an error.
+			Path(
+				Call("GetAccountSettings returns error", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().GetAccountSettings(gomock.Any()).Return(nil, errors.New("API error"))
+				}),
+				Result("wraps error", func(ctx context.Context, mck Mock) {
+					ferr, err := validateInterfaceAccountSettings(ctx, mck.LinodeClient, true, false, path)
+					require.Error(t, err)
+					require.ErrorContains(t, err, "failed to get customer account settings")
+					assert.Nil(t, ferr)
+				}),
+			),
+		),
+	)
+}

--- a/mock/client.go
+++ b/mock/client.go
@@ -412,6 +412,21 @@ func (mr *MockLinodeClientMockRecorder) DeleteVPCSubnet(ctx, vpcID, subnetID any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVPCSubnet", reflect.TypeOf((*MockLinodeClient)(nil).DeleteVPCSubnet), ctx, vpcID, subnetID)
 }
 
+// GetAccountSettings mocks base method.
+func (m *MockLinodeClient) GetAccountSettings(ctx context.Context) (*linodego.AccountSettings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccountSettings", ctx)
+	ret0, _ := ret[0].(*linodego.AccountSettings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAccountSettings indicates an expected call of GetAccountSettings.
+func (mr *MockLinodeClientMockRecorder) GetAccountSettings(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountSettings", reflect.TypeOf((*MockLinodeClient)(nil).GetAccountSettings), ctx)
+}
+
 // GetFirewall mocks base method.
 func (m *MockLinodeClient) GetFirewall(ctx context.Context, firewallID int) (*linodego.Firewall, error) {
 	m.ctrl.T.Helper()
@@ -2261,6 +2276,45 @@ func (m *MockLinodeInterfacesClient) ListInterfaces(ctx context.Context, linodeI
 func (mr *MockLinodeInterfacesClientMockRecorder) ListInterfaces(ctx, linodeID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInterfaces", reflect.TypeOf((*MockLinodeInterfacesClient)(nil).ListInterfaces), ctx, linodeID, opts)
+}
+
+// MockLinodeAccountSettingsClient is a mock of LinodeAccountSettingsClient interface.
+type MockLinodeAccountSettingsClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockLinodeAccountSettingsClientMockRecorder
+	isgomock struct{}
+}
+
+// MockLinodeAccountSettingsClientMockRecorder is the mock recorder for MockLinodeAccountSettingsClient.
+type MockLinodeAccountSettingsClientMockRecorder struct {
+	mock *MockLinodeAccountSettingsClient
+}
+
+// NewMockLinodeAccountSettingsClient creates a new mock instance.
+func NewMockLinodeAccountSettingsClient(ctrl *gomock.Controller) *MockLinodeAccountSettingsClient {
+	mock := &MockLinodeAccountSettingsClient{ctrl: ctrl}
+	mock.recorder = &MockLinodeAccountSettingsClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockLinodeAccountSettingsClient) EXPECT() *MockLinodeAccountSettingsClientMockRecorder {
+	return m.recorder
+}
+
+// GetAccountSettings mocks base method.
+func (m *MockLinodeAccountSettingsClient) GetAccountSettings(ctx context.Context) (*linodego.AccountSettings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccountSettings", ctx)
+	ret0, _ := ret[0].(*linodego.AccountSettings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAccountSettings indicates an expected call of GetAccountSettings.
+func (mr *MockLinodeAccountSettingsClientMockRecorder) GetAccountSettings(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountSettings", reflect.TypeOf((*MockLinodeAccountSettingsClient)(nil).GetAccountSettings), ctx)
 }
 
 // MockK8sClient is a mock of K8sClient interface.

--- a/observability/wrappers/linodeclient/linodeclient.gen.go
+++ b/observability/wrappers/linodeclient/linodeclient.gen.go
@@ -662,6 +662,30 @@ func (_d LinodeClientWithTracing) DeleteVPCSubnet(ctx context.Context, vpcID int
 	return _d.LinodeClient.DeleteVPCSubnet(ctx, vpcID, subnetID)
 }
 
+// GetAccountSettings implements _sourceClients.LinodeClient
+func (_d LinodeClientWithTracing) GetAccountSettings(ctx context.Context) (ap1 *linodego.AccountSettings, err error) {
+	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.GetAccountSettings")
+	defer func() {
+		if _d._spanDecorator != nil {
+			_d._spanDecorator(_span, map[string]interface{}{
+				"ctx": ctx}, map[string]interface{}{
+				"ap1": ap1,
+				"err": err})
+		}
+
+		if err != nil {
+			_span.RecordError(err)
+			_span.SetAttributes(
+				attribute.String("event", "error"),
+				attribute.String("message", err.Error()),
+			)
+		}
+
+		_span.End()
+	}()
+	return _d.LinodeClient.GetAccountSettings(ctx)
+}
+
 // GetFirewall implements _sourceClients.LinodeClient
 func (_d LinodeClientWithTracing) GetFirewall(ctx context.Context, firewallID int) (fp1 *linodego.Firewall, err error) {
 	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.GetFirewall")


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**:

- Validate if the customer's account settings for interfaces_for_new_linodes allows the customer to use Linode Interfaces 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] squashed commits
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


