### PR TITLE
[feat] support bring your own placement group for linodeMachines

### DIFF
--- a/api/v1alpha2/linodemachine_types.go
+++ b/api/v1alpha2/linodemachine_types.go
@@ -154,6 +154,12 @@ type LinodeMachineSpec struct {
 	// +optional
 	PlacementGroupRef *corev1.ObjectReference `json:"placementGroupRef,omitempty"`
 
+	// placementGroupID is the ID of an existing placement group to associate with the Linode instance.
+	// It takes precedence over placementGroupRef when both are set.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	PlacementGroupID int `json:"placementGroupID,omitempty"`
+
 	// firewallRef is a reference to a firewall object. This makes the linode use the specified firewall.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	// +optional

--- a/api/v1alpha2/linodemachinetemplate_types.go
+++ b/api/v1alpha2/linodemachinetemplate_types.go
@@ -46,6 +46,10 @@ type LinodeMachineTemplateStatus struct {
 	// firewallID that is currently applied to the LinodeMachineTemplate.
 	// +optional
 	FirewallID int `json:"firewallID,omitempty"`
+
+	// placementGroupID that is currently associated with the LinodeMachineTemplate
+	// +optional
+	PlacementGroupID int `json:"placementGroupID,omitempty"`
 }
 
 // LinodeMachineTemplateResource describes the data needed to create a LinodeMachine from a template.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachines.yaml
@@ -792,6 +792,12 @@ spec:
                 required:
                 - size
                 type: object
+              placementGroupID:
+                description: |-
+                  placementGroupID is the ID of an existing placement group to associate with the Linode instance.
+                  It takes precedence over placementGroupRef when both are set.
+                minimum: 1
+                type: integer
               placementGroupRef:
                 description: placementGroupRef is a reference to a placement group
                   object. This makes the linode to be launched in that specific group.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_linodemachinetemplates.yaml
@@ -813,6 +813,12 @@ spec:
                         required:
                         - size
                         type: object
+                      placementGroupID:
+                        description: |-
+                          placementGroupID is the ID of an existing placement group to associate with the Linode instance.
+                          It takes precedence over placementGroupRef when both are set.
+                        minimum: 1
+                        type: integer
                       placementGroupRef:
                         description: placementGroupRef is a reference to a placement
                           group object. This makes the linode to be launched in that
@@ -1030,6 +1036,10 @@ spec:
                 x-kubernetes-list-type: map
               firewallID:
                 description: firewallID that is currently applied to the LinodeMachineTemplate.
+                type: integer
+              placementGroupID:
+                description: placementGroupID that is currently associated with the
+                  LinodeMachineTemplate
                 type: integer
               tags:
                 description: tags that are currently applied to the LinodeMachineTemplate.

--- a/docs/src/reference/out.md
+++ b/docs/src/reference/out.md
@@ -701,6 +701,7 @@ _Appears in:_
 | `credentialsRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#secretreference-v1-core)_ | credentialsRef is a reference to a Secret that contains the credentials<br />to use for provisioning this machine. If not supplied then these<br />credentials will be used in-order:<br />  1. LinodeMachine<br />  2. Owner LinodeCluster<br />  3. Controller |  | Optional: \{\} <br /> |
 | `configuration` _[InstanceConfiguration](#instanceconfiguration)_ | configuration is the Akamai instance configuration OS,<br />if not specified, this defaults to the default configuration associated to the instance. |  | Optional: \{\} <br /> |
 | `placementGroupRef` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core)_ | placementGroupRef is a reference to a placement group object. This makes the linode to be launched in that specific group. |  | Optional: \{\} <br /> |
+| `placementGroupID` _integer_ | placementGroupID is the ID of an existing placement group to associate with the Linode instance.<br />It takes precedence over placementGroupRef when both are set. |  | Minimum: 1 <br />Optional: \{\} <br /> |
 | `firewallRef` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core)_ | firewallRef is a reference to a firewall object. This makes the linode use the specified firewall. |  | Optional: \{\} <br /> |
 | `vpcRef` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectreference-v1-core)_ | vpcRef is a reference to a LinodeVPC resource. If specified, this takes precedence over<br />the cluster-level VPC configuration for multi-region support. |  | Optional: \{\} <br /> |
 | `vpcID` _integer_ | vpcID is the ID of an existing VPC in Linode. This allows using a VPC that is not managed by CAPL. |  | Optional: \{\} <br /> |
@@ -823,6 +824,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) array_ | conditions define the current service state of the LinodeMachineTemplate |  | Optional: \{\} <br /> |
 | `tags` _string array_ | tags that are currently applied to the LinodeMachineTemplate. |  | Optional: \{\} <br /> |
 | `firewallID` _integer_ | firewallID that is currently applied to the LinodeMachineTemplate. |  | Optional: \{\} <br /> |
+| `placementGroupID` _integer_ | placementGroupID that is currently associated with the LinodeMachineTemplate |  | Optional: \{\} <br /> |
 
 
 #### LinodeNBPortConfig

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/assert-capi-resources.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/assert-capi-resources.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-controller-manager
+  namespace: capi-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capl-controller-manager
+  namespace: capl-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+status:
+  availableReplicas: 1

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/assert-capi-resources.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/assert-capi-resources.yaml
@@ -13,19 +13,3 @@ metadata:
   namespace: capl-system
 status:
   availableReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: capi-kubeadm-bootstrap-controller-manager
-  namespace: capi-kubeadm-bootstrap-system
-status:
-  availableReplicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: capi-kubeadm-control-plane-controller-manager
-  namespace: capi-kubeadm-control-plane-system
-status:
-  availableReplicas: 1

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/assert-linodemachine.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/assert-linodemachine.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachine
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ($cluster)
+spec:
+  region: us-sea
+  type: g6-nanode-1
+status:
+  ready: true
+  instanceState: running

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/assert-placementgroup.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/assert-placementgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodePlacementGroup
+metadata:
+  name: ($placementgroup)
+spec:
+  region: us-sea
+status:
+  ready: true

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
@@ -58,6 +58,9 @@ spec:
                 value: ($placementgroup)
               - name: NAMESPACE
                 value: ($namespace)
+            shell: bash
+            shellArgs:
+              - -c
             content: |
               set -eu
 
@@ -71,7 +74,7 @@ spec:
               RETRY_DELAY=5
               ATTEMPT=1
 
-              while true; do
+              for _ in $(seq 1 36); do
                 MACHINE_JSON=$(kubectl get linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o json)
                 MACHINE_PLACEMENT_GROUP_ID=$(echo "$MACHINE_JSON" | jq -r '.items[0].spec.placementGroupID // empty')
                 TEMPLATE_PLACEMENT_GROUP_ID=$(kubectl get linodemachinetemplate -n "$NAMESPACE" "$CLUSTER_NAME" -o jsonpath='{.status.placementGroupID}')

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
@@ -56,13 +56,15 @@ spec:
                 value: ($cluster)
               - name: PLACEMENT_GROUP_NAME
                 value: ($placementgroup)
+              - name: NAMESPACE
+                value: ($namespace)
             content: |
               set -eu
 
-              PLACEMENT_GROUP_ID=$(kubectl get linodeplacementgroup "$PLACEMENT_GROUP_NAME" -o jsonpath='{.spec.pgID}')
+              PLACEMENT_GROUP_ID=$(kubectl get linodeplacementgroup "$PLACEMENT_GROUP_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.pgID}')
               test -n "$PLACEMENT_GROUP_ID"
 
-              kubectl patch linodemachinetemplate "$CLUSTER_NAME" --type merge \
+              kubectl patch linodemachinetemplate "$CLUSTER_NAME" -n "$NAMESPACE" --type merge \
                 -p "{\"spec\":{\"template\":{\"spec\":{\"placementGroupID\":$PLACEMENT_GROUP_ID}}}}"
 
               MAX_RETRIES=36
@@ -70,9 +72,9 @@ spec:
               ATTEMPT=1
 
               while true; do
-                MACHINE_JSON=$(kubectl get linodemachine -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o json)
+                MACHINE_JSON=$(kubectl get linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o json)
                 MACHINE_PLACEMENT_GROUP_ID=$(echo "$MACHINE_JSON" | jq -r '.items[0].spec.placementGroupID // empty')
-                TEMPLATE_PLACEMENT_GROUP_ID=$(kubectl get linodemachinetemplate "$CLUSTER_NAME" -o jsonpath='{.status.placementGroupID}')
+                TEMPLATE_PLACEMENT_GROUP_ID=$(kubectl get linodemachinetemplate -n "$NAMESPACE" "$CLUSTER_NAME" -o jsonpath='{.status.placementGroupID}')
                 INSTANCE_ID=$(echo "$MACHINE_JSON" | jq -r '.items[0].spec.providerID // empty' | sed 's#linode://##')
 
                 RESPONSE=$(curl -sS \

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
@@ -1,0 +1,114 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: byo-placement-group
+  labels:
+    all:
+    linodemachine:
+    linodeplacementgroup:
+spec:
+  bindings:
+    - name: run
+      value: (join('-', ['e2e', 'byo-pg', random('[0-9a-z]{5}')]))
+    - name: cluster
+      value: (trim((truncate(($run), `29`)), '-'))
+    - name: placementgroup
+      value: (trim((truncate((join('-', [($run), 'pg'])), `63`)), '-'))
+  template: true
+  steps:
+    - name: Check if CAPI provider resources exist
+      try:
+        - assert:
+            file: assert-capi-resources.yaml
+    - name: Create bring-your-own placement group
+      try:
+        - apply:
+            file: create-placementgroup.yaml
+        - assert:
+            file: assert-placementgroup.yaml
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodePlacementGroup
+    - name: Create cluster without a placement group
+      try:
+        - apply:
+            file: create-cluster.yaml
+        - assert:
+            file: assert-linodemachine.yaml
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachineTemplate
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachine
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 250
+    - name: Assign the running machine using the placement group ID
+      try:
+        - script:
+            env:
+              - name: CLUSTER_NAME
+                value: ($cluster)
+              - name: PLACEMENT_GROUP_NAME
+                value: ($placementgroup)
+            content: |
+              set -eu
+
+              PLACEMENT_GROUP_ID=$(kubectl get linodeplacementgroup "$PLACEMENT_GROUP_NAME" -o jsonpath='{.spec.pgID}')
+              test -n "$PLACEMENT_GROUP_ID"
+
+              kubectl patch linodemachinetemplate "$CLUSTER_NAME" --type merge \
+                -p "{\"spec\":{\"template\":{\"spec\":{\"placementGroupID\":$PLACEMENT_GROUP_ID}}}}"
+
+              MAX_RETRIES=36
+              RETRY_DELAY=5
+              ATTEMPT=1
+
+              while true; do
+                MACHINE_JSON=$(kubectl get linodemachine -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o json)
+                MACHINE_PLACEMENT_GROUP_ID=$(echo "$MACHINE_JSON" | jq -r '.items[0].spec.placementGroupID // empty')
+                TEMPLATE_PLACEMENT_GROUP_ID=$(kubectl get linodemachinetemplate "$CLUSTER_NAME" -o jsonpath='{.status.placementGroupID}')
+                INSTANCE_ID=$(echo "$MACHINE_JSON" | jq -r '.items[0].spec.providerID // empty' | sed 's#linode://##')
+
+                RESPONSE=$(curl -sS \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4beta/placement/groups/$PLACEMENT_GROUP_ID")
+
+                if [ "$MACHINE_PLACEMENT_GROUP_ID" = "$PLACEMENT_GROUP_ID" ] && \
+                   [ "$TEMPLATE_PLACEMENT_GROUP_ID" = "$PLACEMENT_GROUP_ID" ] && \
+                   echo "$RESPONSE" | jq -e --argjson instanceID "$INSTANCE_ID" \
+                     '.members | any(.linode_id == $instanceID)' >/dev/null; then
+                  break
+                fi
+
+                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
+                  echo "$MACHINE_JSON"
+                  echo "$RESPONSE"
+                  exit 1
+                fi
+
+                ATTEMPT=$((ATTEMPT + 1))
+                sleep "$RETRY_DELAY"
+              done
+            check:
+              ($error): ~
+      catch:
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachineTemplate
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodeMachine
+        - describe:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+            kind: LinodePlacementGroup
+        - podLogs:
+            namespace: capl-system
+            selector: control-plane=controller-manager
+            tail: 250

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/chainsaw-test.yaml
@@ -69,11 +69,8 @@ spec:
 
               kubectl patch linodemachinetemplate "$CLUSTER_NAME" -n "$NAMESPACE" --type merge \
                 -p "{\"spec\":{\"template\":{\"spec\":{\"placementGroupID\":$PLACEMENT_GROUP_ID}}}}"
-
-              MAX_RETRIES=36
               RETRY_DELAY=5
-              ATTEMPT=1
-
+              RESPONSE=""
               for _ in $(seq 1 36); do
                 MACHINE_JSON=$(kubectl get linodemachine -n "$NAMESPACE" -l "cluster.x-k8s.io/cluster-name=$CLUSTER_NAME" -o json)
                 MACHINE_PLACEMENT_GROUP_ID=$(echo "$MACHINE_JSON" | jq -r '.items[0].spec.placementGroupID // empty')
@@ -89,18 +86,13 @@ spec:
                    [ "$TEMPLATE_PLACEMENT_GROUP_ID" = "$PLACEMENT_GROUP_ID" ] && \
                    echo "$RESPONSE" | jq -e --argjson instanceID "$INSTANCE_ID" \
                      '.members | any(.linode_id == $instanceID)' >/dev/null; then
-                  break
+                  exit 0
                 fi
-
-                if [ "$ATTEMPT" -ge "$MAX_RETRIES" ]; then
-                  echo "$MACHINE_JSON"
-                  echo "$RESPONSE"
-                  exit 1
-                fi
-
-                ATTEMPT=$((ATTEMPT + 1))
                 sleep "$RETRY_DELAY"
               done
+              echo "$MACHINE_JSON"
+              echo "$RESPONSE"
+              exit 1
             check:
               ($error): ~
       catch:

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/create-cluster.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/create-cluster.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ($cluster)
+spec:
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: ($cluster)
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: LinodeCluster
+    name: ($cluster)
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeCluster
+metadata:
+  name: ($cluster)
+spec:
+  region: us-sea
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ($cluster)
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      controllerManager:
+        extraArgs:
+          - name: cloud-provider
+            value: external
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: LinodeMachineTemplate
+        name: ($cluster)
+  replicas: 1
+  version: 1.33.4
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodeMachineTemplate
+metadata:
+  name: ($cluster)
+spec:
+  template:
+    spec:
+      region: us-sea
+      type: g6-nanode-1

--- a/e2e/linodemachinetemplate-controller/byo-placement-group/create-placementgroup.yaml
+++ b/e2e/linodemachinetemplate-controller/byo-placement-group/create-placementgroup.yaml
@@ -1,0 +1,6 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: LinodePlacementGroup
+metadata:
+  name: ($placementgroup)
+spec:
+  region: us-sea

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -786,8 +786,8 @@ func (r *LinodeMachineReconciler) reconcileUpdate(ctx context.Context, logger lo
 		return res, err
 	}
 
-	if res, err := r.reconcilePlacementGroup(ctx, logger, machineScope, linodeInstance); err != nil || !res.IsZero() {
-		return res, err
+	if err := r.reconcilePlacementGroup(ctx, logger, machineScope, linodeInstance); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Clean up bootstrap data after instance creation.
@@ -800,13 +800,13 @@ func (r *LinodeMachineReconciler) reconcileUpdate(ctx context.Context, logger lo
 	return ctrl.Result{}, nil
 }
 
-func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, linodeInstance *linodego.Instance) (ctrl.Result, error) {
+func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, linodeInstance *linodego.Instance) error {
 	desiredPlacementGroupID := machineScope.LinodeMachine.Spec.PlacementGroupID
 	if desiredPlacementGroupID == 0 && machineScope.LinodeMachine.Spec.PlacementGroupRef != nil {
 		var err error
 		desiredPlacementGroupID, err = getPlacementGroupID(ctx, machineScope, logger)
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
@@ -816,30 +816,36 @@ func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, l
 	}
 
 	if desiredPlacementGroupID == currentPlacementGroupID {
-		return ctrl.Result{}, nil
+		return nil
 	}
 
 	if currentPlacementGroupID != 0 {
 		if _, err := machineScope.LinodeClient.UnassignPlacementGroupLinodes(ctx, currentPlacementGroupID, linodego.PlacementGroupUnAssignOptions{Linodes: []int{linodeInstance.ID}}); err != nil {
 			logger.Error(err, "Failed to unassign placement group linode", "linodeID", linodeInstance.ID, "placementGroupID", currentPlacementGroupID)
-			return ctrl.Result{}, err
+			return err
 		}
 	}
 
-	if desiredPlacementGroupID != 0 {
-		if _, err := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, desiredPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}}); err != nil {
-			logger.Error(err, "Failed to assign placement group linode", "linodeID", linodeInstance.ID, "placementGroupID", desiredPlacementGroupID)
-			if currentPlacementGroupID != 0 {
-				if _, rollbackErr := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, currentPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}}); rollbackErr != nil {
-					logger.Error(rollbackErr, "Failed to restore original placement group", "linodeID", linodeInstance.ID, "placementGroupID", currentPlacementGroupID)
-					return ctrl.Result{}, errors.Join(err, rollbackErr)
-				}
-			}
-			return ctrl.Result{}, err
-		}
+	if desiredPlacementGroupID == 0 {
+		return nil
 	}
 
-	return ctrl.Result{}, nil
+	_, err := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, desiredPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}})
+	if err == nil {
+		return nil
+	}
+
+	logger.Error(err, "Failed to assign placement group linode", "linodeID", linodeInstance.ID, "placementGroupID", desiredPlacementGroupID)
+	if currentPlacementGroupID == 0 {
+		return err
+	}
+
+	if _, rollbackErr := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, currentPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}}); rollbackErr != nil {
+		logger.Error(rollbackErr, "Failed to restore original placement group", "linodeID", linodeInstance.ID, "placementGroupID", currentPlacementGroupID)
+		return errors.Join(err, rollbackErr)
+	}
+
+	return err
 }
 
 func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -786,10 +786,56 @@ func (r *LinodeMachineReconciler) reconcileUpdate(ctx context.Context, logger lo
 		return res, err
 	}
 
+	if res, err := r.reconcilePlacementGroup(ctx, logger, machineScope, linodeInstance); err != nil || !res.IsZero() {
+		return res, err
+	}
+
 	// Clean up bootstrap data after instance creation.
 	if linodeInstance.Status == linodego.InstanceRunning && machineScope.Machine.Status.Phase == "Running" {
 		if err := deleteBootstrapData(ctx, machineScope); err != nil {
 			logger.Error(err, "Fail to delete bootstrap data")
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, linodeInstance *linodego.Instance) (ctrl.Result, error) {
+	desiredPlacementGroupID := machineScope.LinodeMachine.Spec.PlacementGroupID
+	if desiredPlacementGroupID == 0 && machineScope.LinodeMachine.Spec.PlacementGroupRef != nil {
+		var err error
+		desiredPlacementGroupID, err = getPlacementGroupID(ctx, machineScope, logger)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	currentPlacementGroupID := 0
+	if linodeInstance.PlacementGroup != nil {
+		currentPlacementGroupID = linodeInstance.PlacementGroup.ID
+	}
+
+	if desiredPlacementGroupID == currentPlacementGroupID {
+		return ctrl.Result{}, nil
+	}
+
+	if currentPlacementGroupID != 0 {
+		if _, err := machineScope.LinodeClient.UnassignPlacementGroupLinodes(ctx, currentPlacementGroupID, linodego.PlacementGroupUnAssignOptions{Linodes: []int{linodeInstance.ID}}); err != nil {
+			logger.Error(err, "Failed to unassign placement group linode", "linodeID", linodeInstance.ID, "placementGroupID", currentPlacementGroupID)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if desiredPlacementGroupID != 0 {
+		if _, err := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, desiredPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}}); err != nil {
+			logger.Error(err, "Failed to assign placement group linode", "linodeID", linodeInstance.ID, "placementGroupID", desiredPlacementGroupID)
+			if currentPlacementGroupID != 0 {
+				if _, rollbackErr := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, currentPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}}); rollbackErr != nil {
+					logger.Error(rollbackErr, "Failed to restore original placement group", "linodeID", linodeInstance.ID, "placementGroupID", currentPlacementGroupID)
+					return ctrl.Result{}, errors.Join(err, rollbackErr)
+				}
+			}
+			return ctrl.Result{}, err
 		}
 	}
 

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -836,15 +836,6 @@ func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, l
 	}
 
 	logger.Error(err, "Failed to assign placement group linode", "linodeID", linodeInstance.ID, "placementGroupID", desiredPlacementGroupID)
-	if currentPlacementGroupID == 0 {
-		return err
-	}
-
-	if _, rollbackErr := machineScope.LinodeClient.AssignPlacementGroupLinodes(ctx, currentPlacementGroupID, linodego.PlacementGroupAssignOptions{Linodes: []int{linodeInstance.ID}}); rollbackErr != nil {
-		logger.Error(rollbackErr, "Failed to restore original placement group", "linodeID", linodeInstance.ID, "placementGroupID", currentPlacementGroupID)
-		return errors.Join(err, rollbackErr)
-	}
-
 	return err
 }
 

--- a/internal/controller/linodemachine_controller_helpers.go
+++ b/internal/controller/linodemachine_controller_helpers.go
@@ -173,7 +173,7 @@ func newCreateConfig(ctx context.Context, machineScope *scope.MachineScope, gzip
 	}
 
 	// Configure placement group if needed
-	if machineScope.LinodeMachine.Spec.PlacementGroupRef != nil {
+	if machineScope.LinodeMachine.Spec.PlacementGroupID != 0 || machineScope.LinodeMachine.Spec.PlacementGroupRef != nil {
 		if err := configurePlacementGroup(ctx, machineScope, createConfig, logger); err != nil {
 			return nil, err
 		}
@@ -1558,6 +1558,13 @@ func configureVlanInterface(ctx context.Context, machineScope *scope.MachineScop
 
 // configurePlacementGroup adds placement group configuration
 func configurePlacementGroup(ctx context.Context, machineScope *scope.MachineScope, createConfig *linodego.InstanceCreateOptions, logger logr.Logger) error {
+	if machineScope.LinodeMachine.Spec.PlacementGroupID != 0 {
+		createConfig.PlacementGroup = &linodego.InstanceCreatePlacementGroupOptions{
+			ID: machineScope.LinodeMachine.Spec.PlacementGroupID,
+		}
+		return nil
+	}
+
 	pgID, err := getPlacementGroupID(ctx, machineScope, logger)
 	if err != nil {
 		logger.Error(err, "Failed to get Placement Group config")

--- a/internal/controller/linodemachine_placement_group_test.go
+++ b/internal/controller/linodemachine_placement_group_test.go
@@ -32,7 +32,6 @@ func TestReconcilePlacementGroup(t *testing.T) {
 		expectedAssignGroupID   int
 		unassignErr             error
 		assignErr               error
-		rollbackErr             error
 	}{
 		{name: "no placement group"},
 		{name: "already assigned", desiredID: 10, currentID: 10},
@@ -48,10 +47,19 @@ func TestReconcilePlacementGroup(t *testing.T) {
 			},
 			currentID: 10,
 		},
+		{
+			name:      "direct ID takes precedence over placement group reference",
+			desiredID: 10,
+			placementGroupRef: &infrav1alpha2.LinodePlacementGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "managed", Namespace: "default"},
+				Spec:       infrav1alpha2.LinodePlacementGroupSpec{PGID: ptr.To(20)},
+				Status:     infrav1alpha2.LinodePlacementGroupStatus{Ready: true},
+			},
+			currentID: 10,
+		},
 		{name: "returns unassign error", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, unassignErr: errors.New("unassign failed")},
 		{name: "returns assign error", desiredID: 10, expectedAssignGroupID: 10, assignErr: errors.New("assign failed")},
-		{name: "restores original group after move fails", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, expectedAssignGroupID: 10, assignErr: errors.New("assign failed")},
-		{name: "returns assignment and rollback errors", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, expectedAssignGroupID: 10, assignErr: errors.New("assign failed"), rollbackErr: errors.New("rollback failed")},
+		{name: "returns assign error after unassigning original group", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, expectedAssignGroupID: 10, assignErr: errors.New("assign failed")},
 	}
 
 	for _, tt := range tests {
@@ -101,13 +109,6 @@ func TestReconcilePlacementGroup(t *testing.T) {
 				).Return(nil, tt.assignErr)
 				if unassignCall != nil {
 					assignCall.After(unassignCall)
-				}
-				if tt.assignErr != nil && tt.currentID != 0 {
-					linodeClient.EXPECT().AssignPlacementGroupLinodes(
-						gomock.Any(),
-						tt.currentID,
-						linodego.PlacementGroupAssignOptions{Linodes: []int{100}},
-					).Return(nil, tt.rollbackErr).After(assignCall)
 				}
 			}
 

--- a/internal/controller/linodemachine_placement_group_test.go
+++ b/internal/controller/linodemachine_placement_group_test.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/linode/linodego/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
+	"github.com/linode/cluster-api-provider-linode/cloud/scope"
+	"github.com/linode/cluster-api-provider-linode/mock"
+)
+
+func TestReconcilePlacementGroup(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		desiredID               int
+		currentID               int
+		placementGroupRef       *infrav1alpha2.LinodePlacementGroup
+		expectedUnassignGroupID int
+		expectedAssignGroupID   int
+		unassignErr             error
+		assignErr               error
+		rollbackErr             error
+	}{
+		{name: "no placement group"},
+		{name: "already assigned", desiredID: 10, currentID: 10},
+		{name: "assigns ungrouped instance", desiredID: 10, expectedAssignGroupID: 10},
+		{name: "moves instance", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, expectedAssignGroupID: 10},
+		{name: "removes instance", currentID: 5, expectedUnassignGroupID: 5},
+		{
+			name: "resolves placement group reference",
+			placementGroupRef: &infrav1alpha2.LinodePlacementGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "managed", Namespace: "default"},
+				Spec:       infrav1alpha2.LinodePlacementGroupSpec{PGID: ptr.To(10)},
+				Status:     infrav1alpha2.LinodePlacementGroupStatus{Ready: true},
+			},
+			currentID: 10,
+		},
+		{name: "returns unassign error", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, unassignErr: errors.New("unassign failed")},
+		{name: "returns assign error", desiredID: 10, expectedAssignGroupID: 10, assignErr: errors.New("assign failed")},
+		{name: "restores original group after move fails", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, expectedAssignGroupID: 10, assignErr: errors.New("assign failed")},
+		{name: "returns assignment and rollback errors", desiredID: 10, currentID: 5, expectedUnassignGroupID: 5, expectedAssignGroupID: 10, assignErr: errors.New("assign failed"), rollbackErr: errors.New("rollback failed")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			linodeClient := mock.NewMockLinodeClient(ctrl)
+			machineScope := &scope.MachineScope{
+				LinodeClient: linodeClient,
+				LinodeMachine: &infrav1alpha2.LinodeMachine{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+					Spec: infrav1alpha2.LinodeMachineSpec{
+						PlacementGroupID: tt.desiredID,
+					},
+				},
+			}
+
+			if tt.placementGroupRef != nil {
+				scheme := runtime.NewScheme()
+				require.NoError(t, infrav1alpha2.AddToScheme(scheme))
+				machineScope.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.placementGroupRef).Build()
+				machineScope.LinodeMachine.Spec.PlacementGroupRef = &corev1.ObjectReference{
+					Name:      tt.placementGroupRef.Name,
+					Namespace: tt.placementGroupRef.Namespace,
+				}
+			}
+
+			instance := &linodego.Instance{ID: 100}
+			if tt.currentID != 0 {
+				instance.PlacementGroup = &linodego.InstancePlacementGroup{ID: tt.currentID}
+			}
+
+			var unassignCall *gomock.Call
+			if tt.expectedUnassignGroupID != 0 {
+				unassignCall = linodeClient.EXPECT().UnassignPlacementGroupLinodes(
+					gomock.Any(),
+					tt.expectedUnassignGroupID,
+					linodego.PlacementGroupUnAssignOptions{Linodes: []int{100}},
+				).Return(nil, tt.unassignErr)
+			}
+			if tt.expectedAssignGroupID != 0 && tt.unassignErr == nil {
+				assignCall := linodeClient.EXPECT().AssignPlacementGroupLinodes(
+					gomock.Any(),
+					tt.expectedAssignGroupID,
+					linodego.PlacementGroupAssignOptions{Linodes: []int{100}},
+				).Return(nil, tt.assignErr)
+				if unassignCall != nil {
+					assignCall.After(unassignCall)
+				}
+				if tt.assignErr != nil && tt.currentID != 0 {
+					linodeClient.EXPECT().AssignPlacementGroupLinodes(
+						gomock.Any(),
+						tt.currentID,
+						linodego.PlacementGroupAssignOptions{Linodes: []int{100}},
+					).Return(nil, tt.rollbackErr).After(assignCall)
+				}
+			}
+
+			_, err := (&LinodeMachineReconciler{}).reconcilePlacementGroup(context.Background(), logr.Discard(), machineScope, instance)
+			if tt.unassignErr != nil || tt.assignErr != nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfigurePlacementGroupWithDirectID(t *testing.T) {
+	t.Parallel()
+
+	createConfig := &linodego.InstanceCreateOptions{}
+	machineScope := &scope.MachineScope{
+		LinodeMachine: &infrav1alpha2.LinodeMachine{
+			Spec: infrav1alpha2.LinodeMachineSpec{PlacementGroupID: 10},
+		},
+	}
+
+	require.NoError(t, configurePlacementGroup(context.Background(), machineScope, createConfig, logr.Discard()))
+	require.NotNil(t, createConfig.PlacementGroup)
+	require.Equal(t, 10, createConfig.PlacementGroup.ID)
+}

--- a/internal/controller/linodemachine_placement_group_test.go
+++ b/internal/controller/linodemachine_placement_group_test.go
@@ -111,7 +111,7 @@ func TestReconcilePlacementGroup(t *testing.T) {
 				}
 			}
 
-			_, err := (&LinodeMachineReconciler{}).reconcilePlacementGroup(context.Background(), logr.Discard(), machineScope, instance)
+			err := (&LinodeMachineReconciler{}).reconcilePlacementGroup(context.Background(), logr.Discard(), machineScope, instance)
 			if tt.unassignErr != nil || tt.assignErr != nil {
 				require.Error(t, err)
 			} else {

--- a/internal/controller/linodemachinetemplate_controller.go
+++ b/internal/controller/linodemachinetemplate_controller.go
@@ -125,20 +125,33 @@ func (lmtr *LinodeMachineTemplateReconciler) reconcile(ctx context.Context, lmtS
 		}
 
 		machinesFoundForTemplate = true
-		if !slices.Equal(lmtScope.LinodeMachineTemplate.Spec.Template.Spec.Tags, lmtScope.LinodeMachineTemplate.Status.Tags) {
-			err := lmtr.reconcileTags(ctx, lmtScope.LinodeMachineTemplate, &machine)
-			if err != nil {
-				lmtr.Logger.Error(err, "Failed to update tags on LinodeMachine", "template", lmtScope.LinodeMachineTemplate.Name, "machine", machine.Name)
-				outErr = errors.Join(outErr, err)
-				failureReason = "FailedToPatchLinodeMachine"
-				return ctrl.Result{}, outErr
-			}
+		helper, err := patch.NewHelper(&machine, lmtr.Client)
+		if err != nil {
+			lmtr.Logger.Error(err, "Failed to initialize patch helper", "template", lmtScope.LinodeMachineTemplate.Name, "machine", machine.Name)
+			outErr = errors.Join(outErr, err)
+			failureReason = "FailedToPatchLinodeMachine"
+			return ctrl.Result{}, outErr
+		}
+		patchMachine := false
+
+		if !slices.Equal(lmtScope.LinodeMachineTemplate.Spec.Template.Spec.Tags, machine.Spec.Tags) {
+			machine.Spec.Tags = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.Tags
+			patchMachine = true
 		}
 
-		if lmtScope.LinodeMachineTemplate.Spec.Template.Spec.FirewallID != lmtScope.LinodeMachineTemplate.Status.FirewallID {
-			err := lmtr.reconcileFirewallID(ctx, lmtScope.LinodeMachineTemplate, &machine)
-			if err != nil {
-				lmtr.Logger.Error(err, "Failed to update FirewallID on LinodeMachine", "template", lmtScope.LinodeMachineTemplate.Name, "machine", machine.Name)
+		if lmtScope.LinodeMachineTemplate.Spec.Template.Spec.FirewallID != machine.Spec.FirewallID {
+			machine.Spec.FirewallID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.FirewallID
+			patchMachine = true
+		}
+
+		if lmtScope.LinodeMachineTemplate.Spec.Template.Spec.PlacementGroupID != machine.Spec.PlacementGroupID {
+			machine.Spec.PlacementGroupID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.PlacementGroupID
+			patchMachine = true
+		}
+
+		if patchMachine {
+			if err := helper.Patch(ctx, &machine); err != nil {
+				lmtr.Logger.Error(err, "Failed to patch linodeMachine", "template", lmtScope.LinodeMachineTemplate.Name, "machine", machine.Name)
 				outErr = errors.Join(outErr, err)
 				failureReason = "FailedToPatchLinodeMachine"
 				return ctrl.Result{}, outErr
@@ -155,38 +168,12 @@ func (lmtr *LinodeMachineTemplateReconciler) reconcile(ctx context.Context, lmtS
 	if outErr == nil {
 		lmtScope.LinodeMachineTemplate.Status.Tags = slices.Clone(lmtScope.LinodeMachineTemplate.Spec.Template.Spec.Tags)
 		lmtScope.LinodeMachineTemplate.Status.FirewallID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.FirewallID
+		lmtScope.LinodeMachineTemplate.Status.PlacementGroupID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.PlacementGroupID
 		lmtr.Logger.Info("Successfully reconciled LinodeMachineTemplate", "name", lmtScope.LinodeMachineTemplate.Name)
 	} else {
 		lmtr.Logger.Error(outErr, "Error in reconciling LinodeMachineTemplate, retrying..", "name", lmtScope.LinodeMachineTemplate.Name)
 	}
 	return ctrl.Result{}, outErr
-}
-
-func (lmtr *LinodeMachineTemplateReconciler) reconcileTags(ctx context.Context, lmt *infrav1alpha2.LinodeMachineTemplate, machine *infrav1alpha2.LinodeMachine) error {
-	helper, err := patch.NewHelper(machine, lmtr.Client)
-	if err != nil {
-		return fmt.Errorf("failed to init patch helper: %w", err)
-	}
-
-	machine.Spec.Tags = lmt.Spec.Template.Spec.Tags
-	if err := helper.Patch(ctx, machine); err != nil {
-		return fmt.Errorf("failed to patch LinodeMachine %s with new tags: %w", machine.Name, err)
-	}
-	lmtr.Logger.Info("Patched LinodeMachine with new tags", "machine", machine.Name, "tags", lmt.Spec.Template.Spec.Tags)
-
-	return nil
-}
-
-func (lmtr *LinodeMachineTemplateReconciler) reconcileFirewallID(ctx context.Context, lmt *infrav1alpha2.LinodeMachineTemplate, machine *infrav1alpha2.LinodeMachine) error {
-	helper, err := patch.NewHelper(machine, lmtr.Client)
-	if err != nil {
-		return fmt.Errorf("failed to init patch helper: %w", err)
-	}
-	machine.Spec.FirewallID = lmt.Spec.Template.Spec.FirewallID
-	if err := helper.Patch(ctx, machine); err != nil {
-		return fmt.Errorf("failed to patch LinodeMachine %s with new firewallID: %w", machine.Name, err)
-	}
-	return nil
 }
 
 func (lmtr *LinodeMachineTemplateReconciler) SetupWithManager(mgr ctrl.Manager, options crcontroller.Options) error {

--- a/internal/controller/linodemachinetemplate_controller.go
+++ b/internal/controller/linodemachinetemplate_controller.go
@@ -164,16 +164,12 @@ func (lmtr *LinodeMachineTemplateReconciler) reconcile(ctx context.Context, lmtS
 		return ctrl.Result{}, nil
 	}
 
-	// update the LMT status if all the linodeMachines are successfully updated.
-	if outErr == nil {
-		lmtScope.LinodeMachineTemplate.Status.Tags = slices.Clone(lmtScope.LinodeMachineTemplate.Spec.Template.Spec.Tags)
-		lmtScope.LinodeMachineTemplate.Status.FirewallID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.FirewallID
-		lmtScope.LinodeMachineTemplate.Status.PlacementGroupID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.PlacementGroupID
-		lmtr.Logger.Info("Successfully reconciled LinodeMachineTemplate", "name", lmtScope.LinodeMachineTemplate.Name)
-	} else {
-		lmtr.Logger.Error(outErr, "Error in reconciling LinodeMachineTemplate, retrying..", "name", lmtScope.LinodeMachineTemplate.Name)
-	}
-	return ctrl.Result{}, outErr
+	lmtScope.LinodeMachineTemplate.Status.Tags = slices.Clone(lmtScope.LinodeMachineTemplate.Spec.Template.Spec.Tags)
+	lmtScope.LinodeMachineTemplate.Status.FirewallID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.FirewallID
+	lmtScope.LinodeMachineTemplate.Status.PlacementGroupID = lmtScope.LinodeMachineTemplate.Spec.Template.Spec.PlacementGroupID
+	lmtr.Logger.Info("Successfully reconciled LinodeMachineTemplate", "name", lmtScope.LinodeMachineTemplate.Name)
+
+	return ctrl.Result{}, nil
 }
 
 func (lmtr *LinodeMachineTemplateReconciler) SetupWithManager(mgr ctrl.Manager, options crcontroller.Options) error {

--- a/internal/controller/linodemachinetemplate_controller_test.go
+++ b/internal/controller/linodemachinetemplate_controller_test.go
@@ -19,14 +19,15 @@ package controller
 import (
 	"context"
 
-	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
-	"github.com/linode/cluster-api-provider-linode/cloud/scope"
-	"github.com/linode/cluster-api-provider-linode/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
+	"github.com/linode/cluster-api-provider-linode/cloud/scope"
+	"github.com/linode/cluster-api-provider-linode/mock"
 
 	. "github.com/linode/cluster-api-provider-linode/mock/mocktest"
 	. "github.com/onsi/ginkgo/v2"
@@ -246,7 +247,6 @@ var _ = Describe("lifecycle", Ordered, Label("LinodeMachineTemplateReconciler", 
 				res, err := reconciler.reconcile(ctx, lmtScope)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(Equal(ctrl.Result{}))
-				Expect(mck.Logs()).To(ContainSubstring("Patched LinodeMachine with new tags"))
 
 				// get the updated machineTemplate
 				updatedMachineTemplate := &infrav1alpha2.LinodeMachineTemplate{}
@@ -275,7 +275,6 @@ var _ = Describe("lifecycle", Ordered, Label("LinodeMachineTemplateReconciler", 
 				res, err := reconciler.reconcile(ctx, &lmtScope)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(Equal(ctrl.Result{}))
-				Expect(mck.Logs()).NotTo(ContainSubstring("Patched LinodeMachine with new tags"))
 			}),
 		),
 		Path(

--- a/internal/controller/linodemachinetemplate_controller_test.go
+++ b/internal/controller/linodemachinetemplate_controller_test.go
@@ -149,6 +149,7 @@ var _ = Describe("lifecycle", Ordered, Label("LinodeMachineTemplateReconciler", 
 			Spec: infrav1alpha2.LinodeMachineSpec{
 				Region: "us-ord",
 				Type:   "g6-standard-1",
+				Tags:   []string{"test-tag1"},
 			},
 		},
 		{
@@ -173,8 +174,9 @@ var _ = Describe("lifecycle", Ordered, Label("LinodeMachineTemplateReconciler", 
 				},
 			},
 			Spec: infrav1alpha2.LinodeMachineSpec{
-				Region: "us-ord",
-				Type:   "g6-standard-1",
+				Region:     "us-ord",
+				Type:       "g6-standard-1",
+				FirewallID: 67890,
 			},
 		},
 	}

--- a/internal/controller/linodemachinetemplate_propagation_test.go
+++ b/internal/controller/linodemachinetemplate_propagation_test.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1alpha2 "github.com/linode/cluster-api-provider-linode/api/v1alpha2"
+	"github.com/linode/cluster-api-provider-linode/cloud/scope"
+)
+
+func TestMachineTemplatePropagatesMutableFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, infrav1alpha2.AddToScheme(scheme))
+
+	template := &infrav1alpha2.LinodeMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "template", Namespace: "default"},
+		Spec: infrav1alpha2.LinodeMachineTemplateSpec{
+			Template: infrav1alpha2.LinodeMachineTemplateResource{
+				Spec: infrav1alpha2.LinodeMachineSpec{
+					Region:           "us-ord",
+					Type:             "g6-standard-1",
+					Tags:             []string{"new-tag"},
+					FirewallID:       20,
+					PlacementGroupID: 30,
+				},
+			},
+		},
+		Status: infrav1alpha2.LinodeMachineTemplateStatus{
+			Tags:             []string{"new-tag"},
+			FirewallID:       20,
+			PlacementGroupID: 30,
+		},
+	}
+	machine := &infrav1alpha2.LinodeMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine",
+			Namespace: "default",
+			Annotations: map[string]string{
+				clusterv1.TemplateClonedFromNameAnnotation: template.Name,
+			},
+		},
+		Spec: infrav1alpha2.LinodeMachineSpec{Region: "us-ord", Type: "g6-standard-1"},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(template).WithObjects(template, machine).Build()
+
+	lmtScope, err := scope.NewMachineTemplateScope(ctx, scope.MachineTemplateScopeParams{
+		Client:                k8sClient,
+		LinodeMachineTemplate: template,
+	})
+	require.NoError(t, err)
+
+	reconciler := &LinodeMachineTemplateReconciler{Client: k8sClient, Logger: logr.Discard()}
+	_, err = reconciler.reconcile(ctx, lmtScope)
+	require.NoError(t, err)
+
+	updatedMachine := &infrav1alpha2.LinodeMachine{}
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(machine), updatedMachine))
+	require.Equal(t, []string{"new-tag"}, updatedMachine.Spec.Tags)
+	require.Equal(t, 20, updatedMachine.Spec.FirewallID)
+	require.Equal(t, 30, updatedMachine.Spec.PlacementGroupID)
+
+	updatedTemplate := &infrav1alpha2.LinodeMachineTemplate{}
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(template), updatedTemplate))
+	require.Equal(t, []string{"new-tag"}, updatedTemplate.Status.Tags)
+	require.Equal(t, 20, updatedTemplate.Status.FirewallID)
+	require.Equal(t, 30, updatedTemplate.Status.PlacementGroupID)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request adds support for specifying a Linode Placement Group by ID (`placementGroupID`) in addition to the existing reference-based approach, and ensures that Placement Group assignment is correctly reconciled and tested. It also refactors the `LinodeMachineTemplate` reconciliation logic to handle tags, firewall ID, and placement group ID updates in a unified and more maintainable way.

**Placement Group Support and Reconciliation:**

* Added a new `placementGroupID` field to `LinodeMachineSpec` and `LinodeMachineTemplateSpec`, allowing users to directly specify a Placement Group by its ID. This field takes precedence over the existing `placementGroupRef` if both are set. This is similar to how firewalls are handled
* Implemented logic in the `LinodeMachineReconciler` to reconcile placement group assignment during machine updates, including unassigning from the current group and assigning to the desired group, with error handling and rollback. 
* Added comprehensive unit tests for placement group assignment and configuration logic.

**LinodeMachineTemplate Reconciliation Refactor:**

* Refactored the `LinodeMachineTemplateReconciler` to update tags, firewall ID, and placement group ID on associated `LinodeMachine` resources in a single patch operation, replacing the previous separate reconciliation methods.

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
