### PR TITLE
[improvement][fix] Update firewall for Linode Interfaces on LinodeMachine firewall ID changes, only update instance firewall for instances using legacy interfaces

### DIFF
--- a/clients/clients.go
+++ b/clients/clients.go
@@ -120,9 +120,7 @@ type LinodeFirewallClient interface {
 	CreateFirewall(ctx context.Context, opts linodego.FirewallCreateOptions) (*linodego.Firewall, error)
 	GetFirewall(ctx context.Context, firewallID int) (*linodego.Firewall, error)
 	ListFirewalls(ctx context.Context, options *linodego.ListOptions) ([]linodego.Firewall, error)
-	GetFirewallDevice(ctx context.Context, firewallID, deviceID int) (*linodego.FirewallDevice, error)
 	ListFirewallDevices(ctx context.Context, firewallID int, options *linodego.ListOptions) ([]linodego.FirewallDevice, error)
-	GetFirewallRules(ctx context.Context, firewallID int) (*linodego.FirewallRules, error)
 	UpdateFirewall(ctx context.Context, firewallID int, opts linodego.FirewallUpdateOptions) (*linodego.Firewall, error)
 	UpdateFirewallRules(ctx context.Context, firewallID int, rules linodego.FirewallRulesUpdateOptions) (*linodego.FirewallRules, error)
 	DeleteFirewall(ctx context.Context, firewallID int) error

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -126,6 +126,7 @@ type LinodeFirewallClient interface {
 	UpdateFirewallRules(ctx context.Context, firewallID int, rules linodego.FirewallRulesUpdateOptions) (*linodego.FirewallRules, error)
 	DeleteFirewall(ctx context.Context, firewallID int) error
 	DeleteFirewallDevice(ctx context.Context, firewallID, deviceID int) error
+	CreateFirewallDevice(ctx context.Context, firewallID int, opts linodego.FirewallDeviceCreateOptions) (*linodego.FirewallDevice, error)
 }
 
 // LinodeInterfacesClient defines the methods that interact with Linode's Interfaces service.

--- a/clients/clients.go
+++ b/clients/clients.go
@@ -121,6 +121,7 @@ type LinodeFirewallClient interface {
 	GetFirewall(ctx context.Context, firewallID int) (*linodego.Firewall, error)
 	ListFirewalls(ctx context.Context, options *linodego.ListOptions) ([]linodego.Firewall, error)
 	GetFirewallDevice(ctx context.Context, firewallID, deviceID int) (*linodego.FirewallDevice, error)
+	ListFirewallDevices(ctx context.Context, firewallID int, options *linodego.ListOptions) ([]linodego.FirewallDevice, error)
 	GetFirewallRules(ctx context.Context, firewallID int) (*linodego.FirewallRules, error)
 	UpdateFirewall(ctx context.Context, firewallID int, opts linodego.FirewallUpdateOptions) (*linodego.Firewall, error)
 	UpdateFirewallRules(ctx context.Context, firewallID int, rules linodego.FirewallRulesUpdateOptions) (*linodego.FirewallRules, error)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
   - addresssets

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -839,40 +839,48 @@ func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, l
 	return err
 }
 
-func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {
-	var (
-		firewalls  []linodego.Firewall
-		ifaceFWIDs []int
-		err        error
-	)
+// listAttachedFirewallIDs returns the IDs of the firewalls currently attached to the Linode instance,
+// using the appropriate API depending on whether the instance uses Linode Interfaces or not.
+func (r *LinodeMachineReconciler) listAttachedFirewallIDs(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) ([]int, error) {
+	var firewalls []linodego.Firewall
+
 	// Get the instance's firewalls normally if this is not using the new linode interfaces,
 	// otherwise we have to get firewalls per linode interface
 	if machineScope.LinodeMachine.Spec.InterfaceGeneration == linodego.GenerationLinode {
 		interfaces, err := machineScope.LinodeClient.ListInterfaces(ctx, instanceID, nil)
 		if err != nil {
 			logger.Error(err, "Failed to list interfaces for Linode instance")
-			return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil
+			return nil, err
 		}
 		for _, iface := range interfaces {
 			ifaceFWs, err := machineScope.LinodeClient.ListInterfaceFirewalls(ctx, instanceID, iface.ID, nil)
 			if err != nil {
 				logger.Error(err, "Failed to list firewalls for Linode instance interface", "interfaceID", iface.ID)
-				return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil
+				return nil, err
 			}
-			ifaceFWIDs = append(ifaceFWIDs, iface.ID)
 			firewalls = append(firewalls, ifaceFWs...)
 		}
 	} else {
+		var err error
 		firewalls, err = machineScope.LinodeClient.ListInstanceFirewalls(ctx, instanceID, nil)
 		if err != nil {
 			logger.Error(err, "Failed to list firewalls for Linode instance")
-			return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil
+			return nil, err
 		}
 	}
 
 	attachedFWIDs := make([]int, 0, len(firewalls))
 	for _, fw := range firewalls {
 		attachedFWIDs = append(attachedFWIDs, fw.ID)
+	}
+
+	return attachedFWIDs, nil
+}
+
+func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {
+	attachedFWIDs, listErr := r.listAttachedFirewallIDs(ctx, logger, machineScope, instanceID)
+	if listErr != nil {
+		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
 	}
 
 	desiredFWID := machineScope.LinodeMachine.Spec.FirewallID
@@ -885,11 +893,17 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 		desiredFWID = fwID
 	}
 
+	// a FirewallID of 0 means no firewall is desired.
+	desiredFWIDs := []int{}
+	if desiredFWID != 0 {
+		desiredFWIDs = []int{desiredFWID}
+	}
+
 	// update the firewallID if needed.
-	if !slices.Equal(attachedFWIDs, []int{desiredFWID}) {
+	if !slices.Equal(attachedFWIDs, desiredFWIDs) {
 		if _, err := machineScope.LinodeClient.UpdateInstanceFirewalls(ctx, instanceID,
 			linodego.InstanceFirewallUpdateOptions{
-				FirewallIDs: []int{desiredFWID},
+				FirewallIDs: desiredFWIDs,
 			},
 		); err != nil {
 			logger.Error(err, "Failed to update firewalls for Linode instance")
@@ -898,7 +912,7 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 	}
 
 	// if this is using Linode Interfaces, update the interface firewalls
-	if len(machineScope.LinodeMachine.Spec.LinodeInterfaces) > 0 && !slices.Contains(ifaceFWIDs, desiredFWID) {
+	if len(machineScope.LinodeMachine.Spec.LinodeInterfaces) > 0 && desiredFWID != 0 && !slices.Contains(attachedFWIDs, desiredFWID) {
 		if _, err := machineScope.LinodeClient.CreateFirewallDevice(ctx, desiredFWID,
 			linodego.FirewallDeviceCreateOptions{
 				Type: linodego.FirewallDeviceLinodeInterface,

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -936,7 +936,7 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 	// if this is using Linode Interfaces, update the interface firewalls
 	if desiredFWID != 0 {
 		if err := r.reconcileLinodeInterfaceFirewalls(ctx, logger, machineScope, ifaceFWIDs, desiredFWID); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerRetryDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
 		}
 	}
 

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -839,26 +839,32 @@ func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, l
 	return err
 }
 
-// listAttachedFirewallIDsAndIfaceIDs returns the IDs of the firewalls currently attached to the Linode instance/interfaces
-// and the interfaces if using LinodeInterfaces
-func (r *LinodeMachineReconciler) listAttachedFirewallIDsAndIfaceIDs(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (fwIDs, ifaceIDs []int, err error) {
+// listAttachedFirewallIDsAndIfaceIDs returns the IDs of the firewalls currently attached to the Linode instance
+// (flattened across all interfaces when using Linode Interfaces), and a map of interface ID to the IDs of the
+// firewalls currently attached to that specific interface (only populated when using Linode Interfaces).
+func (r *LinodeMachineReconciler) listAttachedFirewallIDsAndIfaceIDs(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (fwIDs []int, ifaceFWIDs map[int][]int, err error) {
 	var firewalls []linodego.Firewall
-	var linodeInterfaces []linodego.LinodeInterface
 
 	// Get the instance's firewalls normally if this is not using the new linode interfaces,
 	// otherwise we have to get firewalls per linode interface
 	if machineScope.LinodeMachine.Spec.InterfaceGeneration == linodego.GenerationLinode {
-		linodeInterfaces, err = machineScope.LinodeClient.ListInterfaces(ctx, instanceID, nil)
+		linodeInterfaces, err := machineScope.LinodeClient.ListInterfaces(ctx, instanceID, nil)
 		if err != nil {
 			logger.Error(err, "Failed to list interfaces for Linode instance")
 			return nil, nil, err
 		}
+		ifaceFWIDs = make(map[int][]int, len(linodeInterfaces))
 		for _, iface := range linodeInterfaces {
 			ifaceFWs, err := machineScope.LinodeClient.ListInterfaceFirewalls(ctx, instanceID, iface.ID, nil)
 			if err != nil {
 				logger.Error(err, "Failed to list firewalls for Linode instance interface", "interfaceID", iface.ID)
 				return nil, nil, err
 			}
+			ifaceFWIDList := make([]int, 0, len(ifaceFWs))
+			for _, fw := range ifaceFWs {
+				ifaceFWIDList = append(ifaceFWIDList, fw.ID)
+			}
+			ifaceFWIDs[iface.ID] = ifaceFWIDList
 			firewalls = append(firewalls, ifaceFWs...)
 		}
 	} else {
@@ -875,16 +881,26 @@ func (r *LinodeMachineReconciler) listAttachedFirewallIDsAndIfaceIDs(ctx context
 		attachedFWIDs = append(attachedFWIDs, fw.ID)
 	}
 
-	ifaceIDs = make([]int, 0, len(linodeInterfaces))
-	for _, iface := range linodeInterfaces {
-		ifaceIDs = append(ifaceIDs, iface.ID)
-	}
+	return attachedFWIDs, ifaceFWIDs, nil
+}
 
-	return attachedFWIDs, ifaceIDs, nil
+// findFirewallDeviceID looks up the FirewallDevice ID that associates the given Linode Interface with the given
+// firewall. It returns 0 if no such device exists.
+func (r *LinodeMachineReconciler) findFirewallDeviceID(ctx context.Context, machineScope *scope.MachineScope, firewallID, ifaceID int) (int, error) {
+	devices, err := machineScope.LinodeClient.ListFirewallDevices(ctx, firewallID, nil)
+	if err != nil {
+		return 0, err
+	}
+	for _, device := range devices {
+		if device.Entity.Type == linodego.FirewallDeviceLinodeInterface && device.Entity.ID == ifaceID {
+			return device.ID, nil
+		}
+	}
+	return 0, nil
 }
 
 func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {
-	attachedFWIDs, ifaceIDs, listErr := r.listAttachedFirewallIDsAndIfaceIDs(ctx, logger, machineScope, instanceID)
+	attachedFWIDs, ifaceFWIDs, listErr := r.listAttachedFirewallIDsAndIfaceIDs(ctx, logger, machineScope, instanceID)
 	if listErr != nil {
 		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
 	}
@@ -918,28 +934,60 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 	}
 
 	// if this is using Linode Interfaces, update the interface firewalls
-	if desiredFWID != 0 && !slices.Contains(attachedFWIDs, desiredFWID) {
-		for _, ifaceID := range ifaceIDs {
-			// clean up the linode interface from the firewalls, ignoring if it's not found
-			for _, fwID := range attachedFWIDs {
-				if err := machineScope.LinodeClient.DeleteFirewallDevice(ctx, fwID, ifaceID); utilerrors.FilterOut(err, linodego.IsNotFound) != nil {
-					logger.Error(err, "Failed to delete firewall for Linode instance", "fwID", fwID, "ifaceID", ifaceID)
-				}
-			}
-			// on the desired firewall create the linode_interface device
-			if _, err := machineScope.LinodeClient.CreateFirewallDevice(ctx, desiredFWID,
-				linodego.FirewallDeviceCreateOptions{
-					Type: linodego.FirewallDeviceLinodeInterface,
-					ID:   ifaceID,
-				},
-			); err != nil {
-				logger.Error(err, "Failed to create firewall device for Linode instance", "fwID", desiredFWID, "ifaceID", ifaceID)
-				return ctrl.Result{}, err
-			}
+	if desiredFWID != 0 {
+		if err := r.reconcileLinodeInterfaceFirewalls(ctx, logger, machineScope, ifaceFWIDs, desiredFWID); err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// reconcileLinodeInterfaceFirewalls ensures each Linode Interface is attached to the desired firewall,
+// cleaning up its device from any previously attached firewalls.
+func (r *LinodeMachineReconciler) reconcileLinodeInterfaceFirewalls(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, ifaceFWIDs map[int][]int, desiredFWID int) error {
+	for ifaceID, currentFWIDs := range ifaceFWIDs {
+		if slices.Contains(currentFWIDs, desiredFWID) {
+			// this interface is already attached to the desired firewall
+			continue
+		}
+
+		r.cleanupOldInterfaceFirewallDevices(ctx, logger, machineScope, ifaceID, currentFWIDs)
+
+		// on the desired firewall create the linode_interface device
+		if _, err := machineScope.LinodeClient.CreateFirewallDevice(ctx, desiredFWID,
+			linodego.FirewallDeviceCreateOptions{
+				Type: linodego.FirewallDeviceLinodeInterface,
+				ID:   ifaceID,
+			},
+		); err != nil {
+			logger.Error(err, "Failed to create firewall device for Linode instance", "fwID", desiredFWID, "ifaceID", ifaceID)
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupOldInterfaceFirewallDevices removes the given interface's firewall device from each of its
+// previously attached firewalls. Failures are logged but not treated as fatal since a stale device left
+// behind does not block progress and will be retried on the next reconcile.
+func (r *LinodeMachineReconciler) cleanupOldInterfaceFirewallDevices(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, ifaceID int, oldFWIDs []int) {
+	for _, fwID := range oldFWIDs {
+		deviceID, err := r.findFirewallDeviceID(ctx, machineScope, fwID, ifaceID)
+		if err != nil {
+			logger.Error(err, "Failed to list firewall devices for Linode firewall", "fwID", fwID, "ifaceID", ifaceID)
+			continue
+		}
+		if deviceID == 0 {
+			// no matching device found for this interface on this firewall; nothing to clean up
+			logger.Info("No matching firewall device for Linode firewall", "fwID", fwID)
+			continue
+		}
+
+		if err := utilerrors.FilterOut(machineScope.LinodeClient.DeleteFirewallDevice(ctx, fwID, deviceID), linodego.IsNotFound); err != nil {
+			logger.Error(err, "Failed to delete firewall device for Linode instance interface", "fwID", fwID, "ifaceID", ifaceID, "deviceID", deviceID)
+		}
+	}
 }
 
 func (r *LinodeMachineReconciler) reconcileDelete(

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -839,24 +839,25 @@ func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, l
 	return err
 }
 
-// listAttachedFirewallIDs returns the IDs of the firewalls currently attached to the Linode instance,
-// using the appropriate API depending on whether the instance uses Linode Interfaces or not.
-func (r *LinodeMachineReconciler) listAttachedFirewallIDs(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) ([]int, error) {
+// listAttachedFirewallIDsAndIfaceIDs returns the IDs of the firewalls currently attached to the Linode instance/interfaces
+// and the interfaces if using LinodeInterfaces
+func (r *LinodeMachineReconciler) listAttachedFirewallIDsAndIfaceIDs(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (fwIDs, ifaceIDs []int, err error) {
 	var firewalls []linodego.Firewall
+	var linodeInterfaces []linodego.LinodeInterface
 
 	// Get the instance's firewalls normally if this is not using the new linode interfaces,
 	// otherwise we have to get firewalls per linode interface
 	if machineScope.LinodeMachine.Spec.InterfaceGeneration == linodego.GenerationLinode {
-		interfaces, err := machineScope.LinodeClient.ListInterfaces(ctx, instanceID, nil)
+		linodeInterfaces, err = machineScope.LinodeClient.ListInterfaces(ctx, instanceID, nil)
 		if err != nil {
 			logger.Error(err, "Failed to list interfaces for Linode instance")
-			return nil, err
+			return nil, nil, err
 		}
-		for _, iface := range interfaces {
+		for _, iface := range linodeInterfaces {
 			ifaceFWs, err := machineScope.LinodeClient.ListInterfaceFirewalls(ctx, instanceID, iface.ID, nil)
 			if err != nil {
 				logger.Error(err, "Failed to list firewalls for Linode instance interface", "interfaceID", iface.ID)
-				return nil, err
+				return nil, nil, err
 			}
 			firewalls = append(firewalls, ifaceFWs...)
 		}
@@ -865,7 +866,7 @@ func (r *LinodeMachineReconciler) listAttachedFirewallIDs(ctx context.Context, l
 		firewalls, err = machineScope.LinodeClient.ListInstanceFirewalls(ctx, instanceID, nil)
 		if err != nil {
 			logger.Error(err, "Failed to list firewalls for Linode instance")
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -874,11 +875,16 @@ func (r *LinodeMachineReconciler) listAttachedFirewallIDs(ctx context.Context, l
 		attachedFWIDs = append(attachedFWIDs, fw.ID)
 	}
 
-	return attachedFWIDs, nil
+	ifaceIDs = make([]int, 0, len(linodeInterfaces))
+	for _, iface := range linodeInterfaces {
+		ifaceIDs = append(ifaceIDs, iface.ID)
+	}
+
+	return attachedFWIDs, ifaceIDs, nil
 }
 
 func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {
-	attachedFWIDs, listErr := r.listAttachedFirewallIDs(ctx, logger, machineScope, instanceID)
+	attachedFWIDs, ifaceIDs, listErr := r.listAttachedFirewallIDsAndIfaceIDs(ctx, logger, machineScope, instanceID)
 	if listErr != nil {
 		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
 	}
@@ -912,14 +918,24 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 	}
 
 	// if this is using Linode Interfaces, update the interface firewalls
-	if len(machineScope.LinodeMachine.Spec.LinodeInterfaces) > 0 && desiredFWID != 0 && !slices.Contains(attachedFWIDs, desiredFWID) {
-		if _, err := machineScope.LinodeClient.CreateFirewallDevice(ctx, desiredFWID,
-			linodego.FirewallDeviceCreateOptions{
-				Type: linodego.FirewallDeviceLinodeInterface,
-			},
-		); err != nil {
-			logger.Error(err, "Failed to create firewall device for Linode instance")
-			return ctrl.Result{}, err
+	if desiredFWID != 0 && !slices.Contains(attachedFWIDs, desiredFWID) {
+		for _, ifaceID := range ifaceIDs {
+			// clean up the linode interface from the firewalls, ignoring if it's not found
+			for _, fwID := range attachedFWIDs {
+				if err := machineScope.LinodeClient.DeleteFirewallDevice(ctx, fwID, ifaceID); utilerrors.FilterOut(err, linodego.IsNotFound) != nil {
+					logger.Error(err, "Failed to delete firewall for Linode instance", "fwID", fwID, "ifaceID", ifaceID)
+				}
+			}
+			// on the desired firewall create the linode_interface device
+			if _, err := machineScope.LinodeClient.CreateFirewallDevice(ctx, desiredFWID,
+				linodego.FirewallDeviceCreateOptions{
+					Type: linodego.FirewallDeviceLinodeInterface,
+					ID:   ifaceID,
+				},
+			); err != nil {
+				logger.Error(err, "Failed to create firewall device for Linode instance", "fwID", desiredFWID, "ifaceID", ifaceID)
+				return ctrl.Result{}, err
+			}
 		}
 	}
 

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -841,8 +841,9 @@ func (r *LinodeMachineReconciler) reconcilePlacementGroup(ctx context.Context, l
 
 func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {
 	var (
-		firewalls []linodego.Firewall
-		err       error
+		firewalls  []linodego.Firewall
+		ifaceFWIDs []int
+		err        error
 	)
 	// Get the instance's firewalls normally if this is not using the new linode interfaces,
 	// otherwise we have to get firewalls per linode interface
@@ -858,6 +859,7 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 				logger.Error(err, "Failed to list firewalls for Linode instance interface", "interfaceID", iface.ID)
 				return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil
 			}
+			ifaceFWIDs = append(ifaceFWIDs, iface.ID)
 			firewalls = append(firewalls, ifaceFWs...)
 		}
 	} else {
@@ -873,30 +875,40 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 		attachedFWIDs = append(attachedFWIDs, fw.ID)
 	}
 
-	desiredFWIDs := []int{}
-	if machineScope.LinodeMachine.Spec.FirewallID != 0 {
-		desiredFWIDs = []int{machineScope.LinodeMachine.Spec.FirewallID}
-	} else if machineScope.LinodeMachine.Spec.FirewallRef != nil {
+	desiredFWID := machineScope.LinodeMachine.Spec.FirewallID
+	if machineScope.LinodeMachine.Spec.FirewallRef != nil {
 		fwID, err := getFirewallID(ctx, machineScope, logger)
 		if err != nil {
 			logger.Error(err, "Failed to get firewall ID from firewall ref")
 			return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerRetryDelay)}, nil
 		}
-		desiredFWIDs = []int{fwID}
+		desiredFWID = fwID
 	}
 
 	// update the firewallID if needed.
-	if !slices.Equal(attachedFWIDs, desiredFWIDs) {
-		_, err := machineScope.LinodeClient.UpdateInstanceFirewalls(ctx, instanceID,
+	if !slices.Equal(attachedFWIDs, []int{desiredFWID}) {
+		if _, err := machineScope.LinodeClient.UpdateInstanceFirewalls(ctx, instanceID,
 			linodego.InstanceFirewallUpdateOptions{
-				FirewallIDs: desiredFWIDs,
+				FirewallIDs: []int{desiredFWID},
 			},
-		)
-		if err != nil {
+		); err != nil {
 			logger.Error(err, "Failed to update firewalls for Linode instance")
 			return ctrl.Result{}, err
 		}
 	}
+
+	// if this is using Linode Interfaces, update the interface firewalls
+	if len(machineScope.LinodeMachine.Spec.LinodeInterfaces) > 0 && !slices.Contains(ifaceFWIDs, desiredFWID) {
+		if _, err := machineScope.LinodeClient.CreateFirewallDevice(ctx, desiredFWID,
+			linodego.FirewallDeviceCreateOptions{
+				Type: linodego.FirewallDeviceLinodeInterface,
+			},
+		); err != nil {
+			logger.Error(err, "Failed to create firewall device for Linode instance")
+			return ctrl.Result{}, err
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -903,7 +903,7 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 	attachedFWIDs, ifaceFWIDs, listErr := r.listAttachedFirewallIDsAndIfaceIDs(ctx, logger, machineScope, instanceID)
 	if listErr != nil {
 		logger.Error(listErr, "Failed to list attached firewall IDs", "instanceID", instanceID)
-		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
+		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil
 	}
 
 	desiredFWID := machineScope.LinodeMachine.Spec.FirewallID

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -102,7 +102,7 @@ type LinodeMachineReconciler struct {
 
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;watch;list
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=get;watch;list
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/linodemachine_controller.go
+++ b/internal/controller/linodemachine_controller.go
@@ -774,8 +774,7 @@ func (r *LinodeMachineReconciler) reconcileUpdate(ctx context.Context, logger lo
 	// update the tags if needed
 	machineTags := getTags(machineScope, linodeInstance.Tags)
 	if !slices.Equal(machineTags, linodeInstance.Tags) {
-		_, err = machineScope.LinodeClient.UpdateInstance(ctx, instanceID, linodego.InstanceUpdateOptions{Tags: machineTags})
-		if err != nil {
+		if _, err = machineScope.LinodeClient.UpdateInstance(ctx, instanceID, linodego.InstanceUpdateOptions{Tags: machineTags}); err != nil {
 			logger.Error(err, "Failed to update tags for Linode instance")
 			return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil
 		}
@@ -847,7 +846,8 @@ func (r *LinodeMachineReconciler) listAttachedFirewallIDsAndIfaceIDs(ctx context
 
 	// Get the instance's firewalls normally if this is not using the new linode interfaces,
 	// otherwise we have to get firewalls per linode interface
-	if machineScope.LinodeMachine.Spec.InterfaceGeneration == linodego.GenerationLinode {
+	switch machineScope.LinodeMachine.Spec.InterfaceGeneration {
+	case linodego.GenerationLinode:
 		linodeInterfaces, err := machineScope.LinodeClient.ListInterfaces(ctx, instanceID, nil)
 		if err != nil {
 			logger.Error(err, "Failed to list interfaces for Linode instance")
@@ -867,7 +867,7 @@ func (r *LinodeMachineReconciler) listAttachedFirewallIDsAndIfaceIDs(ctx context
 			ifaceFWIDs[iface.ID] = ifaceFWIDList
 			firewalls = append(firewalls, ifaceFWs...)
 		}
-	} else {
+	case linodego.GenerationLegacyConfig:
 		var err error
 		firewalls, err = machineScope.LinodeClient.ListInstanceFirewalls(ctx, instanceID, nil)
 		if err != nil {
@@ -902,6 +902,7 @@ func (r *LinodeMachineReconciler) findFirewallDeviceID(ctx context.Context, mach
 func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logger logr.Logger, machineScope *scope.MachineScope, instanceID int) (ctrl.Result, error) {
 	attachedFWIDs, ifaceFWIDs, listErr := r.listAttachedFirewallIDsAndIfaceIDs(ctx, logger, machineScope, instanceID)
 	if listErr != nil {
+		logger.Error(listErr, "Failed to list attached firewall IDs", "instanceID", instanceID)
 		return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerWaitForRunningDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
 	}
 
@@ -921,22 +922,26 @@ func (r *LinodeMachineReconciler) reconcileFirewallID(ctx context.Context, logge
 		desiredFWIDs = []int{desiredFWID}
 	}
 
-	// update the firewallID if needed.
 	if !slices.Equal(attachedFWIDs, desiredFWIDs) {
-		if _, err := machineScope.LinodeClient.UpdateInstanceFirewalls(ctx, instanceID,
-			linodego.InstanceFirewallUpdateOptions{
-				FirewallIDs: desiredFWIDs,
-			},
-		); err != nil {
-			logger.Error(err, "Failed to update firewalls for Linode instance")
-			return ctrl.Result{}, err
-		}
-	}
-
-	// if this is using Linode Interfaces, update the interface firewalls
-	if desiredFWID != 0 {
-		if err := r.reconcileLinodeInterfaceFirewalls(ctx, logger, machineScope, ifaceFWIDs, desiredFWID); err != nil {
-			return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerRetryDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
+		switch machineScope.LinodeMachine.Spec.InterfaceGeneration {
+		case linodego.GenerationLegacyConfig:
+			if _, err := machineScope.LinodeClient.UpdateInstanceFirewalls(ctx, instanceID,
+				linodego.InstanceFirewallUpdateOptions{
+					FirewallIDs: desiredFWIDs,
+				},
+			); err != nil {
+				logger.Error(err, "Failed to update firewalls for Linode instance")
+				return ctrl.Result{}, err
+			}
+		case linodego.GenerationLinode:
+			if desiredFWID != 0 {
+				if err := r.reconcileLinodeInterfaceFirewalls(ctx, logger, machineScope, ifaceFWIDs, desiredFWID); err != nil {
+					return ctrl.Result{RequeueAfter: reconciler.WithJitter(reconciler.DefaultMachineControllerRetryDelay)}, nil //nolint:nilerr // error is logged and requeued, not returned
+				}
+			}
+		default:
+			logger.Error(nil, "Invalid interface generation", "instanceID", instanceID)
+			return ctrl.Result{}, nil // do not requeue on invalid configuration
 		}
 	}
 

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -2064,6 +2064,56 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 			}),
 		),
 		Path(
+			Call("linode interface firewall is updated", func(ctx context.Context, mck Mock) {
+				mck.LinodeClient.EXPECT().GetInstance(ctx, 11111).Return(
+					&linodego.Instance{
+						ID:      11111,
+						IPv4:    []net.IP{net.IPv4(192, 168, 0, 2)},
+						IPv6:    "fd00::",
+						Tags:    []string{"test-cluster-2"},
+						Status:  linodego.InstanceRunning,
+						Updated: new(time.Now()),
+					}, nil)
+				mck.LinodeClient.EXPECT().UpdateInstance(ctx, 11111, gomock.Any()).Return(
+					&linodego.Instance{
+						ID:      11111,
+						IPv4:    []net.IP{net.IPv4(192, 168, 0, 2)},
+						IPv6:    "fd00::",
+						Tags:    []string{"test-cluster-2", "test-tag"},
+						Status:  linodego.InstanceRunning,
+						Updated: new(time.Now()),
+					}, nil)
+				mck.LinodeClient.EXPECT().ListInterfaces(ctx, 11111, nil).Return(
+					[]linodego.LinodeInterface{
+						{ID: 200}, // Instance currently has a single Linode Interface
+					}, nil)
+				mck.LinodeClient.EXPECT().ListInterfaceFirewalls(ctx, 11111, 200, nil).Return(
+					[]linodego.Firewall{
+						{ID: 5}, // Interface currently has firewall ID 5 attached
+					}, nil)
+				mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
+					FirewallIDs: []int{10}, // Update to firewall ID 10
+				}).Return(nil, nil)
+				mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
+					Type: linodego.FirewallDeviceLinodeInterface,
+				}).Return(&linodego.FirewallDevice{}, nil)
+			}),
+			Result("linode interface firewall is updated", func(ctx context.Context, mck Mock) {
+				linodeMachine.Spec.InterfaceGeneration = linodego.GenerationLinode
+				linodeMachine.Spec.LinodeInterfaces = []infrav1alpha2.LinodeInterfaceCreateOptions{{}}
+				linodeMachine.Spec.FirewallID = 10 // Set new firewall ID
+				_, err := reconciler.reconcile(ctx, logr.Logger{}, mScope)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Reset the interface fields so subsequent ordered specs aren't affected
+				// by the persisted LinodeMachine changes made in this test.
+				Expect(k8sClient.Get(ctx, machineKey, linodeMachine)).To(Succeed())
+				linodeMachine.Spec.InterfaceGeneration = ""
+				linodeMachine.Spec.LinodeInterfaces = nil
+				Expect(k8sClient.Update(ctx, linodeMachine)).To(Succeed())
+			}),
+		),
+		Path(
 			Call("machine firewall update applied when multiple firewall already attached", func(ctx context.Context, mck Mock) {
 				mck.LinodeClient.EXPECT().GetInstance(ctx, 11111).Return(
 					&linodego.Instance{
@@ -2218,6 +2268,12 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 				Expect(res.RequeueAfter).To(BeNumerically(">=", rutil.DefaultMachineControllerRetryDelay))
 				Expect(res.RequeueAfter).To(BeNumerically("<=", rutil.DefaultMachineControllerRetryDelay+time.Duration(float64(rutil.DefaultMachineControllerRetryDelay)*rutil.RetryJitterFraction)))
 				Expect(mck.Logs()).To(ContainSubstring("Failed to fetch LinodeFirewall"))
+
+				// Reset FirewallRef so subsequent ordered specs aren't affected by this
+				// nonexistent reference persisted on the LinodeMachine.
+				Expect(k8sClient.Get(ctx, machineKey, linodeMachine)).To(Succeed())
+				linodeMachine.Spec.FirewallRef = nil
+				Expect(k8sClient.Update(ctx, linodeMachine)).To(Succeed())
 			}),
 		),
 		OneOf(

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -2126,7 +2126,136 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 			}),
 		),
 		Path(
+			Call("linode interface firewall is not updated because there was an linode error", func(ctx context.Context, mck Mock) {
+				linodeMachine.Spec.InterfaceGeneration = linodego.GenerationLinode
+				linodeMachine.Spec.LinodeInterfaces = []infrav1alpha2.LinodeInterfaceCreateOptions{{}}
+				mck.LinodeClient.EXPECT().GetInstance(ctx, 11111).Return(
+					&linodego.Instance{
+						ID:      11111,
+						IPv4:    []net.IP{net.IPv4(192, 168, 0, 2)},
+						IPv6:    "fd00::",
+						Tags:    []string{"test-cluster-2"},
+						Status:  linodego.InstanceRunning,
+						Updated: new(time.Now()),
+					}, nil)
+				mck.LinodeClient.EXPECT().UpdateInstance(ctx, 11111, gomock.Any()).Return(
+					&linodego.Instance{
+						ID:      11111,
+						IPv4:    []net.IP{net.IPv4(192, 168, 0, 2)},
+						IPv6:    "fd00::",
+						Tags:    []string{"test-cluster-2", "test-tag"},
+						Status:  linodego.InstanceRunning,
+						Updated: new(time.Now()),
+					}, nil)
+			}),
+			OneOf(
+				Path(Result("list interfaces error", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().ListInterfaces(ctx, 11111, nil).Return(
+						nil, &linodego.Error{Code: http.StatusInternalServerError})
+					res, err := reconciler.reconcile(ctx, mck.Logger(), mScope)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(res.RequeueAfter).To(BeNumerically(">=", rutil.DefaultMachineControllerWaitForRunningDelay))
+					Expect(res.RequeueAfter).To(BeNumerically("<=", rutil.DefaultMachineControllerWaitForRunningDelay+time.Duration(float64(rutil.DefaultMachineControllerWaitForRunningDelay)*rutil.RetryJitterFraction)))
+				})),
+				Path(Result("list interfaces devices error", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().ListInterfaces(ctx, 11111, nil).Return(
+						[]linodego.LinodeInterface{
+							{ID: 200}, // Instance currently has a single Linode Interface
+						}, nil)
+					mck.LinodeClient.EXPECT().ListInterfaceFirewalls(ctx, 11111, 200, nil).Return(
+						nil, &linodego.Error{Code: http.StatusInternalServerError})
+					res, err := reconciler.reconcile(ctx, mck.Logger(), mScope)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(res.RequeueAfter).To(BeNumerically(">=", rutil.DefaultMachineControllerWaitForRunningDelay))
+					Expect(res.RequeueAfter).To(BeNumerically("<=", rutil.DefaultMachineControllerWaitForRunningDelay+time.Duration(float64(rutil.DefaultMachineControllerWaitForRunningDelay)*rutil.RetryJitterFraction)))
+				})),
+				Path(Result("list firewall devices error does not cause requeue", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().ListInterfaces(ctx, 11111, nil).Return(
+						[]linodego.LinodeInterface{
+							{ID: 200}, // Instance currently has a single Linode Interface
+						}, nil)
+					mck.LinodeClient.EXPECT().ListInterfaceFirewalls(ctx, 11111, 200, nil).Return(
+						[]linodego.Firewall{
+							{ID: 5}, // Interface currently has firewall ID 5 attached
+						}, nil)
+					mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
+						FirewallIDs: []int{10}, // Update to firewall ID 10
+					}).Return(nil, nil)
+					mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
+						nil, &linodego.Error{Code: http.StatusInternalServerError})
+					mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
+						Type: linodego.FirewallDeviceLinodeInterface,
+						ID:   200,
+					}).Return(&linodego.FirewallDevice{}, nil)
+
+					_, err := reconciler.reconcile(ctx, logr.Logger{}, mScope)
+					Expect(err).NotTo(HaveOccurred())
+				})),
+				Path(Result("delete firewall device error does not cause requeue", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().ListInterfaces(ctx, 11111, nil).Return(
+						[]linodego.LinodeInterface{
+							{ID: 200}, // Instance currently has a single Linode Interface
+						}, nil)
+					mck.LinodeClient.EXPECT().ListInterfaceFirewalls(ctx, 11111, 200, nil).Return(
+						[]linodego.Firewall{
+							{ID: 5}, // Interface currently has firewall ID 5 attached
+						}, nil)
+					mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
+						FirewallIDs: []int{10}, // Update to firewall ID 10
+					}).Return(nil, nil)
+					mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
+						[]linodego.FirewallDevice{
+							{
+								ID: 999, // The FirewallDevice ID is distinct from the interface ID
+								Entity: linodego.FirewallDeviceEntity{
+									ID:   200,
+									Type: linodego.FirewallDeviceLinodeInterface,
+								},
+							},
+						}, nil)
+					mck.LinodeClient.EXPECT().DeleteFirewallDevice(ctx, 5, 999).Return(&linodego.Error{Code: http.StatusInternalServerError})
+					mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
+						Type: linodego.FirewallDeviceLinodeInterface,
+						ID:   200,
+					}).Return(&linodego.FirewallDevice{}, nil)
+
+					_, err := reconciler.reconcile(ctx, logr.Logger{}, mScope)
+					Expect(err).NotTo(HaveOccurred())
+				})),
+				Path(Result("list and delete firewall devices error does not cause requeue but create devices error does", func(ctx context.Context, mck Mock) {
+					mck.LinodeClient.EXPECT().ListInterfaces(ctx, 11111, nil).Return(
+						[]linodego.LinodeInterface{
+							{ID: 200}, // Instance currently has a single Linode Interface
+						}, nil)
+					mck.LinodeClient.EXPECT().ListInterfaceFirewalls(ctx, 11111, 200, nil).Return(
+						[]linodego.Firewall{
+							{ID: 5}, // Interface currently has firewall ID 5 attached
+						}, nil)
+					mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
+						FirewallIDs: []int{10}, // Update to firewall ID 10
+					}).Return(nil, nil)
+					mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
+						nil, &linodego.Error{Code: http.StatusInternalServerError})
+					mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
+						Type: linodego.FirewallDeviceLinodeInterface,
+						ID:   200,
+					}).Return(nil, &linodego.Error{Code: http.StatusInternalServerError})
+
+					res, err := reconciler.reconcile(ctx, mck.Logger(), mScope)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(res.RequeueAfter).To(BeNumerically(">=", rutil.DefaultMachineControllerRetryDelay))
+					Expect(res.RequeueAfter).To(BeNumerically("<=", rutil.DefaultMachineControllerRetryDelay+time.Duration(float64(rutil.DefaultMachineControllerRetryDelay)*rutil.RetryJitterFraction)))
+				})),
+			),
+		),
+		Path(
 			Call("machine firewall update applied when multiple firewall already attached", func(ctx context.Context, mck Mock) {
+				// Reset the interface fields so subsequent ordered specs aren't affected
+				// by the persisted LinodeMachine changes made in this test.
+				Expect(k8sClient.Get(ctx, machineKey, linodeMachine)).To(Succeed())
+				linodeMachine.Spec.InterfaceGeneration = ""
+				linodeMachine.Spec.LinodeInterfaces = nil
+				Expect(k8sClient.Update(ctx, linodeMachine)).To(Succeed())
 				mck.LinodeClient.EXPECT().GetInstance(ctx, 11111).Return(
 					&linodego.Instance{
 						ID:      11111,

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -2094,8 +2094,10 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 				mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
 					FirewallIDs: []int{10}, // Update to firewall ID 10
 				}).Return(nil, nil)
+				mck.LinodeClient.EXPECT().DeleteFirewallDevice(ctx, 5, 200).Return(nil)
 				mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
 					Type: linodego.FirewallDeviceLinodeInterface,
+					ID:   200,
 				}).Return(&linodego.FirewallDevice{}, nil)
 			}),
 			Result("linode interface firewall is updated", func(ctx context.Context, mck Mock) {

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -2094,7 +2094,17 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 				mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
 					FirewallIDs: []int{10}, // Update to firewall ID 10
 				}).Return(nil, nil)
-				mck.LinodeClient.EXPECT().DeleteFirewallDevice(ctx, 5, 200).Return(nil)
+				mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
+					[]linodego.FirewallDevice{
+						{
+							ID: 999, // The FirewallDevice ID is distinct from the interface ID
+							Entity: linodego.FirewallDeviceEntity{
+								ID:   200,
+								Type: linodego.FirewallDeviceLinodeInterface,
+							},
+						},
+					}, nil)
+				mck.LinodeClient.EXPECT().DeleteFirewallDevice(ctx, 5, 999).Return(nil)
 				mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
 					Type: linodego.FirewallDeviceLinodeInterface,
 					ID:   200,

--- a/internal/controller/linodemachine_controller_test.go
+++ b/internal/controller/linodemachine_controller_test.go
@@ -2091,9 +2091,6 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 					[]linodego.Firewall{
 						{ID: 5}, // Interface currently has firewall ID 5 attached
 					}, nil)
-				mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
-					FirewallIDs: []int{10}, // Update to firewall ID 10
-				}).Return(nil, nil)
 				mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
 					[]linodego.FirewallDevice{
 						{
@@ -2178,9 +2175,6 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 						[]linodego.Firewall{
 							{ID: 5}, // Interface currently has firewall ID 5 attached
 						}, nil)
-					mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
-						FirewallIDs: []int{10}, // Update to firewall ID 10
-					}).Return(nil, nil)
 					mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
 						nil, &linodego.Error{Code: http.StatusInternalServerError})
 					mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{
@@ -2200,9 +2194,6 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 						[]linodego.Firewall{
 							{ID: 5}, // Interface currently has firewall ID 5 attached
 						}, nil)
-					mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
-						FirewallIDs: []int{10}, // Update to firewall ID 10
-					}).Return(nil, nil)
 					mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
 						[]linodego.FirewallDevice{
 							{
@@ -2231,9 +2222,6 @@ var _ = Describe("machine-update", Ordered, Label("machine", "machine-update"), 
 						[]linodego.Firewall{
 							{ID: 5}, // Interface currently has firewall ID 5 attached
 						}, nil)
-					mck.LinodeClient.EXPECT().UpdateInstanceFirewalls(ctx, 11111, linodego.InstanceFirewallUpdateOptions{
-						FirewallIDs: []int{10}, // Update to firewall ID 10
-					}).Return(nil, nil)
 					mck.LinodeClient.EXPECT().ListFirewallDevices(ctx, 5, nil).Return(
 						nil, &linodego.Error{Code: http.StatusInternalServerError})
 					mck.LinodeClient.EXPECT().CreateFirewallDevice(ctx, 10, linodego.FirewallDeviceCreateOptions{

--- a/mock/client.go
+++ b/mock/client.go
@@ -457,36 +457,6 @@ func (mr *MockLinodeClientMockRecorder) GetFirewall(ctx, firewallID any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewall", reflect.TypeOf((*MockLinodeClient)(nil).GetFirewall), ctx, firewallID)
 }
 
-// GetFirewallDevice mocks base method.
-func (m *MockLinodeClient) GetFirewallDevice(ctx context.Context, firewallID, deviceID int) (*linodego.FirewallDevice, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFirewallDevice", ctx, firewallID, deviceID)
-	ret0, _ := ret[0].(*linodego.FirewallDevice)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFirewallDevice indicates an expected call of GetFirewallDevice.
-func (mr *MockLinodeClientMockRecorder) GetFirewallDevice(ctx, firewallID, deviceID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewallDevice", reflect.TypeOf((*MockLinodeClient)(nil).GetFirewallDevice), ctx, firewallID, deviceID)
-}
-
-// GetFirewallRules mocks base method.
-func (m *MockLinodeClient) GetFirewallRules(ctx context.Context, firewallID int) (*linodego.FirewallRules, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFirewallRules", ctx, firewallID)
-	ret0, _ := ret[0].(*linodego.FirewallRules)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFirewallRules indicates an expected call of GetFirewallRules.
-func (mr *MockLinodeClientMockRecorder) GetFirewallRules(ctx, firewallID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewallRules", reflect.TypeOf((*MockLinodeClient)(nil).GetFirewallRules), ctx, firewallID)
-}
-
 // GetImage mocks base method.
 func (m *MockLinodeClient) GetImage(ctx context.Context, imageID string) (*linodego.Image, error) {
 	m.ctrl.T.Helper()
@@ -2192,36 +2162,6 @@ func (m *MockLinodeFirewallClient) GetFirewall(ctx context.Context, firewallID i
 func (mr *MockLinodeFirewallClientMockRecorder) GetFirewall(ctx, firewallID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewall", reflect.TypeOf((*MockLinodeFirewallClient)(nil).GetFirewall), ctx, firewallID)
-}
-
-// GetFirewallDevice mocks base method.
-func (m *MockLinodeFirewallClient) GetFirewallDevice(ctx context.Context, firewallID, deviceID int) (*linodego.FirewallDevice, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFirewallDevice", ctx, firewallID, deviceID)
-	ret0, _ := ret[0].(*linodego.FirewallDevice)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFirewallDevice indicates an expected call of GetFirewallDevice.
-func (mr *MockLinodeFirewallClientMockRecorder) GetFirewallDevice(ctx, firewallID, deviceID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewallDevice", reflect.TypeOf((*MockLinodeFirewallClient)(nil).GetFirewallDevice), ctx, firewallID, deviceID)
-}
-
-// GetFirewallRules mocks base method.
-func (m *MockLinodeFirewallClient) GetFirewallRules(ctx context.Context, firewallID int) (*linodego.FirewallRules, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFirewallRules", ctx, firewallID)
-	ret0, _ := ret[0].(*linodego.FirewallRules)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFirewallRules indicates an expected call of GetFirewallRules.
-func (mr *MockLinodeFirewallClientMockRecorder) GetFirewallRules(ctx, firewallID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewallRules", reflect.TypeOf((*MockLinodeFirewallClient)(nil).GetFirewallRules), ctx, firewallID)
 }
 
 // ListFirewallDevices mocks base method.

--- a/mock/client.go
+++ b/mock/client.go
@@ -108,6 +108,21 @@ func (mr *MockLinodeClientMockRecorder) CreateFirewall(ctx, opts any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFirewall", reflect.TypeOf((*MockLinodeClient)(nil).CreateFirewall), ctx, opts)
 }
 
+// CreateFirewallDevice mocks base method.
+func (m *MockLinodeClient) CreateFirewallDevice(ctx context.Context, firewallID int, opts linodego.FirewallDeviceCreateOptions) (*linodego.FirewallDevice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFirewallDevice", ctx, firewallID, opts)
+	ret0, _ := ret[0].(*linodego.FirewallDevice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateFirewallDevice indicates an expected call of CreateFirewallDevice.
+func (mr *MockLinodeClientMockRecorder) CreateFirewallDevice(ctx, firewallID, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFirewallDevice", reflect.TypeOf((*MockLinodeClient)(nil).CreateFirewallDevice), ctx, firewallID, opts)
+}
+
 // CreateInstance mocks base method.
 func (m *MockLinodeClient) CreateInstance(ctx context.Context, opts linodego.InstanceCreateOptions) (*linodego.Instance, error) {
 	m.ctrl.T.Helper()
@@ -2104,6 +2119,21 @@ func (m *MockLinodeFirewallClient) CreateFirewall(ctx context.Context, opts lino
 func (mr *MockLinodeFirewallClientMockRecorder) CreateFirewall(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFirewall", reflect.TypeOf((*MockLinodeFirewallClient)(nil).CreateFirewall), ctx, opts)
+}
+
+// CreateFirewallDevice mocks base method.
+func (m *MockLinodeFirewallClient) CreateFirewallDevice(ctx context.Context, firewallID int, opts linodego.FirewallDeviceCreateOptions) (*linodego.FirewallDevice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFirewallDevice", ctx, firewallID, opts)
+	ret0, _ := ret[0].(*linodego.FirewallDevice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateFirewallDevice indicates an expected call of CreateFirewallDevice.
+func (mr *MockLinodeFirewallClientMockRecorder) CreateFirewallDevice(ctx, firewallID, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFirewallDevice", reflect.TypeOf((*MockLinodeFirewallClient)(nil).CreateFirewallDevice), ctx, firewallID, opts)
 }
 
 // DeleteFirewall mocks base method.

--- a/mock/client.go
+++ b/mock/client.go
@@ -697,6 +697,21 @@ func (mr *MockLinodeClientMockRecorder) ListDomains(ctx, opts any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockLinodeClient)(nil).ListDomains), ctx, opts)
 }
 
+// ListFirewallDevices mocks base method.
+func (m *MockLinodeClient) ListFirewallDevices(ctx context.Context, firewallID int, options *linodego.ListOptions) ([]linodego.FirewallDevice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFirewallDevices", ctx, firewallID, options)
+	ret0, _ := ret[0].([]linodego.FirewallDevice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFirewallDevices indicates an expected call of ListFirewallDevices.
+func (mr *MockLinodeClientMockRecorder) ListFirewallDevices(ctx, firewallID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFirewallDevices", reflect.TypeOf((*MockLinodeClient)(nil).ListFirewallDevices), ctx, firewallID, options)
+}
+
 // ListFirewalls mocks base method.
 func (m *MockLinodeClient) ListFirewalls(ctx context.Context, options *linodego.ListOptions) ([]linodego.Firewall, error) {
 	m.ctrl.T.Helper()
@@ -2207,6 +2222,21 @@ func (m *MockLinodeFirewallClient) GetFirewallRules(ctx context.Context, firewal
 func (mr *MockLinodeFirewallClientMockRecorder) GetFirewallRules(ctx, firewallID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirewallRules", reflect.TypeOf((*MockLinodeFirewallClient)(nil).GetFirewallRules), ctx, firewallID)
+}
+
+// ListFirewallDevices mocks base method.
+func (m *MockLinodeFirewallClient) ListFirewallDevices(ctx context.Context, firewallID int, options *linodego.ListOptions) ([]linodego.FirewallDevice, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFirewallDevices", ctx, firewallID, options)
+	ret0, _ := ret[0].([]linodego.FirewallDevice)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFirewallDevices indicates an expected call of ListFirewallDevices.
+func (mr *MockLinodeFirewallClientMockRecorder) ListFirewallDevices(ctx, firewallID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFirewallDevices", reflect.TypeOf((*MockLinodeFirewallClient)(nil).ListFirewallDevices), ctx, firewallID, options)
 }
 
 // ListFirewalls mocks base method.

--- a/observability/wrappers/linodeclient/linodeclient.gen.go
+++ b/observability/wrappers/linodeclient/linodeclient.gen.go
@@ -137,6 +137,32 @@ func (_d LinodeClientWithTracing) CreateFirewall(ctx context.Context, opts linod
 	return _d.LinodeClient.CreateFirewall(ctx, opts)
 }
 
+// CreateFirewallDevice implements _sourceClients.LinodeClient
+func (_d LinodeClientWithTracing) CreateFirewallDevice(ctx context.Context, firewallID int, opts linodego.FirewallDeviceCreateOptions) (fp1 *linodego.FirewallDevice, err error) {
+	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.CreateFirewallDevice")
+	defer func() {
+		if _d._spanDecorator != nil {
+			_d._spanDecorator(_span, map[string]interface{}{
+				"ctx":        ctx,
+				"firewallID": firewallID,
+				"opts":       opts}, map[string]interface{}{
+				"fp1": fp1,
+				"err": err})
+		}
+
+		if err != nil {
+			_span.RecordError(err)
+			_span.SetAttributes(
+				attribute.String("event", "error"),
+				attribute.String("message", err.Error()),
+			)
+		}
+
+		_span.End()
+	}()
+	return _d.LinodeClient.CreateFirewallDevice(ctx, firewallID, opts)
+}
+
 // CreateInstance implements _sourceClients.LinodeClient
 func (_d LinodeClientWithTracing) CreateInstance(ctx context.Context, opts linodego.InstanceCreateOptions) (ip1 *linodego.Instance, err error) {
 	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.CreateInstance")

--- a/observability/wrappers/linodeclient/linodeclient.gen.go
+++ b/observability/wrappers/linodeclient/linodeclient.gen.go
@@ -1142,6 +1142,32 @@ func (_d LinodeClientWithTracing) ListDomains(ctx context.Context, opts *linodeg
 	return _d.LinodeClient.ListDomains(ctx, opts)
 }
 
+// ListFirewallDevices implements _sourceClients.LinodeClient
+func (_d LinodeClientWithTracing) ListFirewallDevices(ctx context.Context, firewallID int, options *linodego.ListOptions) (fa1 []linodego.FirewallDevice, err error) {
+	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.ListFirewallDevices")
+	defer func() {
+		if _d._spanDecorator != nil {
+			_d._spanDecorator(_span, map[string]interface{}{
+				"ctx":        ctx,
+				"firewallID": firewallID,
+				"options":    options}, map[string]interface{}{
+				"fa1": fa1,
+				"err": err})
+		}
+
+		if err != nil {
+			_span.RecordError(err)
+			_span.SetAttributes(
+				attribute.String("event", "error"),
+				attribute.String("message", err.Error()),
+			)
+		}
+
+		_span.End()
+	}()
+	return _d.LinodeClient.ListFirewallDevices(ctx, firewallID, options)
+}
+
 // ListFirewalls implements _sourceClients.LinodeClient
 func (_d LinodeClientWithTracing) ListFirewalls(ctx context.Context, options *linodego.ListOptions) (fa1 []linodego.Firewall, err error) {
 	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.ListFirewalls")

--- a/observability/wrappers/linodeclient/linodeclient.gen.go
+++ b/observability/wrappers/linodeclient/linodeclient.gen.go
@@ -737,57 +737,6 @@ func (_d LinodeClientWithTracing) GetFirewall(ctx context.Context, firewallID in
 	return _d.LinodeClient.GetFirewall(ctx, firewallID)
 }
 
-// GetFirewallDevice implements _sourceClients.LinodeClient
-func (_d LinodeClientWithTracing) GetFirewallDevice(ctx context.Context, firewallID int, deviceID int) (fp1 *linodego.FirewallDevice, err error) {
-	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.GetFirewallDevice")
-	defer func() {
-		if _d._spanDecorator != nil {
-			_d._spanDecorator(_span, map[string]interface{}{
-				"ctx":        ctx,
-				"firewallID": firewallID,
-				"deviceID":   deviceID}, map[string]interface{}{
-				"fp1": fp1,
-				"err": err})
-		}
-
-		if err != nil {
-			_span.RecordError(err)
-			_span.SetAttributes(
-				attribute.String("event", "error"),
-				attribute.String("message", err.Error()),
-			)
-		}
-
-		_span.End()
-	}()
-	return _d.LinodeClient.GetFirewallDevice(ctx, firewallID, deviceID)
-}
-
-// GetFirewallRules implements _sourceClients.LinodeClient
-func (_d LinodeClientWithTracing) GetFirewallRules(ctx context.Context, firewallID int) (fp1 *linodego.FirewallRules, err error) {
-	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.GetFirewallRules")
-	defer func() {
-		if _d._spanDecorator != nil {
-			_d._spanDecorator(_span, map[string]interface{}{
-				"ctx":        ctx,
-				"firewallID": firewallID}, map[string]interface{}{
-				"fp1": fp1,
-				"err": err})
-		}
-
-		if err != nil {
-			_span.RecordError(err)
-			_span.SetAttributes(
-				attribute.String("event", "error"),
-				attribute.String("message", err.Error()),
-			)
-		}
-
-		_span.End()
-	}()
-	return _d.LinodeClient.GetFirewallRules(ctx, firewallID)
-}
-
 // GetImage implements _sourceClients.LinodeClient
 func (_d LinodeClientWithTracing) GetImage(ctx context.Context, imageID string) (ip1 *linodego.Image, err error) {
 	ctx, _span := tracing.Start(ctx, "_sourceClients.LinodeClient.GetImage")


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
**What this PR does / why we need it**: 
- If a `LinodeMachine` is configured to use Linode Interfaces and the `LinodeMachine.Spec.FirewallID` / ID of the `FirewallRef` changes, we need to be able to update the cloud firewall to allow the LinodeMachine's Linode Interfaces. 
Firewall ID updates on a `LinodeMachine` were already made possible in #813.

- There was also a bug in the instance firewall update logic where it would try to update the instance firewall regardless of interface generation resulting in this error:
```
2026-09-08T15:27:05Z	DEBUG	events	[400] Linode is using Linode Interfaces. Please apply Cloud Firewall to the interfaces of the Linode instead of directly to the Linode.	{"type": "Warning", "object": "nil", "action": "Reconcile", "reason": "UpdateError"}
```

- Fixes the events RBAC for the controller which uses a different API group:
```
E0908 15:26:16.368794       1 event_broadcaster.go:270] "Server rejected event (will not retry!)" err="events.events.k8s.io \"test-cluster-cp-92k2c.18d361f3893374d5\" is forbidden: User \"system:serviceaccount:capl-system:capl-controller-manager\" cannot patch resource \"events\" in API group \"events.k8s.io\" in the namespace \"default\"" event="&Event{ObjectMeta:{test-cluster-cp-92k2c.18d361f3893374d5  default    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},EventTime:2026-09-08 15:26:15.6030135 +0000 UTC m=+3117.259302542,Series:&EventSeries{Count:2,LastObservedTime:2026-09-08 15:26:16.367112459 +0000 UTC m=+3118.023401459,},ReportingController:LinodeMachineReconciler,ReportingInstance:LinodeMachineReconciler-capl-controller-manager-65f5cbc854-ndhcn,Action:Reconcile,Reason:UpdateError,Regarding:{LinodeMachine default test-cluster-cp-92k2c e89042ff-0c35-4856-86d5-b29077ef5e5c infrastructure.cluster.x-k8s.io/v1alpha2 20184 },Related:nil,Note:[400] Linode is using Linode Interfaces. Please apply Cloud Firewall to the interfaces of the Linode instead of directly to the Linode.,Type:Warning,DeprecatedSource:{ },DeprecatedFirstTimestamp:0001-01-01 00:00:00 +0000 UTC,DeprecatedLastTimestamp:0001-01-01 00:00:00 +0000 UTC,DeprecatedCount:0,}"
```

- This also cleans up a couple unused client methods on the firewalls client.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests


