### PR TITLE
[test][fix] Update DNS e2e test to 3 replicas, fix LFW patch for kube apiserver access for DNS-LB flavor

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -5,8 +5,8 @@ metadata:
   name: configuration
 spec:
   timeouts:
-    assert: 10m0s
+    assert: 20m0s
     cleanup: 5m0s
     delete: 5m0s
     error: 5m0s
-    exec: 20m0s # specifically for the DNS e2e test which is SLOW
+    exec: 5m0s

--- a/e2e/capl-cluster-flavors/kubeadm-dns-lb-cluster/assert-child-cluster-resources.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dns-lb-cluster/assert-child-cluster-resources.yaml
@@ -28,3 +28,21 @@ kind: KubeadmControlPlane
 metadata:
   labels:
     cluster.x-k8s.io/cluster-name: ($cluster)
+status:
+  readyReplicas: 3
+  availableReplicas: 3
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmReleaseProxy
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+  - type: ClusterAvailable
+    status: "True"
+  - type: HelmReleaseReady
+    status: "True"
+  status: deployed

--- a/e2e/capl-cluster-flavors/kubeadm-dns-lb-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dns-lb-cluster/chainsaw-test.yaml
@@ -50,7 +50,7 @@ spec:
               --kubernetes-version ${KUBERNETES_VERSION} \
               --infrastructure local-linode:v0.0.0 \
               --flavor kubeadm-dns-loadbalancing \
-              --control-plane-machine-count ${CONTROL_PLANE_MACHINE_COUNT:-1} --worker-machine-count 0 \
+              --control-plane-machine-count ${CONTROL_PLANE_MACHINE_COUNT:-3} --worker-machine-count 0 \
               --config ${CLUSTERCTL_CONFIG:=${HOME}/.cluster-api/clusterctl.yaml} > dns-lb-cluster.yaml
             check:
               ($error == null): true
@@ -91,14 +91,14 @@ spec:
               set -e
               count=0
               for _ in $(seq 1 40); do # cap at 20 minutes per exec timeout in .chainsaw.yaml
-                count=$(dig $CLUSTER_URL +short | wc -l | tr -d ' ')
+                count=$(dig @ns1.linode.com. $CLUSTER_URL +short | wc -l | tr -d ' ')
                 if [[ "$count" == "${CONTROL_PLANE_MACHINE_COUNT:-1}" ]]; then
                   exit 0
                 fi
                 sleep 30
               done
 
-              echo "expected ${CONTROL_PLANE_MACHINE_COUNT:-1} records, got ${count:-0}"
+              echo "expected ${CONTROL_PLANE_MACHINE_COUNT:-3} records, got ${count:-0}"
               exit 1
             check:
               ($error == null): true

--- a/e2e/capl-cluster-flavors/kubeadm-dns-lb-cluster/chainsaw-test.yaml
+++ b/e2e/capl-cluster-flavors/kubeadm-dns-lb-cluster/chainsaw-test.yaml
@@ -90,7 +90,7 @@ spec:
             content: |
               set -e
               count=0
-              for _ in $(seq 1 40); do # cap at 20 minutes per exec timeout in .chainsaw.yaml
+              for _ in $(seq 1 10); do # cap at 5 minutes per exec timeout in .chainsaw.yaml
                 count=$(dig @ns1.linode.com. $CLUSTER_URL +short | wc -l | tr -d ' ')
                 if [[ "$count" == "${CONTROL_PLANE_MACHINE_COUNT:-1}" ]]; then
                   exit 0

--- a/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
+++ b/templates/flavors/kubeadm/dns-loadbalancing/kustomization.yaml
@@ -27,7 +27,6 @@ patches:
       group: infrastructure.cluster.x-k8s.io
       version: v1alpha2
       kind: LinodeFirewall
-      name: ${CLUSTER_NAME}
     patch: |-
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
       kind: LinodeFirewall


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: 

The reason 3-replica DNS-LB e2e tests were timing out was because of issues with the default LFW not being patched correctly to update the rules for the NBless-specific configuration.

This change fixes the kustomize patch and updates the DNS test to use 3 replicas for the control plane.

Chainsaw timeouts have been adjusted accordingly (takes a long time for a 3-replica kubeadm control plane to come up since nodes have to be added serially).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests


