### PR TITLE
[CI] gosec is already run by golangci-lint

### DIFF
--- a/.github/workflows/go-analyze.yml
+++ b/.github/workflows/go-analyze.yml
@@ -83,6 +83,3 @@ jobs:
 
       - name: Vulncheck
         run: mise run vulncheck
-
-      - name: Gosec
-        run: mise run gosec

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,6 @@ tidy: ## Run go mod tidy against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-.PHONY: gosec
-gosec: ## Run gosec against code.
-	gosec -exclude-dir=bin -exclude-generated ./...
-
 .PHONY: lint
 lint: ## Run lint against code.
 	golangci-lint run -c .golangci.yml

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,6 @@ kind = "0.31.0"
 "aqua:hexdigest/gowrap" = "1.4.3"
 s5cmd = "2.3.0"
 golangci-lint = "2.11.4"
-"aqua:securego/gosec" = "2.22.11"
 mdbook = "0.5.2"
 jq = "1.8.1"
 "go:github.com/elastic/crd-ref-docs" = "0.3.0"
@@ -35,10 +34,6 @@ run = "make tidy"
 [tasks.vet]
 description = "Run Go vet"
 run = "make vet"
-
-[tasks.gosec]
-description = "Run Go sec"
-run = "make gosec"
 
 [tasks.lint]
 description = "Run lint checks"


### PR DESCRIPTION
Removes redundant gosec check since golangci-lint already handles it and it's enabled in the .golangci.yml: https://golangci-lint.run/docs/linters/configuration/#gosec

Vulncheck and Nilaway still aren't included linters though so those stay.

(see also https://github.com/linode/linode-cloud-controller-manager/pull/614)


